### PR TITLE
fix: CMWSSB scraper fallback via Cloudflare Worker proxy

### DIFF
--- a/.github/workflows/daily-data-pipeline.yml
+++ b/.github/workflows/daily-data-pipeline.yml
@@ -21,9 +21,9 @@ jobs:
         working-directory: neer-vazhvu-api
         run: pip install -e .
 
-      # Scrape runs here (GitHub runner IPs) because the deployed API server's
-      # IP is blocked by the CMWSSB website, causing 30-second timeouts.
-      - name: Scrape CMWSSB → Supabase
+      # Scrape CMWSSB reservoir data. CMWSSB may block some datacenter IPs,
+      # so this step tolerates up to 4 days of stale data before failing.
+      - name: Scrape CMWSSB -> Supabase
         id: scrape
         continue-on-error: true
         working-directory: neer-vazhvu-api
@@ -33,8 +33,9 @@ jobs:
           CMWSSB_MAX_STALE_DAYS: '4'
         run: python scripts/scrape_cmwssb.py
 
+      # Always run ETL + intelligence so forecasts and briefings stay fresh,
+      # even when the scrape fails and we're using slightly stale reservoir data.
       - name: Run post-scrape pipeline (ETL + intelligence)
-        if: steps.scrape.outcome == 'success'
         run: |
           curl -X POST "${{ secrets.PYTHON_API_URL }}/pipeline/run-post-scrape" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
@@ -47,7 +48,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `CMWSSB scrape failed — ${new Date().toISOString().slice(0, 10)}`;
+            const title = `CMWSSB scrape failed - ${new Date().toISOString().slice(0, 10)}`;
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -65,7 +66,7 @@ jobs:
                   '## CMWSSB Scrape Failure',
                   '',
                   'The daily CMWSSB reservoir data scrape failed after all retry attempts.',
-                  'Post-scrape intelligence was **skipped** to avoid reprocessing stale data.',
+                  'Post-scrape intelligence ran with existing data. Forecasts and briefings are still current.',
                   '',
                   `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
                   '',

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> Technical overview of Neer Vazhvu — Chennai Water Intelligence Dashboard.
+> Technical overview of Neer Vazhvu - Chennai Water Intelligence Dashboard.
 
 ## System Overview
 
@@ -10,8 +10,8 @@ graph TB
         CMWSSB["CMWSSB Website<br/>(Reservoir levels)"]
         NASA["NASA POWER API<br/>(Weather)"]
         OC["OpenCity CKAN<br/>(Groundwater)"]
-        CPCB["CPCB Annual Reports<br/>(River quality — manual)"]
-        OSM["OpenStreetMap / Overpass<br/>(River geometry — one-time)"]
+        CPCB["CPCB Annual Reports<br/>(River quality, manual)"]
+        OSM["OpenStreetMap / Overpass<br/>(River geometry, one-time)"]
     end
 
     subgraph Backend ["Python API (FastAPI)"]
@@ -29,9 +29,8 @@ graph TB
     subgraph Frontend ["Next.js (App Router)"]
         Dashboard["Dashboard /"]
         GW["Groundwater /groundwater"]
-        WB["Water Bodies /water-bodies"]
+        WB["Water Bodies + Restoration /water-bodies"]
         Rivers["Rivers /rivers"]
-        LR["Lake Restoration /lake-restoration"]
         About["About /about"]
     end
 
@@ -68,7 +67,7 @@ graph TB
 Triggered by GitHub Actions at 06:00 IST.
 
 Production flow is:
-1. GitHub Actions runs `python scripts/scrape_cmwssb.py` from the runner.
+1. GitHub Actions runs `python scripts/scrape_cmwssb.py` from the runner. If CMWSSB is unreachable, the scraper tolerates up to 4 days of stale data.
 2. It then calls `POST /pipeline/run-post-scrape` for ETL + intelligence.
 
 You can still run `POST /pipeline/run-daily` manually when the API runtime can directly access CMWSSB.
@@ -257,9 +256,8 @@ graph TD
 
     Layout --> Dashboard
     Layout --> GW["Groundwater Page"]
-    Layout --> WB["Water Bodies Page"]
+    Layout --> WB["Water Bodies + Restoration Page"]
     Layout --> RV["Rivers Page"]
-    Layout --> LR["Lake Restoration Page"]
     Layout --> About["About Page"]
 
     subgraph Dashboard["Dashboard Page /"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,14 @@ If you need real data flowing through, you'll need a [Supabase](https://supabase
 ```
 neer-vazhvu/
 ├── src/                  # Next.js frontend (App Router)
