### PR TITLE
fix(cron): fail closed when CRON_SECRET is missing

### DIFF
--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -7,10 +7,19 @@ import { NextRequest, NextResponse } from 'next/server';
 export function verifyCronAuth(request: NextRequest): NextResponse | null {
   const authHeader = request.headers.get('authorization');
   const expectedToken = process.env.CRON_SECRET;
+  const allowDevBypass =
+    process.env.NODE_ENV === 'development' &&
+    process.env.ALLOW_UNPROTECTED_CRON === 'true';
 
   if (!expectedToken) {
-    console.warn('CRON_SECRET not set — cron endpoints are unprotected');
-    return null;
+    if (allowDevBypass) {
+      console.warn('CRON_SECRET not set — allowing cron auth bypass in local development');
+      return null;
+    }
+    return NextResponse.json(
+      { error: 'Server misconfigured: CRON_SECRET is missing' },
+      { status: 500 }
+    );
   }
 
   if (authHeader !== `Bearer ${expectedToken}`) {


### PR DESCRIPTION
Summary:
- fail closed when CRON_SECRET is not set in non-development environments
- allow explicit local bypass only in development via ALLOW_UNPROTECTED_CRON=true
- prevent accidental unauthenticated cron execution in production

Context:
Tracks P1 item from the bug/refactor scan for cron auth hardening.