### PR TITLE
ux(footer): clarify core live sources and link full source list

### DIFF
--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -98,7 +98,7 @@ export function AboutContent() {
 
       <Separator className="my-8" />
 
-      <section className="space-y-4">
+      <section id="data-sources" className="space-y-4">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.assumptions")}</h2>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">

--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -98,7 +98,7 @@ export function AboutContent() {
 
       <Separator className="my-8" />
 
-      <section id="data-sources" className="space-y-4">
+      <section className="space-y-4">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.assumptions")}</h2>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
@@ -140,7 +140,7 @@ export function AboutContent() {
 
       <Separator className="my-8" />
 
-      <section className="space-y-4">
+      <section id="data-sources" className="space-y-4">
         <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.data_sources")}</h2>
         <p className="text-slate-600 dark:text-slate-400">
           {t("about.data_pipeline")}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -37,6 +37,13 @@ export function Footer() {
             >
               OpenCity Chennai
             </a>
+            {" · "}
+            <a
+              href="/about#data-sources"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {t("footer.all_sources")}
+            </a>
           </div>
           <div>
             {t("footer.open_source")}

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -21,7 +21,8 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "lang.view_in_tamil":     { en: "View in Tamil", ta: "தமிழில் பார்க்க" },
 
   // ── Footer ────────────────────────────────────────────────────────────────
-  "footer.data_sources":  { en: "Data sources:",             ta: "தரவு ஆதாரங்கள்:" },
+  "footer.data_sources":  { en: "Core live sources:",        ta: "முக்கிய நேரடி தரவு ஆதாரங்கள்:" },
+  "footer.all_sources":   { en: "All sources",               ta: "அனைத்து ஆதாரங்கள்" },
   "footer.open_source":   { en: "Open source · Built for Chennai", ta: "திறந்த மூலம் · சென்னைக்காக" },
 
   // ── Days Left Hero ────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary:
- relabel footer data text from generic Data sources to Core live sources
- add footer link to About section anchor with complete source list
- add i18n key for All sources in English and Tamil
- add #data-sources anchor to About page data-sources section

Why:
- footer currently lists only live pipeline sources (CMWSSB, NASA POWER, OpenCity)
- site also contains additional static/manual sources documented on About
- this makes footer accurate while preserving quick access to full attribution