### PR TITLE
fix(pipeline): enforce dependency gates between ETL steps

### DIFF
--- a/neer-vazhvu-api/app/etl/pipeline.py
+++ b/neer-vazhvu-api/app/etl/pipeline.py
@@ -293,19 +293,35 @@ async def run_daily() -> list[dict]:
     """Run the full daily pipeline."""
     steps = []
 
-    # Data collection (fail-independent)
-    steps.append(await _run_step("scrape_cmwssb", _step_scrape_cmwssb))
-    steps.append(await _run_step("fetch_nasa", _step_fetch_nasa))
+    # Data collection
+    step = await _run_step("scrape_cmwssb", _step_scrape_cmwssb)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("fetch_nasa", _step_fetch_nasa)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
     steps.append(
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
 
-    # ETL (depends on fresh data but runs even if scraping had issues)
-    steps.append(await _run_step("compute_estimate", _step_compute_estimate))
+    # ETL
+    step = await _run_step("compute_estimate", _step_compute_estimate)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
 
-    # Intelligence (depends on ETL)
-    steps.append(await _run_step("forecast", _step_forecast))
-    steps.append(await _run_step("briefing", _step_briefing))
+    # Intelligence
+    step = await _run_step("forecast", _step_forecast)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("briefing", _step_briefing)
+    steps.append(step)
 
     return steps
 
@@ -313,8 +329,13 @@ async def run_daily() -> list[dict]:
 async def run_monthly() -> list[dict]:
     """Run monthly jobs: OpenCity groundwater + risk scoring."""
     steps = []
-    steps.append(await _run_step("fetch_opencity", _step_fetch_opencity))
-    steps.append(await _run_step("risk_scoring", _step_risk_scoring))
+    step = await _run_step("fetch_opencity", _step_fetch_opencity)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("risk_scoring", _step_risk_scoring)
+    steps.append(step)
     return steps
 
 
@@ -326,20 +347,43 @@ async def run_post_scrape() -> list[dict]:
     don't redundantly hit the CMWSSB website.
     """
     steps = []
-    steps.append(await _run_step("fetch_nasa", _step_fetch_nasa))
+    step = await _run_step("fetch_nasa", _step_fetch_nasa)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
     steps.append(
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
-    steps.append(await _run_step("compute_estimate", _step_compute_estimate))
-    steps.append(await _run_step("forecast", _step_forecast))
-    steps.append(await _run_step("briefing", _step_briefing))
+
+    step = await _run_step("compute_estimate", _step_compute_estimate)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("forecast", _step_forecast)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("briefing", _step_briefing)
+    steps.append(step)
     return steps
 
 
 async def run_intelligence_only() -> list[dict]:
     """Run only intelligence steps (for backfills/manual triggers)."""
     steps = []
-    steps.append(await _run_step("forecast", _step_forecast))
-    steps.append(await _run_step("risk_scoring", _step_risk_scoring))
-    steps.append(await _run_step("briefing", _step_briefing))
+    step = await _run_step("forecast", _step_forecast)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("risk_scoring", _step_risk_scoring)
+    steps.append(step)
+    if step["status"] == "error":
+        return steps
+
+    step = await _run_step("briefing", _step_briefing)
+    steps.append(step)
     return steps

--- a/neer-vazhvu-api/app/intelligence/forecaster.py
+++ b/neer-vazhvu-api/app/intelligence/forecaster.py
@@ -273,14 +273,19 @@ async def forecast_reservoirs() -> list[dict]:
     """Generate forecasts for all 6 reservoirs and store in Supabase."""
     supabase = get_supabase()
     all_results: list[dict] = []
+    failures: list[str] = []
 
     for reservoir in RESERVOIRS:
         try:
             results = _forecast_single_reservoir(reservoir)
             all_results.extend(results)
         except Exception as e:
-            print(f"Forecast failed for {reservoir}: {e}")
-            continue
+            failures.append(f"{reservoir}: {e}")
+
+    if failures:
+        raise RuntimeError(
+            "Forecast failed for one or more reservoirs: " + "; ".join(failures)
+        )
 
     if all_results:
         supabase.table("reservoir_forecast").upsert(


### PR DESCRIPTION
Summary:
- block dependent ETL steps when required upstream steps fail
- fail forecast step when any reservoir forecast fails
- prevent partially-successful runs from producing misleading outputs

Context:
Tracks P1 item from the bug/refactor scan for pipeline integrity.