### PR TITLE
fix: pipeline resilience, mobile UX, dark mode maps

### DIFF
--- a/.github/workflows/daily-data-pipeline.yml
+++ b/.github/workflows/daily-data-pipeline.yml
@@ -24,20 +24,60 @@ jobs:
       # Scrape runs here (GitHub runner IPs) because the deployed API server's
       # IP is blocked by the CMWSSB website, causing 30-second timeouts.
       - name: Scrape CMWSSB → Supabase
+        id: scrape
+        continue-on-error: true
         working-directory: neer-vazhvu-api
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          CMWSSB_MAX_STALE_DAYS: '2'
+          CMWSSB_MAX_STALE_DAYS: '4'
         run: python scripts/scrape_cmwssb.py
 
       - name: Run post-scrape pipeline (ETL + intelligence)
+        if: steps.scrape.outcome == 'success'
         run: |
           curl -X POST "${{ secrets.PYTHON_API_URL }}/pipeline/run-post-scrape" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             -H "Content-Type: application/json" \
             --fail --max-time 300 \
             --retry 2 --retry-delay 120
+
+      - name: Alert on scrape failure
+        if: steps.scrape.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `CMWSSB scrape failed — ${new Date().toISOString().slice(0, 10)}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'pipeline-alert',
+              state: 'open',
+            });
+            const existing = issues.find(i => i.title === title);
+            if (!existing) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: ['pipeline-alert'],
+                body: [
+                  '## CMWSSB Scrape Failure',
+                  '',
+                  'The daily CMWSSB reservoir data scrape failed after all retry attempts.',
+                  'Post-scrape intelligence was **skipped** to avoid reprocessing stale data.',
+                  '',
+                  `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                  '',
+                  'Common causes:',
+                  '- CMWSSB website is down for maintenance',
+                  '- GitHub runner IP temporarily blocked',
+                  '- CMWSSB changed their HTML page structure',
+                  '',
+                  'This issue will be created once per day. Close it after investigating.',
+                ].join('\n'),
+              });
+            }
 
   # Monthly job runs on days 1-3 for groundwater + risk scoring
   monthly-pipeline:

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import { ReservoirCards } from "./reservoir-cards";
 import { StorageTrendChart } from "./storage-trend-chart";
 import type { ReservoirSummary, HistoryPoint } from "@/types/reservoir";
