### PR TITLE
fix: improve river map visibility in light mode + correct station coords

### DIFF
--- a/public/data/river-quality.json
+++ b/public/data/river-quality.json
@@ -212,8 +212,8 @@
         {
           "id": "kosasthalaiyar-ponneri",
           "name": "Kosasthalaiyar at Ponneri",
-          "lat": 13.3402,
-          "lng": 80.1952,
+          "lat": 13.2820,
+          "lng": 80.2048,
           "stretch": "Upper",
           "readings": [
             { "year": 2015, "do_mgl": 3.5, "bod_mgl": 18, "ph": 7.0, "conductivity_us": 520 },
@@ -231,8 +231,8 @@
         {
           "id": "kosasthalaiyar-ennore",
           "name": "Kosasthalaiyar near Ennore Creek",
-          "lat": 13.2252,
-          "lng": 80.3128,
+          "lat": 13.2484,
+          "lng": 80.2549,
           "stretch": "Lower (Ennore)",
           "readings": [
             { "year": 2015, "do_mgl": 1.5, "bod_mgl": 48, "ph": 7.1, "conductivity_us": 1850 },

--- a/src/components/rivers/combined-rivers-map.tsx
+++ b/src/components/rivers/combined-rivers-map.tsx
@@ -87,12 +87,12 @@ export function CombinedRiversMap({
 
   // Industrial zone polygons  -  light orange wash, background context
   const zoneStyle = (): PathOptions => ({
-    fillColor: "#f97316",
-    fillOpacity: 0.10,
-    color: "#f97316",
-    weight: 1,
+    fillColor: "#ea580c",
+    fillOpacity: 0.18,
+    color: "#ea580c",
+    weight: 1.5,
     dashArray: "4, 4",
-    opacity: 0.5,
+    opacity: 0.7,
   });
 
   const onEachZone = (feature: Feature, layer: Layer) => {

--- a/src/types/industrial-pollution.ts
+++ b/src/types/industrial-pollution.ts
@@ -51,7 +51,7 @@ export const SOURCE_TYPE_COLORS: Record<PollutionSourceType, string> = {
   petrochemical: "#7c3aed",     // purple
   chemical: "#f97316",          // orange
   port: "#0ea5e9",              // blue
-  industrial_estate: "#84cc16", // lime
+  industrial_estate: "#4d7c0f", // dark lime
   discharge_zone: "#64748b",    // slate
 };
 

--- a/src/types/river-quality.ts
+++ b/src/types/river-quality.ts
@@ -52,8 +52,8 @@ export interface SelectedRiver {
 export const QUALITY_COLORS: Record<RiverQualityStatus, string> = {
   dead: "#dc2626",
   severely_degraded: "#f97316",
-  degraded: "#eab308",
-  stressed: "#84cc16",
+  degraded: "#a16207",
+  stressed: "#4d7c0f",
   healthy: "#22c55e",
 };
 


### PR DESCRIPTION
## Summary

- Darken degraded (`#eab308` -> `#a16207`) and stressed (`#84cc16` -> `#4d7c0f`) river colors so they're visible on light map tiles
- Increase industrial zone fill opacity (0.10 -> 0.18) and border weight/opacity for light mode visibility
- Darken industrial estate marker color (`#84cc16` -> `#4d7c0f`)
- Fix Kosasthalaiyar monitoring station coordinates -- both were ~6-7km off the actual river (placed at town centers instead of on the river)

## Test plan

- [x] Check river map in light mode -- Kosasthalaiyar (degraded) and industrial zones should be clearly visible
- [x] Check river map in dark mode -- colors still look good
- [x] Verify Kosasthalaiyar station markers sit on the river polyline