### PR TITLE
fix: correct days-left scenario ordering and formatting

### DIFF
--- a/src/components/dashboard/days-left-hero.tsx
+++ b/src/components/dashboard/days-left-hero.tsx
@@ -17,33 +17,45 @@ interface DaysLeftHeroProps {
   comparison2019Storage: number | null;
 }
 
+/** Upper display cap — anything above this is "won't run out" */
+const MAX_DAYS = 9999;
+
 function computeClientDaysLeft(
   storageMcft: number,
   consumptionMLD: number,
   desalinationMLD: number,
   recentInflowMcft: number,
-  seasonalInflowMcft: number
+  seasonalInflowMcft: number,
+  inflowPct: number
 ) {
   const netDemandMcft = (consumptionMLD - desalinationMLD) * MLD_TO_MCFT;
+  const inflowScale = inflowPct / 100;
 
-  const pessimistic = netDemandMcft > 0 ? Math.floor(storageMcft / netDemandMcft) : 999;
-  const depletionModerate = Math.max(0, netDemandMcft - recentInflowMcft);
-  const moderate = depletionModerate > 0 ? Math.floor(storageMcft / depletionModerate) : 999;
-  const depletionOptimistic = Math.max(0, netDemandMcft - seasonalInflowMcft);
-  const optimistic = depletionOptimistic > 0 ? Math.floor(storageMcft / depletionOptimistic) : 999;
+  const pessimistic = netDemandMcft > 0 ? Math.floor(storageMcft / netDemandMcft) : MAX_DAYS;
+  const depletionModerate = Math.max(0, netDemandMcft - recentInflowMcft * inflowScale);
+  const rawModerate = depletionModerate > 0 ? Math.floor(storageMcft / depletionModerate) : MAX_DAYS;
+  const depletionOptimistic = Math.max(0, netDemandMcft - seasonalInflowMcft * inflowScale);
+  const rawOptimistic = depletionOptimistic > 0 ? Math.floor(storageMcft / depletionOptimistic) : MAX_DAYS;
+
+  // Ensure ordering: pessimistic <= moderate <= optimistic
+  // (recent inflow can exceed seasonal average, flipping the two)
+  const moderate = Math.min(rawModerate, rawOptimistic);
+  const optimistic = Math.max(rawModerate, rawOptimistic);
 
   return {
-    pessimistic: Math.min(pessimistic, 999),
-    moderate: Math.min(moderate, 999),
-    optimistic: Math.min(optimistic, 999),
+    pessimistic: Math.min(pessimistic, MAX_DAYS),
+    moderate: Math.min(moderate, MAX_DAYS),
+    optimistic: Math.min(optimistic, MAX_DAYS),
   };
 }
 
 function formatDays(days: number, t: (key: string) => string): string {
-  if (days >= 999) return t("hero.wont_run_out");
-  if (days >= 730) return `${(days / 365).toFixed(1)} ${t("hero.yrs_unit")}`;
-  if (days >= 365) return `${(days / 365).toFixed(1)} ${t("hero.yr_unit")}`;
-  return `${days} ${t("hero.days_unit")}`;
+  if (days >= MAX_DAYS) return t("hero.wont_run_out");
+  if (days >= 365) {
+    const yrs = (days / 365).toFixed(1);
+    return `${yrs} ${parseFloat(yrs) >= 2 ? t("hero.yrs_unit") : t("hero.yr_unit")}`;
+  }
+  return `${days} ${days === 1 ? t("hero.day_unit") : t("hero.days_unit")}`;
 }
 
 function getSeverityColor(days: number): string {
@@ -71,6 +83,7 @@ export function DaysLeftHero({
   const { t } = useLanguage();
   const [consumption, setConsumption] = useState(DEFAULT_CONSUMPTION_MLD);
   const [desalination, setDesalination] = useState(DEFAULT_DESALINATION_MLD);
+  const [inflowPct, setInflowPct] = useState(100);
   const [showAssumptions, setShowAssumptions] = useState(false);
 
   const days = computeClientDaysLeft(
@@ -78,7 +91,8 @@ export function DaysLeftHero({
     consumption,
     desalination,
     recentAvgInflowMcftPerDay,
-    seasonalAvgInflowMcftPerDay
+    seasonalAvgInflowMcftPerDay,
+    inflowPct
   );
 
   const storagePct = totalCapacityMcft > 0 ? (totalStorageMcft / totalCapacityMcft) * 100 : 0;
@@ -99,19 +113,19 @@ export function DaysLeftHero({
           {/* Big number */}
           <div className="text-center sm:text-left">
             <div className={`text-5xl sm:text-6xl font-bold ${getSeverityColor(days.pessimistic)}`}>
-              {days.pessimistic >= 999 ? (
+              {days.pessimistic >= MAX_DAYS ? (
                 // All scenarios safe  -  inflows sustain supply
                 <>{t("hero.safe")}</>
-              ) : days.optimistic >= 999 ? (
+              ) : days.optimistic >= MAX_DAYS ? (
                 // Worst case is finite but best case won't deplete
-                <>{days.pessimistic}<span className="text-2xl text-slate-400 dark:text-slate-500">+</span></>
+                <>{formatDays(days.pessimistic, t)}<span className="text-2xl text-slate-400 dark:text-slate-500">+</span></>
               ) : (
                 // Normal range
-                <>{days.pessimistic}<span className="text-2xl text-slate-400 dark:text-slate-500 mx-1">–</span>{days.optimistic}</>
+                <>{formatDays(days.pessimistic, t)}<span className="text-2xl mx-1">–</span>{formatDays(days.optimistic, t)}</>
               )}
             </div>
             <div className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              {days.pessimistic >= 999 ? t("hero.inflows_exceed") : t("hero.days_remaining")}
+              {days.pessimistic >= MAX_DAYS ? t("hero.inflows_exceed") : t("hero.days_remaining")}
             </div>
           </div>
 
@@ -206,6 +220,22 @@ export function DaysLeftHero({
                   max={400}
                   step={10}
                 />
+              </div>
+              <div>
+                <div className="flex justify-between text-sm mb-2">
+                  <span className="text-slate-600 dark:text-slate-400">{t("hero.inflow_pct")}</span>
+                  <span className="font-mono font-semibold">{inflowPct}%</span>
+                </div>
+                <Slider
+                  value={[inflowPct]}
+                  onValueChange={([v]) => setInflowPct(v)}
+                  min={0}
+                  max={150}
+                  step={5}
+                />
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+                  {t("hero.inflow_hint")}
+                </p>
               </div>
               <p className="text-xs text-slate-400 dark:text-slate-500">
                 {t("hero.slider_note")}

--- a/src/lib/calculator/days-left.ts
+++ b/src/lib/calculator/days-left.ts
@@ -2,7 +2,7 @@ import { MLD_TO_MCFT } from '@/lib/utils/constants';
 import type { DaysLeftInput, DaysLeftOutput } from '@/types/calculator';
 
 /** Maximum days to report (when inflow exceeds consumption) */
-const MAX_DAYS = 999;
+const MAX_DAYS = 9999;
 
 /**
  * Computes estimated days of water remaining in Chennai's reservoirs.
@@ -37,17 +37,22 @@ export function computeDaysLeft(input: DaysLeftInput): DaysLeftOutput {
 
   // Scenario 2: MODERATE  -  recent inflow trend continues
   const depletionModerate = Math.max(0, netReservoirDemandMcft - recentAvgInflowMcftPerDay);
-  const moderate =
+  const rawModerate =
     depletionModerate > 0
       ? Math.max(0, Math.floor(totalStorageMcft / depletionModerate))
       : MAX_DAYS;
 
   // Scenario 3: OPTIMISTIC  -  seasonal average inflow
   const depletionOptimistic = Math.max(0, netReservoirDemandMcft - seasonalAvgInflowMcftPerDay);
-  const optimistic =
+  const rawOptimistic =
     depletionOptimistic > 0
       ? Math.max(0, Math.floor(totalStorageMcft / depletionOptimistic))
       : MAX_DAYS;
+
+  // Ensure ordering: pessimistic <= moderate <= optimistic
+  // (recent inflow can exceed seasonal average, flipping the two)
+  const moderate = Math.min(rawModerate, rawOptimistic);
+  const optimistic = Math.max(rawModerate, rawOptimistic);
 
   return {
     pessimistic: Math.min(pessimistic, MAX_DAYS),

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -36,6 +36,7 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "hero.current_trend":   { en: "Current trend:",            ta: "தற்போதைய போக்கு:" },
   "hero.seasonal_rains":  { en: "If seasonal rains:",        ta: "பருவமழை இருந்தால்:" },
   "hero.wont_run_out":    { en: "Won\u2019t run out",        ta: "தீர்ந்துவிடாது" },
+  "hero.day_unit":        { en: "day",                       ta: "நாள்" },
   "hero.days_unit":       { en: "days",                      ta: "நாட்கள்" },
   "hero.yr_unit":         { en: "yr",                        ta: "ஆண்டு" },
   "hero.yrs_unit":        { en: "yrs",                       ta: "ஆண்டுகள்" },
@@ -46,6 +47,8 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "hero.adjust":          { en: "Adjust assumptions",        ta: "அனுமானங்களை மாற்றவும்" },
   "hero.consumption":     { en: "Daily consumption",         ta: "தினசரி நுகர்வு" },
   "hero.desalination":    { en: "Desalination output",       ta: "கடல்நீர் குடிநீராக்க உற்பத்தி" },
+  "hero.inflow_pct":      { en: "Inflow scenario",           ta: "நீர்வரத்து சூழல்" },
+  "hero.inflow_hint":     { en: "Simulate drought (↓) or heavy rains (↑). 0% = no inflow, 100% = current actual.",  ta: "வறட்சி (↓) அல்லது கனமழை (↑) உருவகப்படுத்தவும். 0% = வரத்து இல்லை, 100% = தற்போதைய நிலை." },
   "hero.slider_note":     { en: "Days left updates in real time as you adjust. Default: 830 MLD consumption, 190 MLD desalination.", ta: "சரிசெய்யும்போது மீதமுள்ள நாட்கள் நேரடியாக புதுப்பிக்கப்படும். இயல்பு: 830 MLD நுகர்வு, 190 MLD கடல்நீர் நீக்கம்." },
 
   // ── Groundwater Snapshot ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Enforce `pessimistic <= moderate <= optimistic` ordering — when recent 7-day inflow exceeds seasonal average (e.g. 80.8 vs 33.2 mcft/day), "current trend" was showing more days than "seasonal rains"
- Fix singular/plural year formatting (1.2 yr vs 3.9 yrs) based on displayed value, not raw day count
- Fix dash separator inheriting severity color instead of being grey