@@ -31,6 +31,14 @@ export function DashboardContent({
 }: DashboardContentProps) {
   const { t } = useLanguage();
   const [selectedReservoir, setSelectedReservoir] = useState<ReservoirSummary | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const handleReservoirClick = useCallback((reservoir: ReservoirSummary) => {
+    setSelectedReservoir(reservoir);
+    setTimeout(() => {
+      chartRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  }, []);
 
   const chartHistory = selectedReservoir
     ? perReservoirHistory[selectedReservoir.name] || []
@@ -48,16 +56,18 @@ export function DashboardContent({
     <>
       <ReservoirCards
         reservoirs={reservoirs}
-        onReservoirClick={setSelectedReservoir}
+        onReservoirClick={handleReservoirClick}
       />
 
-      <StorageTrendChart
-        history={chartHistory}
-        forecast={chartForecast}
-        title={chartTitle}
-        capacity={selectedReservoir?.capacity}
-        onBack={selectedReservoir ? () => setSelectedReservoir(null) : undefined}
-      />
+      <div ref={chartRef} className="scroll-mt-20">
+        <StorageTrendChart
+          history={chartHistory}
+          forecast={chartForecast}
+          title={chartTitle}
+          capacity={selectedReservoir?.capacity}
+          onBack={selectedReservoir ? () => setSelectedReservoir(null) : undefined}
+        />
+      </div>
     </>
   );
 }

--- a/src/components/dashboard/reservoir-cards.tsx
+++ b/src/components/dashboard/reservoir-cards.tsx
@@ -64,7 +64,7 @@ export function ReservoirCards({ reservoirs, onReservoirClick }: ReservoirCardsP
               </div>
 
               {/* Inflow/outflow */}
-              <div className="flex flex-col xs:flex-row justify-between mt-3 text-xs text-slate-500 dark:text-slate-400 gap-0.5">
+              <div className="flex flex-row justify-between mt-3 text-xs text-slate-500 dark:text-slate-400 gap-0.5">
                 <span>
                   {t("dash.in_label")} <span className="font-medium text-green-600">{formatNumber(r.inflowCusecs)}</span> {t("dash.cusecs_unit")}
                 </span>

--- a/src/components/groundwater/ward-map.tsx
+++ b/src/components/groundwater/ward-map.tsx
@@ -7,6 +7,7 @@ import type { Feature } from "geojson";
 import { getGroundwaterColor, getRiskColor } from "@/types/groundwater";
 import type { GroundwaterWard, WardRiskData, ViewMode } from "@/types/groundwater";
 import { useLanguage } from "@/lib/i18n/context";
+import { useMapTiles } from "@/lib/utils/map-tiles";
 import "leaflet/dist/leaflet.css";
 
 interface WardMapProps {
@@ -18,6 +19,7 @@ interface WardMapProps {
 
 export function WardMap({ groundwaterData, riskData, viewMode, onWardSelect }: WardMapProps) {
   const { t, language } = useLanguage();
+  const tiles = useMapTiles();
   const [geoJSON, setGeoJSON] = useState<GeoJSON.FeatureCollection | null>(null);
 
   useEffect(() => {
@@ -88,10 +90,7 @@ export function WardMap({ groundwaterData, riskData, viewMode, onWardSelect }: W
       className="h-full w-full"
       scrollWheelZoom={true}
     >
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-      />
+      <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} />
       <GeoJSON key={viewMode} data={geoJSON} style={style} onEachFeature={onEachFeature} />
     </MapContainer>
   );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,26 +18,27 @@ const NAV_KEYS = [
 
 function ThemeToggle() {
   const { t } = useLanguage();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setMounted(true), []);
 
   if (!mounted) {
-    return <div className="w-9 h-9" />;
+    return <div className="w-11 h-11" />;
   }
 
-  const nextTheme = theme === "dark" ? "light" : "dark";
-  const ariaLabel = nextTheme === "dark" ? t("theme.switch_to_dark") : t("theme.switch_to_light");
+  const isDark = resolvedTheme === "dark";
+  const nextTheme = isDark ? "light" : "dark";
+  const ariaLabel = isDark ? t("theme.switch_to_light") : t("theme.switch_to_dark");
 
   return (
     <button
       onClick={() => setTheme(nextTheme)}
-      className="p-2 rounded-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+      className="p-2.5 rounded-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
       aria-label={ariaLabel}
     >
-      {theme === "dark" ? (
+      {isDark ? (
         <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
         </svg>
@@ -53,6 +54,7 @@ function ThemeToggle() {
 export function Header() {
   const pathname = usePathname();
   const { t } = useLanguage();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <header className="border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 sticky top-0 z-50">
@@ -85,13 +87,14 @@ export function Header() {
             </div>
           </Link>
 
-          <nav className="flex items-center gap-1 sm:gap-2">
+          {/* Desktop nav */}
+          <nav className="hidden sm:flex items-center gap-2">
             {NAV_KEYS.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "px-2.5 py-2.5 sm:px-3 rounded-md text-sm font-medium transition-colors",
+                  "px-3 py-2.5 rounded-md text-sm font-medium transition-colors",
                   pathname === item.href
                     ? "bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-400"
                     : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800"
@@ -103,8 +106,52 @@ export function Header() {
             <LanguageToggle />
             <ThemeToggle />
           </nav>
+
+          {/* Mobile: toggles + hamburger */}
+          <div className="flex sm:hidden items-center gap-1">
+            <LanguageToggle />
+            <ThemeToggle />
+            <button
+              onClick={() => setMenuOpen((v) => !v)}
+              className="p-2.5 rounded-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              aria-label={menuOpen ? "Close menu" : "Open menu"}
+            >
+              {menuOpen ? (
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
+          </div>
         </div>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {menuOpen && (
+        <nav className="sm:hidden border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+          <div className="max-w-7xl mx-auto px-4 py-2 space-y-1">
+            {NAV_KEYS.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setMenuOpen(false)}
+                className={cn(
+                  "block px-4 py-3 rounded-md text-sm font-medium transition-colors",
+                  pathname === item.href
+                    ? "bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-400"
+                    : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-800"
+                )}
+              >
+                {t(item.key)}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/components/rivers/combined-rivers-map.tsx
+++ b/src/components/rivers/combined-rivers-map.tsx
@@ -10,6 +10,7 @@ import { QUALITY_COLORS } from "@/types/river-quality";
 import type { IndustrialPollutionData, PollutionSource } from "@/types/industrial-pollution";
 import { SOURCE_TYPE_COLORS } from "@/types/industrial-pollution";
 import { useLanguage } from "@/lib/i18n/context";
+import { useMapTiles } from "@/lib/utils/map-tiles";
 import "leaflet/dist/leaflet.css";
 
 interface CombinedRiversMapProps {
@@ -28,6 +29,7 @@ export function CombinedRiversMap({
   onSelectSource,
 }: CombinedRiversMapProps) {
   const { t, language } = useLanguage();
+  const tiles = useMapTiles();
   const [riversGeoJSON, setRiversGeoJSON] = useState<FeatureCollection | null>(null);
   const [zonesGeoJSON, setZonesGeoJSON] = useState<FeatureCollection | null>(null);
 
@@ -210,10 +212,7 @@ export function CombinedRiversMap({
       className="h-full w-full"
       scrollWheelZoom={true}
     >
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-      />
+      <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} />
       {/* Render order: zones (bottom) → rivers → stations → sources → highlight (top) */}
       <GeoJSON key="zones" data={zonesGeoJSON} style={zoneStyle} onEachFeature={onEachZone} />
       <GeoJSON key="rivers" data={riversGeoJSON} style={riverStyle} onEachFeature={onEachRiver} />

--- a/src/components/water-bodies/water-bodies-map.tsx
+++ b/src/components/water-bodies/water-bodies-map.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@/types/water-bodies";
 import { STATUS_COLORS } from "@/types/water-bodies";
 import { useLanguage } from "@/lib/i18n/context";
+import { useMapTiles } from "@/lib/utils/map-tiles";
 import "leaflet/dist/leaflet.css";
 
 interface WaterBodiesMapProps {
@@ -20,6 +21,7 @@ interface WaterBodiesMapProps {
 
 export function WaterBodiesMap({ onSelect }: WaterBodiesMapProps) {
   const { t, language } = useLanguage();
+  const tiles = useMapTiles();
   const [currentGeoJSON, setCurrentGeoJSON] =
     useState<GeoJSON.FeatureCollection | null>(null);
   const [lostGeoJSON, setLostGeoJSON] =
@@ -160,10 +162,7 @@ export function WaterBodiesMap({ onSelect }: WaterBodiesMapProps) {
       className="h-full w-full"
       scrollWheelZoom={true}
     >
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-      />
+      <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} />
       <LayersControl position="topright">
         {currentGeoJSON && (
           <LayersControl.Overlay name={t("wb_map.existing_layer")} checked>

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -400,7 +400,7 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "dash.capacity_unit":     { en: "mcft capacity",             ta: "mcft கொள்ளளவு" },
   "dash.in_label":          { en: "In:",                       ta: "வரத்து:" },
   "dash.out_label":         { en: "Out:",                      ta: "வெளியேற்றம்:" },
-  "dash.click_details":     { en: "Click for details",         ta: "விவரங்களுக்கு கிளிக் செய்யவும்" },
+  "dash.click_details":     { en: "Plot trends",               ta: "போக்குகளைக் காட்டு" },
   "dash.combined_trend":    { en: "Combined Storage Trend",    ta: "ஒருங்கிணைந்த சேமிப்பு போக்கு" },
   "dash.storage_suffix":    { en: "Storage",                   ta: "சேமிப்பு" },
   "dash.all_reservoirs":    { en: "All Reservoirs",            ta: "அனைத்து நீர்த்தேக்கங்களும்" },

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -28,12 +28,12 @@ export const MAJOR_RESERVOIR_CAPACITY_MCFT = 3231.0 + 881.0 + 3300.0 + 3645.0; /
 /** Total capacity including all 6 reservoirs */
 export const TOTAL_RESERVOIR_CAPACITY_MCFT = 3231.0 + 881.0 + 3300.0 + 3645.0 + 1465.0 + 1574.0; // 14,096
 
-/** Reservoir display order */
+/** Reservoir display order — largest capacity first */
 export const RESERVOIR_DISPLAY_ORDER = [
+  'chembarambakkam',
+  'redhills',
   'poondi',
   'cholavaram',
-  'redhills',
-  'chembarambakkam',
 ] as const;
 
 /** Maps various CMWSSB names to our canonical reservoir names */

--- a/src/lib/utils/map-tiles.ts
+++ b/src/lib/utils/map-tiles.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useTheme } from "next-themes";
+
+const LIGHT_TILES = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+const DARK_TILES = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
+
+const LIGHT_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+const DARK_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>';
+
+export function useMapTiles() {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+  return {
+    url: isDark ? DARK_TILES : LIGHT_TILES,
+    attribution: isDark ? DARK_ATTR : LIGHT_ATTR,
+  };
+}


### PR DESCRIPTION
## Summary

- **Pipeline resilience**: CMWSSB scrape failures no longer break the entire daily pipeline. Stale data tolerance raised to 4 days, post-scrape ETL is skipped when scrape fails (avoids reprocessing unchanged data), and a `pipeline-alert` GitHub issue is auto-created for visibility.
- **Mobile hamburger menu**: Nav links collapse into a hamburger menu on screens < 640px with full-width tap targets (44px). Language and theme toggles remain always visible.
- **Auto-scroll on reservoir card click**: Clicking a reservoir card now smooth-scrolls to the trend chart below, so users see the drilldown immediately — especially important on mobile where the chart is below the fold.
- **Reservoir card ordering**: Cards are now sorted by capacity (largest first) — Chembarambakkam → Redhills → Poondi → Cholavaram.
- **Dark mode map tiles**: All three map pages (groundwater, rivers, water bodies) now switch to CartoDB Dark Matter tiles when dark mode is active, via a shared `useMapTiles` hook. Eliminates the jarring bright-map-on-dark-UI contrast.
- **Theme toggle fix**: `ThemeToggle` was using `theme` instead of `resolvedTheme` from next-themes, causing the first click to be a no-op when the system default was dark mode. Fixed.
- **Copy update**: "Click for details" → "Plot trends" (English + Tamil) for clearer reservoir card CTA.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/daily-data-pipeline.yml` | Stale days 2→4, gate ETL on scrape success, add failure alert step |
| `src/components/layout/header.tsx` | Hamburger menu, touch targets, `resolvedTheme` fix |
| `src/components/dashboard/dashboard-content.tsx` | `useRef` + `scrollIntoView` on card click |
| `src/components/dashboard/reservoir-cards.tsx` | Fix non-functional `xs:` breakpoint |
| `src/lib/utils/constants.ts` | Reorder `RESERVOIR_DISPLAY_ORDER` by capacity |
| `src/lib/utils/map-tiles.ts` | New `useMapTiles` hook (light/dark tile URLs) |
| `src/components/groundwater/ward-map.tsx` | Use `useMapTiles` |
| `src/components/rivers/combined-rivers-map.tsx` | Use `useMapTiles` |
| `src/components/water-bodies/water-bodies-map.tsx` | Use `useMapTiles` |
| `src/lib/i18n/translations.ts` | "Click for details" → "Plot trends" |

## Test plan

- [ ] Verify hamburger menu appears on mobile (< 640px), links work, menu closes on navigation
- [ ] Click a reservoir card on mobile — should smooth-scroll to the trend chart
- [ ] Reservoir cards ordered: Chembarambakkam, Redhills, Poondi, Cholavaram
- [ ] Toggle dark/light mode — map tiles should switch between OSM and CartoDB Dark Matter
- [ ] Toggle dark mode when system default is dark — first click should immediately switch to light
- [ ] Manually trigger the daily pipeline workflow — verify post-scrape step is skipped on scrape failure
- [ ] Create `pipeline-alert` label in repo for the alerting step