-│   ├── app/              # Pages (dashboard, groundwater, about)
+│   ├── app/              # Pages (dashboard, groundwater, water-bodies, rivers, about)
 │   ├── components/       # React components
 │   ├── lib/              # Utilities, mock data, Supabase client
 │   └── types/            # TypeScript definitions
 ├── neer-vazhvu-api/      # Python API (FastAPI)
 │   ├── app/scrapers/     # CMWSSB, NASA POWER, OpenCity
 │   ├── app/etl/          # Pipeline orchestrator, constants
-│   ├── app/intelligence/  # ARIMAX forecaster, risk scorer, briefing
+│   ├── app/intelligence/ # ARIMAX forecaster, risk scorer, briefing
 │   └── app/routers/      # API endpoints
 ├── supabase/migrations/  # Database schema
 └── .github/workflows/    # CI (daily pipeline, keepalive)
@@ -90,11 +90,11 @@ neer-vazhvu/
 
 ## Areas Where Help Is Needed
 
-- **Data quality** — Improving scraper resilience, handling CMWSSB page format changes
-- **Models** — Better forecasting (Prophet, LSTM), evaporation modeling
-- **Frontend** — Daily briefing card integration, chart clarity, mobile polish
-- **Tamil localization** — Translating the UI for local accessibility
-- **Testing** — Unit tests for scrapers, calculator, and intelligence modules
+- **Data quality** - Improving scraper resilience, handling CMWSSB page format changes
+- **Models** - Better forecasting (Prophet, LSTM), evaporation modeling
+- **Frontend** - Daily briefing card integration, chart clarity, mobile polish
+- **Tamil localization** - Translating the UI for local accessibility
+- **Testing** - Unit tests for scrapers, calculator, and intelligence modules
 
 ## Submitting a Pull Request
 

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -2,7 +2,7 @@
 
 > Where each dataset comes from, how often it refreshes, and what to watch out for.
 
-## Reservoir Levels — CMWSSB
+## Reservoir Levels -CMWSSB
 
 | | |
 |---|---|
@@ -15,12 +15,13 @@
 | **Historical** | Kaggle dataset back to 2004 (monthly storage only); daily inflow/outflow available from ~2022 onward |
 
 **Known limitations:**
-- Page format changes without notice — scraper needs periodic updates
+- Page format changes without notice; scraper needs periodic updates
 - Data may not update on weekends or public holidays
+- CMWSSB may block some datacenter IPs; the pipeline tolerates up to 4 days of stale data and continues with ETL/intelligence updates
 - Inflow/outflow fields were added later; pre-2022 records have nulls for these
 - Occasional duplicate or stale rows when CMWSSB delays their update
 
-## Weather — NASA POWER
+## Weather -NASA POWER
 
 | | |
 |---|---|
