### PR TITLE
fix(build): remove external Google font fetch dependency

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,9 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { ThemeProvider } from "@/components/theme-provider";
 import { LanguageProvider } from "@/lib/i18n/context";
-
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Neer Vazhvu — Chennai Water Intelligence",
@@ -39,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} font-sans antialiased`} suppressHydrationWarning>
+      <body className="font-sans antialiased" suppressHydrationWarning>
         <LanguageProvider>
           <ThemeProvider>
             <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
Summary:
- remove next/font/google Inter import from app layout
- avoid build-time dependency on external font fetches
- improve build reliability in restricted/offline environments

Context:
Tracks P1 item from the bug/refactor scan for build stability.