### PR TITLE
docs: update README/architecture/contributing to current pipeline and setup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,13 +57,19 @@ graph TB
     StaticFiles -->|static| Frontend
     StaticFiles2 -->|static| Frontend
 
-    Cron -->|POST /pipeline/run-daily| ETL
+    Cron -->|POST /pipeline/run-post-scrape| ETL
     KA -->|GET /health| Backend
 ```
 
 ## Daily Pipeline
 
-Triggered by GitHub Actions at 06:00 IST, or manually via `POST /pipeline/run-daily`.
+Triggered by GitHub Actions at 06:00 IST.
+
+Production flow is:
+1. GitHub Actions runs `python scripts/scrape_cmwssb.py` from the runner.
+2. It then calls `POST /pipeline/run-post-scrape` for ETL + intelligence.
+
+You can still run `POST /pipeline/run-daily` manually when the API runtime can directly access CMWSSB.
 
 ```mermaid
 flowchart LR
@@ -272,7 +278,8 @@ graph TD
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | `/health` | None | Service health + recent pipeline runs |
-| POST | `/pipeline/run-daily` | Bearer | Full daily pipeline |
+| POST | `/pipeline/run-daily` | Bearer | Full daily pipeline (includes scrape) |
+| POST | `/pipeline/run-post-scrape` | Bearer | Daily pipeline without scrape (used by GH Actions) |
 | POST | `/pipeline/run-monthly` | Bearer | Groundwater + risk scoring |
 | POST | `/pipeline/run-intelligence` | Bearer | Forecast + risk + briefing only |
 | GET | `/intelligence/forecast` | None | Latest reservoir forecasts |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ neer-vazhvu/
 
 - **Data quality** — Improving scraper resilience, handling CMWSSB page format changes
 - **Models** — Better forecasting (Prophet, LSTM), evaporation modeling
-- **Frontend** — Risk map layer, briefing card component, mobile polish
+- **Frontend** — Daily briefing card integration, chart clarity, mobile polish
 - **Tamil localization** — Translating the UI for local accessibility
 - **Testing** — Unit tests for scrapers, calculator, and intelligence modules
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks res
 
 | Layer | Technology |
 |-------|------------|
-| Frontend | Next.js 15, React 19, TypeScript, Tailwind CSS v4, shadcn/ui |
+| Frontend | Next.js 16, React 19, TypeScript, Tailwind CSS v4, shadcn/ui |
 | Charts | Recharts |
 | Maps | Leaflet + react-leaflet — GCC ward boundaries (GeoJSON) + OSM water body polygons + curated lost bodies (GeoJSON) |
 | Backend API | Python 3.12, FastAPI, statsforecast, pandas |
@@ -178,9 +178,10 @@ uvicorn app.main:app --reload --port 8000
 ### 5. Seed Historical Data
 
 ```bash
-# From the neer-vazhvu-api directory
-python -m scripts.seed_kaggle      # 15 years of reservoir data
-python -m scripts.seed_opencity    # Groundwater data (2021-2024)
+# From the repo root
+npx tsx scripts/seed-kaggle.ts                 # Reservoir history
+npx tsx scripts/seed-opencity-groundwater.ts   # Groundwater history
+npx tsx scripts/seed-opencity-lakes.ts         # Optional lake-level history
 ```
 
 ### 6. Refresh Static GeoJSON Data (optional)
@@ -212,7 +213,8 @@ npx tsx scripts/fetch-industrial-zones-osm.ts
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/pipeline/run-daily` | Full pipeline: scrape → ETL → forecast → briefing |
+| POST | `/pipeline/run-daily` | Full pipeline in API runtime: scrape → ETL → forecast → briefing |
+| POST | `/pipeline/run-post-scrape` | Pipeline without scrape (used by GitHub Actions after external CMWSSB scrape) |
 | POST | `/pipeline/run-monthly` | Groundwater fetch + risk scoring |
 | POST | `/pipeline/run-intelligence` | Forecast + risk + briefing only (backfills) |
 
@@ -267,7 +269,7 @@ neer-vazhvu/
 │   └── migrations/               # SQL migrations (001, 002)
 ├── public/
 │   ├── geojson/                  # Static GeoJSON data
-│   │   ├── gcc-wards.geojson                    # GCC ward boundaries (choropleth)
+│   │   ├── chennai-wards-2022.geojson           # GCC ward boundaries (choropleth)
 │   │   ├── chennai-water-bodies-current.geojson # OSM water bodies (1,635 features)
 │   │   ├── chennai-water-bodies-lost.geojson    # Curated lost water bodies (15 entries)
 │   │   ├── chennai-rivers.geojson               # River polylines (Cooum, Adyar, etc.)
@@ -284,7 +286,7 @@ neer-vazhvu/
 | Parameter | Default | Source |
 |-----------|---------|--------|
 | Daily consumption | 830 MLD | CMWSSB annual report |
-| Desalination output | 190 MLD | Minjur (100) + Nemmeli (100) |
+| Desalination output | 190 MLD | Model baseline constant (`DEFAULT_DESALINATION_MLD`) |
 | Groundwater supply | Not modeled | Conservative assumption |
 | Evaporation losses | Not modeled | Planned for V2 |
 


### PR DESCRIPTION
Summary:
- update README tech stack version (Next.js 16)
- fix historical seed commands to current npx tsx scripts usage
- add /pipeline/run-post-scrape to documented pipeline endpoints
- clarify that production daily workflow uses external CMWSSB scrape + post-scrape pipeline call
- fix stale geojson filename in project tree (chennai-wards-2022.geojson)
- fix desalination assumption source text to match current model constant
- refresh one stale frontend help-needed bullet in CONTRIBUTING

Files changed:
- README.md
- ARCHITECTURE.md
- CONTRIBUTING.md

Context:
These docs were partially out of sync with recent workflow changes (GitHub Actions scrape step and post-scrape API endpoint), and with current repository scripts/file names.