### PR TITLE
fix(jsonb): write native dict/list values instead of JSON strings

### DIFF
--- a/neer-vazhvu-api/app/intelligence/briefing.py
+++ b/neer-vazhvu-api/app/intelligence/briefing.py
@@ -5,7 +5,6 @@ Template-based (no LLM required). Pulls data from multiple tables
 and applies rule-based logic to produce a structured briefing.
 """
 
-import json
 from datetime import date, timedelta
 
 from app.db import get_supabase
@@ -211,9 +210,9 @@ async def generate_briefing() -> dict:
             "briefing_date": today.isoformat(),
             "headline": "No data available — waiting for pipeline to populate",
             "summary": "The daily data pipeline has not yet produced estimates.",
-            "key_metrics": json.dumps({}),
-            "alerts": json.dumps([]),
-            "recommendations": json.dumps(["Run the daily pipeline to generate data."]),
+            "key_metrics": {},
+            "alerts": [],
+            "recommendations": ["Run the daily pipeline to generate data."],
         }
         supabase.table("daily_briefing").upsert(
             briefing, on_conflict="briefing_date"
@@ -289,9 +288,9 @@ async def generate_briefing() -> dict:
         "briefing_date": today.isoformat(),
         "headline": headline,
         "summary": summary,
-        "key_metrics": json.dumps(key_metrics),
-        "alerts": json.dumps(alerts),
-        "recommendations": json.dumps(recommendations),
+        "key_metrics": key_metrics,
+        "alerts": alerts,
+        "recommendations": recommendations,
     }
 
     supabase.table("daily_briefing").upsert(

--- a/neer-vazhvu-api/app/intelligence/risk_scorer.py
+++ b/neer-vazhvu-api/app/intelligence/risk_scorer.py
@@ -5,7 +5,6 @@ Computes a composite risk score (0–100) for each of Chennai's 200 wards.
 Components: groundwater depth (40%), trend (30%), reservoir stress (20%), seasonal (10%).
 """
 
-import json
 from datetime import date
 
 from app.db import get_supabase
@@ -206,7 +205,7 @@ async def compute_risk_scores() -> list[dict]:
                 "trend_component": tr_score,
                 "reservoir_component": res_score,
                 "seasonal_component": sea_score,
-                "factors": json.dumps(factors),
+                "factors": factors,
             }
         )
 


### PR DESCRIPTION
Summary:
- stop serializing JSONB payloads with json.dumps before persistence
- write native Python dict/list values for JSONB columns
- avoid double-encoded payloads and simplify downstream reads

Context:
Tracks P1 item from the bug/refactor scan for JSONB persistence correctness.