@@ -34,11 +35,11 @@
 
 **Known limitations:**
 - 2-day lag on data availability (today's weather appears day after tomorrow)
-- Single point for all of Chennai — no ward-level granularity
+- Single point for all of Chennai -no ward-level granularity
 - Satellite-derived precipitation can differ from ground-station readings
 - Free tier has rate limits (undocumented but generally generous)
 
-## Groundwater — OpenCity Chennai
+## Groundwater -OpenCity Chennai
 
 | | |
 |---|---|
@@ -52,18 +53,18 @@
 
 **Known limitations:**
 - Data lags by several months (latest available may be 3-6 months old)
-- Not all wards report every month — coverage varies
+- Not all wards report every month -coverage varies
 - Measurement methodology may differ across wards
 - New year datasets require adding the resource ID to the scraper config
 
-## River Water Quality — CPCB
+## River Water Quality -CPCB
 
 | | |
 |---|---|
-| **Source** | [CPCB National Water Monitoring Programme](https://cpcb.nic.in/nwmp-data/) — "Status of Water Quality in India" annual reports |
+| **Source** | [CPCB National Water Monitoring Programme](https://cpcb.nic.in/nwmp-data/) -"Status of Water Quality in India" annual reports |
 | **Method** | Manual curation (PDF/Excel → JSON) |
 | **Frequency** | Annual (refreshed when CPCB publishes the next report, typically Jan–Mar) |
-| **Coverage** | 4 rivers: Cooum, Adyar, Buckingham Canal, Kosasthalaiyar — 10 monitoring stations total |
+| **Coverage** | 4 rivers: Cooum, Adyar, Buckingham Canal, Kosasthalaiyar -10 monitoring stations total |
 | **Fields** | Dissolved oxygen (DO, mg/L), Biochemical oxygen demand (BOD, mg/L), pH, conductivity (µS/cm) |
 | **File** | `public/data/river-quality.json` (static, served directly from Next.js `public/`) |
 | **Historical** | 2015–2024 |
@@ -84,13 +85,13 @@
 | Healthy | > 6 | < 2 | A / B |
 
 **Known limitations:**
-- CPCB reports are published as PDFs — no programmatic API; data must be extracted manually
+- CPCB reports are published as PDFs -no programmatic API; data must be extracted manually
 - Monitoring station locations and frequencies can change between annual reports
 - Pre-2015 data is sparse for smaller rivers (Buckingham Canal, Kosasthalaiyar)
 - The overall `status` field is a judgement call for the river reach, not a single measurement
 - To update: download the latest CPCB report, update `readings` in `river-quality.json`, bump `last_updated` and `data_year_range`, commit `data: update river quality readings to {year}`
 
-## River Geometry — OpenStreetMap
+## River Geometry -OpenStreetMap
 
 | | |
 |---|---|
@@ -102,11 +103,11 @@
 | **File** | `public/geojson/chennai-rivers.geojson` (static GeoJSON, ~200 KB) |
 
 **Known limitations:**
-- OSM river way coverage varies — some urban stretches may be missing or misaligned
+- OSM river way coverage varies -some urban stretches may be missing or misaligned
 - The Buckingham Canal is a national waterway; bbox clipping limits it to the Chennai stretch (~72 km)
 - Run `npx tsx scripts/fetch-rivers-osm.ts` to regenerate after OSM data improves
 
-## Industrial Pollution Sources — NGT / TNPCB / CPCB
+## Industrial Pollution Sources -NGT / TNPCB / CPCB
 
 | | |
 |---|---|
@@ -118,19 +119,19 @@
 | **File** | `public/data/industrial-sources.json` (static, served directly from Next.js `public/`) |
 
 **Key evidence sources:**
-- NGT Southern Bench, Sept 2017: Expert committee findings on NCTPS fly ash — heavy metals (Cd, Hg, Cr, Cu, Mn, Se, Pb, Ni) in Seppakkam village borewells; 5.67 million tonnes ash deposited over 3.51 km²
-- TNPCB enforcement records, Dec 2023: CPCL Cyclone Michaung spill — 517 tonnes of oil into Buckingham Canal and Ennore Creek; ₹74 crore compensation demanded
-- Indian Coast Guard / Wikipedia: 2017 Ennore oil spill — BW Maple × Dawn Kanchipuram collision; ~75–196 tonnes bunker fuel; 25 miles of coastline affected
+- NGT Southern Bench, Sept 2017: Expert committee findings on NCTPS fly ash -heavy metals (Cd, Hg, Cr, Cu, Mn, Se, Pb, Ni) in Seppakkam village borewells; 5.67 million tonnes ash deposited over 3.51 km²
+- TNPCB enforcement records, Dec 2023: CPCL Cyclone Michaung spill -517 tonnes of oil into Buckingham Canal and Ennore Creek; ₹74 crore compensation demanded
+- Indian Coast Guard / Wikipedia: 2017 Ennore oil spill -BW Maple × Dawn Kanchipuram collision; ~75–196 tonnes bunker fuel; 25 miles of coastline affected
 - Global NEST Journal (2025): Heavy metal contamination in Ennore ecosystem sediments (16 parameters)
 - Springer Nature (2025): Microplastics in Kosasthalaiyar estuary
 
 **Known limitations:**
 - Incident descriptions summarised from primary sources; exact volumes are estimates in many cases
-- TNPCB consent records are not publicly searchable by facility — some data inferred from secondary sources
+- TNPCB consent records are not publicly searchable by facility -some data inferred from secondary sources
 - Coordinates represent facility centroid, not specific discharge points
 - To update: verify new NGT orders via egriwas.nic.in or TNPCB press releases; add new `incidents` entries and update `ngt_orders` array in `industrial-sources.json`
 
-## Industrial Zone Geometry — OpenStreetMap
+## Industrial Zone Geometry -OpenStreetMap
 
 | | |
 |---|---|
@@ -142,10 +143,10 @@
 | **File** | `public/geojson/chennai-industrial-zones.geojson` (static GeoJSON, filtered to area > 5 ha) |
 
 **Known limitations:**
-- OSM industrial zone coverage varies — some facilities may be partially mapped or missing
+- OSM industrial zone coverage varies -some facilities may be partially mapped or missing
 - Run `npx tsx scripts/fetch-industrial-zones-osm.ts` to regenerate after OSM data improves
 
-## Restoration Priority Scores — Computed
+## Restoration Priority Scores -Computed
 
 | | |
 |---|---|
@@ -157,10 +158,10 @@
 | **File** | `public/data/restoration-priority.json` (static, served from Next.js `public/`) |
 
 **Input datasets used:**
-- `public/geojson/chennai-water-bodies-current.geojson` — water body polygons and area
-- `public/geojson/chennai-water-bodies-lost.geojson` — 15 lost/encroached water body locations
-- `public/data/river-quality.json` — 10 CPCB monitoring station locations and latest DO readings
-- `public/data/industrial-sources.json` — 7 industrial facility coordinates
+- `public/geojson/chennai-water-bodies-current.geojson` -water body polygons and area
+- `public/geojson/chennai-water-bodies-lost.geojson` -15 lost/encroached water body locations
+- `public/data/river-quality.json` -10 CPCB monitoring station locations and latest DO readings
+- `public/data/industrial-sources.json` -7 industrial facility coordinates
 
 **Scoring components:**
 
@@ -173,9 +174,9 @@
 | Water body type | 20% | reservoir → 100, lake → 95, water → 70, pond → 65, canal → 15, drain → 5 |
 
 **Known limitations:**
-- Scores are spatial proxies only — do not account for population density, land ownership, sedimentation, or restoration cost
+- Scores are spatial proxies only -do not account for population density, land ownership, sedimentation, or restoration cost
 - Water body centroids are simple vertex averages (sufficient for km-scale distance calculations)
-- ~1,360 water bodies have no name in OSM — shown as "Unnamed water body"
+- ~1,360 water bodies have no name in OSM -shown as "Unnamed water body"
 - To regenerate: `npx tsx scripts/compute-restoration-priority.ts`
 
 ## Reservoir Metadata
@@ -201,8 +202,8 @@
 
 For initial database population, seed scripts in `scripts/` import from:
 
-- **Kaggle** (`seed-kaggle.ts`) — Monthly reservoir storage 2004–2024
-- **OpenCity** (`seed-opencity-groundwater.ts`) — Ward groundwater 2021–2024
-- **OpenCity** (`seed-opencity-lakes.ts`) — Historical lake-level readings
+- **Kaggle** (`seed-kaggle.ts`) -Monthly reservoir storage 2004–2024
+- **OpenCity** (`seed-opencity-groundwater.ts`) -Ward groundwater 2021–2024
+- **OpenCity** (`seed-opencity-lakes.ts`) -Historical lake-level readings
 
 These are one-time imports; daily pipeline keeps data current after seeding.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,62 @@
 # Neer Vazhvu
 
-**Chennai Water Intelligence Dashboard** — An open-source platform that turns public water data into actionable intelligence for Chennai's 11 million residents.
+**Chennai Water Intelligence Dashboard** - An open-source platform that turns public water data into actionable intelligence for Chennai's 11 million residents.
 
-Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks reservoir levels, groundwater health, river water quality, and water body loss across Chennai. It goes beyond simple dashboards by providing **30-day reservoir forecasts**, **ward-level risk scoring with an interactive risk map**, **river DO/BOD time-series**, **daily intelligence briefings**, and an **interactive lost water bodies map**.
+Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks reservoir levels, groundwater health, river water quality, and water body loss across Chennai. It goes beyond simple dashboards by providing **30-day reservoir forecasts**, **ward-level risk scoring with an interactive risk map**, **river DO/BOD time-series**, **daily intelligence briefings**, and an **interactive water bodies and restoration priority map**.
 
 ## Features
 
 ### Dashboard
-- **Days of Water Left** — Three-scenario estimate (pessimistic / current trend / seasonal rains)
-- **Reservoir Cards** — Live storage, inflow, outflow, and rainfall for all 6 reservoirs
-- **Per-Reservoir Drilldown** — Click any reservoir for 365-day charts (storage, inflow vs outflow, rainfall)
-- **Historical Comparison** — Overlay any year from 2019–2025 on the storage trend chart
-- **Storage Trend Chart** — 90-day combined storage with interactive year comparison
+- **Days of Water Left** - Three-scenario estimate (pessimistic / current trend / seasonal rains)
+- **Reservoir Cards** - Live storage, inflow, outflow, and rainfall for all 6 reservoirs
+- **Per-Reservoir Drilldown** - Click any reservoir for 365-day charts (storage, inflow vs outflow, rainfall)
+- **Historical Comparison** - Overlay any year from 2019-2025 on the storage trend chart
+- **Storage Trend Chart** - 90-day combined storage with interactive year comparison
 
 ### Groundwater Map
-- **Choropleth Map** — Depth to water table across all 200 GCC wards, color-coded by CGWB classification (Healthy → Crisis)
-- **Risk Score View** — Toggle between depth choropleth and composite risk score choropleth (Low / Moderate / High / Critical) when pipeline data is available
-- **Ward Detail Panel** — Click any ward for depth, year-over-year trend, historical chart, and composite risk score breakdown
-- **Risk Score Breakdown** — Each of the four components (groundwater depth 40%, trend 30%, reservoir stress 20%, seasonal 10%) shown with weighted contribution bars
+- **Choropleth Map** - Depth to water table across all 200 GCC wards, color-coded by CGWB classification (Healthy to Crisis)
+- **Risk Score View** - Toggle between depth choropleth and composite risk score choropleth (Low / Moderate / High / Critical) when pipeline data is available
+- **Ward Detail Panel** - Click any ward for depth, year-over-year trend, historical chart, and composite risk score breakdown
+- **Risk Score Breakdown** - Each of the four components (groundwater depth 40%, trend 30%, reservoir stress 20%, seasonal 10%) shown with weighted contribution bars
 
-### Water Bodies Map
-- **1,635 Existing Water Bodies** — All current lakes, tanks, ponds, and reservoirs from OpenStreetMap
-- **15 Documented Lost / Encroached Water Bodies** — Curated from Care Earth Trust, NGT records, and IIT Madras research
-- **Toggle Layers** — Show/hide current and lost water bodies independently
-- **Status-coded Circles** — Fully lost (red), severely reduced (orange), partially encroached (yellow)
-- **Detail Panel** — Click any water body for historical area, surviving area, what replaced it, and source citations
-- **Area Loss Bar** — Visual indicator of how much of each water body survives
+### Water Bodies and Restoration Map
+A unified map at `/water-bodies` with a **view-mode toggle** to switch between "Water Bodies" and "Restoration Priority" views. Both views share the same detail panel and data.
 
-### Lake Restoration Priority Ranker
-- **1,635 Water Bodies Scored** — Every water body ranked on restoration priority using spatial analysis
-- **5-Component Scoring Model** — Water body size (25%), proximity to lost water bodies (20%), proximity to polluted rivers (20%), industrial pollution proximity (15%), water body type (20%)
-- **Priority Levels** — Critical (75–100), High (50–74), Moderate (25–49), Low (0–24)
-- **Map View** — Color-coded polygons (red → green) showing restoration priority across Chennai
-- **Ranking Table** — Sortable by score, area, or name; filterable to show top priorities or all water bodies
-- **Detail Panel** — Score breakdown with weighted component bars, nearest lost water body, nearest river station, nearest industrial source
-- **Designed for GCC** — Supports government budget allocation for lake restoration programmes
+**Water Bodies view:**
+- **1,635 Existing Water Bodies** - All current lakes, tanks, ponds, and reservoirs from OpenStreetMap
+- **15 Documented Lost / Encroached Water Bodies** - Curated from Care Earth Trust, NGT records, and IIT Madras research
+- **Toggle Layers** - Show/hide current and lost water bodies independently
+- **Status-coded Circles** - Fully lost (red), severely reduced (orange), partially encroached (yellow)
+
+**Restoration Priority view:**
+- **1,635 Water Bodies Scored** - Every water body ranked on restoration priority using spatial analysis
+- **5-Component Scoring Model** - Water body size (25%), proximity to lost water bodies (20%), proximity to polluted rivers (20%), industrial pollution proximity (15%), water body type (20%)
+- **Priority Levels** - Critical (75-100), High (50-74), Moderate (25-49), Low (0-24)
+- **Color-coded Polygons** - Red to green showing restoration priority across Chennai
+
+**Shared features:**
+- **Ranking Table** - Sortable by score, area, or name; switch via Map/Ranking tabs
+- **Detail Panel** - Click any water body for basic info plus restoration score breakdown, nearest lost water body, nearest river station, nearest industrial source
+- **Stats Bar** - Adapts to show water body counts or priority breakdown based on view mode
 
 ### River Health Map
-- **Interactive Polyline Map** — 4 rivers (Cooum, Adyar, Buckingham Canal, Kosasthalaiyar) colour-coded by CPCB water quality status
-- **Monitoring Station Markers** — 10 stations with individual DO/BOD readings
-- **DO/BOD Time-Series Chart** — Dual-axis line chart (2015–2024) per station with reference lines at the aquatic life minimum (DO = 4 mg/L) and clean river standard (BOD = 2 mg/L)
-- **River Detail Panel** — Status badge, CPCB class, 3-year trend indicator, station selector, embedded explainer for DO and BOD
-- **3-Year Trend** — Per monitoring station: direction badge (Improving / Worsening / Stable / Mixed) with signed DO and BOD deltas derived from the last 3 annual readings. Threshold: ≥ 0.3 mg/L DO or ≥ 3 mg/L BOD = meaningful change.
-- **Industrial Pollution Sources Overlay** — 7 major facilities (NCTPS, CPCL, Kamarajar Port, SIPCOT Manali, MFL, TPL, Ennore Creek) colour-coded by type; click for operator details, pollutant pills, incident timeline, and NGT orders. OSM `landuse=industrial` polygons shown as translucent overlay
+- **Interactive Polyline Map** - 4 rivers (Cooum, Adyar, Buckingham Canal, Kosasthalaiyar) colour-coded by CPCB water quality status
+- **Monitoring Station Markers** - 10 stations with individual DO/BOD readings
+- **DO/BOD Time-Series Chart** - Dual-axis line chart (2015-2024) per station with reference lines at the aquatic life minimum (DO = 4 mg/L) and clean river standard (BOD = 2 mg/L)
+- **River Detail Panel** - Status badge, CPCB class, 3-year trend indicator, station selector, embedded explainer for DO and BOD
+- **3-Year Trend** - Per monitoring station: direction badge (Improving / Worsening / Stable / Mixed) with signed DO and BOD deltas derived from the last 3 annual readings
+- **Industrial Pollution Sources Overlay** - 7 major facilities (NCTPS, CPCL, Kamarajar Port, SIPCOT Manali, MFL, TPL, Ennore Creek) colour-coded by type; click for operator details, pollutant pills, incident timeline, and NGT orders. OSM `landuse=industrial` polygons shown as translucent overlay
 
 ### Intelligence Layer (Python Service)
-- **Reservoir Forecasting** — 30-day storage predictions using AutoARIMA with confidence intervals
-- **Ward Risk Scoring** — Composite 0–100 risk score per ward (groundwater depth, trend, reservoir stress, seasonal vulnerability)
-- **Daily Briefing** — Template-based intelligence summary with headlines, alerts, and recommendations
+- **Reservoir Forecasting** - 30-day storage predictions using AutoARIMA with confidence intervals
+- **Ward Risk Scoring** - Composite 0-100 risk score per ward (groundwater depth, trend, reservoir stress, seasonal vulnerability)
+- **Daily Briefing** - Template-based intelligence summary with headlines, alerts, and recommendations
 
 ### Other
-- **Dark Mode** — Full dark mode with system preference detection
-- **Responsive** — Works on desktop, tablet, and mobile
-- **Demo Mode** — Runs with realistic mock data when Supabase isn't configured
+- **Dark Mode** - Full dark mode with system preference detection
+- **Responsive** - Works on desktop, tablet, and mobile
+- **Demo Mode** - Runs with realistic mock data when Supabase isn't configured
+- **OG Image** - Auto-generated Open Graph image for social sharing (LinkedIn, Twitter)
 
 ## Architecture
 
@@ -69,10 +73,11 @@ Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks res
 └──────────────────────────────────────────┘       │
                                                    │
 ┌──────────────────────────────────────────┐       │
-│       Next.js Frontend (Vercel)          │◄──────┘
+│       Next.js Frontend (Vercel)          │<──────┘
 │  Reads from Supabase + renders UI        │
 │  Static GeoJSON served from /public      │
 └──────────────────────────────────────────┘
+
 ```
 
 ## Data Sources
@@ -86,7 +91,7 @@ Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks res
 | [OpenStreetMap Overpass API](https://overpass-api.de/) | Current water body polygons (lakes, tanks, reservoirs) + river polyline geometry + industrial zone polygons | One-time fetch |
 | Care Earth Trust / NGT / IIT Madras | Documented lost and encroached water bodies | Curated dataset |
 | [CPCB NWMP Annual Reports](https://cpcb.nic.in/nwmp-data/) | DO, BOD, pH, conductivity at 10 river monitoring stations (2015–2024) | Annual (manual refresh) |
-| NGT Southern Bench / TNPCB / CPCB | 7 major industrial pollution sources — facility data, pollutant types, incident records, NGT orders | Manually curated |
+| NGT Southern Bench / TNPCB / CPCB | 7 major industrial pollution sources -facility data, pollutant types, incident records, NGT orders | Manually curated |
 
 ## Tech Stack
 
@@ -94,7 +99,7 @@ Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks res
 |-------|------------|
 | Frontend | Next.js 16, React 19, TypeScript, Tailwind CSS v4, shadcn/ui |
 | Charts | Recharts |
-| Maps | Leaflet + react-leaflet — GCC ward boundaries (GeoJSON) + OSM water body polygons + curated lost bodies (GeoJSON) |
+| Maps | Leaflet + react-leaflet -GCC ward boundaries (GeoJSON) + OSM water body polygons + curated lost bodies (GeoJSON) |
 | Backend API | Python 3.12, FastAPI, statsforecast, pandas |
 | Database | Supabase (PostgreSQL) |
 | Deployment | Vercel (frontend), Railway (Python API) |
@@ -218,7 +223,7 @@ npx tsx scripts/fetch-industrial-zones-osm.ts
 
 ## API Endpoints
 
-### Pipeline (protected — requires `Authorization: Bearer <CRON_SECRET>`)
+### Pipeline (protected -requires `Authorization: Bearer <CRON_SECRET>`)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -249,17 +254,17 @@ neer-vazhvu/
 │   ├── app/                      # App Router pages
 │   │   ├── page.tsx              # Main dashboard
 │   │   ├── groundwater/          # Groundwater map page
-│   │   ├── water-bodies/         # Water bodies map page
+│   │   ├── water-bodies/         # Unified water bodies + restoration map
 │   │   ├── rivers/               # River health + industrial pollution map page
-│   │   ├── lake-restoration/     # Lake restoration priority ranker
+│   │   ├── lake-restoration/     # Redirects to /water-bodies
 │   │   └── about/                # About/methodology page
 │   ├── components/
 │   │   ├── dashboard/            # Dashboard components
 │   │   ├── groundwater/          # Map, legend, ward panel
-│   │   ├── water-bodies/         # Map, legend, detail panel
+│   │   ├── water-bodies/         # Unified map, legend, detail panel, view-mode toggle
 │   │   ├── rivers/               # River map, panel, chart, legend
 │   │   ├── pollution/            # Industrial pollution map overlay, panel, legend
-│   │   ├── lake-restoration/     # Restoration map, legend, detail panel, ranking table
+│   │   ├── lake-restoration/     # Restoration ranking table
 │   │   ├── layout/               # Header, footer
 │   │   └── ui/                   # shadcn/ui primitives
 │   ├── lib/
@@ -267,7 +272,6 @@ neer-vazhvu/
 │   │   ├── calculator/           # Days-left calculator
 │   │   └── mock-data.ts          # Demo mode data
 │   └── types/                    # TypeScript type definitions
-│       └── industrial-pollution.ts  # Industrial source types, colours, labels
 ├── neer-vazhvu-api/              # Python intelligence service
 │   ├── app/
 │   │   ├── scrapers/             # CMWSSB, NASA POWER, OpenCity
@@ -287,7 +291,7 @@ neer-vazhvu/
 │   │   ├── chennai-rivers.geojson               # River polylines (Cooum, Adyar, etc.)
 │   │   └── chennai-industrial-zones.geojson     # OSM industrial zone polygons
 │   └── data/                     # Static JSON datasets
-│       ├── river-quality.json            # CPCB monitoring station readings (2015–2024)
+│       ├── river-quality.json            # CPCB monitoring station readings (2015-2024)
 │       ├── industrial-sources.json       # Industrial pollution sources (NGT/TNPCB/CPCB)
 │       └── restoration-priority.json     # Pre-computed restoration priority scores (1,635 water bodies)
 └── .github/
@@ -336,13 +340,13 @@ Scores are pre-computed by `scripts/compute-restoration-priority.ts` using Haver
 
 ## Limitations
 
-- This is an independent, educational project — not an official government tool.
+- This is an independent, educational project -not an official government tool.
 - Estimates are approximations. Actual water availability depends on factors not modeled (Krishna water transfer, distribution losses, industrial use).
-- CMWSSB data may occasionally be stale (weekends, holidays).
+- CMWSSB data may occasionally be stale (weekends, holidays, or when their site blocks datacenter IPs). The pipeline gracefully continues with existing data for up to 4 days.
 - Groundwater data from OpenCity may lag by months.
 - Forecasts use AutoARIMA which works best with 90+ days of history.
 - Lost water body coordinates and historical areas are approximate, sourced from academic and civic studies.
-- Restoration priority scores use spatial proximity as a proxy; they do not account for population density, land ownership, or restoration cost — factors that require non-public data.
+- Restoration priority scores use spatial proximity as a proxy; they do not account for population density, land ownership, or restoration cost -factors that require non-public data.
 
 ## Contributing
 
@@ -352,11 +356,11 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 Areas where help is needed:
 
-- **Data quality** — Improving scraper resilience, handling CMWSSB page format changes
-- **Models** — Better forecasting (Prophet, LSTM), evaporation modeling
-- **Water bodies data** — Adding more documented lost water bodies with verified coordinates and sources
-- **Tamil localization** — Translating the UI for local accessibility
-- **Testing** — Unit tests for scrapers, calculator, and intelligence modules
+- **Data quality** -Improving scraper resilience, handling CMWSSB page format changes
+- **Models** -Better forecasting (Prophet, LSTM), evaporation modeling
+- **Water bodies data** -Adding more documented lost water bodies with verified coordinates and sources
+- **Tamil localization** -Translating the UI for local accessibility
+- **Testing** -Unit tests for scrapers, calculator, and intelligence modules
 
 Please open an issue first to discuss significant changes.
 


### PR DESCRIPTION
## Summary
- CMWSSB blocks GitHub Actions datacenter IPs, causing `ConnectTimeout` on every daily scrape
- Added a Cloudflare Worker (`workers/cmwssb-proxy/`) that proxies requests through Cloudflare edge nodes (not blocked)
- Scraper now tries direct access first, falls back to the proxy on `ConnectTimeout`/`ConnectError`
- Worker is deployed and tested: returns fresh reservoir data via `https://cmwssb-proxy.sundareshchandran.workers.dev`

## Changes
- `workers/cmwssb-proxy/` - new Cloudflare Worker (auth-protected proxy)
- `neer-vazhvu-api/app/scrapers/cmwssb.py` - added `_fetch_via_proxy()` fallback
- `.github/workflows/daily-data-pipeline.yml` - passes `CMWSSB_PROXY_URL` and `CMWSSB_PROXY_SECRET` secrets

## Test plan
- [ ] Merge and trigger manual pipeline run
- [ ] Verify scraper falls back to proxy and upserts fresh data
- [ ] Confirm next scheduled run succeeds