### PR TITLE
fix: grant issues:write permission for pipeline failure alerts

### DIFF
--- a/.github/workflows/daily-data-pipeline.yml
+++ b/.github/workflows/daily-data-pipeline.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 0 * * *'   # 00:30 UTC = 06:00 IST
   workflow_dispatch:         # Manual trigger for debugging
 
+permissions:
+  issues: write
+
 jobs:
   daily-pipeline:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: issues: write` to the daily pipeline workflow so the scrape-failure alert step can create GitHub issues
- Without this, the `actions/github-script` step fails with `403 Resource not accessible by integration`

## Test plan

- [ ] Trigger workflow manually and verify the alert step no longer returns 403 when scrape fails