### PR TITLE
Add live CGWB groundwater stations from India WRIS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,6 +16,7 @@ graph TB
         GCC["GCC SWD Survey<br/>(Storm water drains, one-time)"]
         IMD["IMD Gridded Rainfall<br/>(via imdlib, one-time)"]
         WRIS["India WRIS / CGWB<br/>(GW exploitation, one-time)"]
+        WRIS_ST["India WRIS GWL API<br/>(CGWB station time series, daily)"]
         DGI["data.gov.in<br/>(Water Bodies Census)"]
         CMWSSB_SEW["CMWSSB Sewerage<br/>(STPs, SPS, pumping mains, one-time)"]
         ANTHROPIC["Anthropic Claude API<br/>(AI narratives)"]
@@ -29,7 +30,7 @@ graph TB
     end
 
     subgraph Database ["Supabase (PostgreSQL)"]
-        Core["Core Tables<br/>reservoir_daily<br/>weather_daily<br/>groundwater_monthly<br/>water_bodies_census"]
+        Core["Core Tables<br/>reservoir_daily<br/>weather_daily<br/>groundwater_monthly<br/>groundwater_wris<br/>water_bodies_census"]
         Computed["Computed Tables<br/>water_estimate_daily<br/>reservoir_forecast<br/>ward_risk_score<br/>daily_briefing<br/>ward_narrative"]
         GEE["GEE Tables<br/>water_body_satellite_summary<br/>reservoir_catchment_context<br/>water_body_satellite_evidence"]
         Storage["Supabase Storage<br/>satellite-evidence bucket"]
@@ -62,6 +63,7 @@ graph TB
     CMWSSB_SEW -->|KML/KMZ conversion| StaticFiles2
     IMD -->|imdlib script| StaticFiles
     WRIS -->|ArcGIS REST| StaticFiles
+    WRIS_ST -->|REST API, daily scrape| Scrapers
     ANTHROPIC -->|Claude API| Computed
     GEE_SRC -->|Earth Engine API| GEE
     GEE_SRC -->|Sentinel-2 thumbnails| Storage
@@ -120,6 +122,7 @@ flowchart LR
 | Scrape CMWSSB | cmwssb.tn.gov.in | `reservoir_daily` | Daily |
 | Fetch Weather | open-meteo.com (primary) / power.larc.nasa.gov (fallback) | `weather_daily` | Daily (zero lag) |
 | Fetch OpenCity | data.opencity.in | `groundwater_monthly` | Monthly (days 1-3) |
+| Fetch WRIS Stations | indiawris.gov.in Ground Water Level API | `groundwater_wris` (and `groundwater_wris_latest` view with stuck/stale sensor quality flag) | Daily |
 | Compute Estimate | Aggregated storage + inflow | `water_estimate_daily` | Daily |
 | Forecast | StatsForecast ARIMAX | `reservoir_forecast` | Daily |
 | Risk Scores | Groundwater + reservoir stress | `ward_risk_score` | Monthly |
@@ -174,6 +177,21 @@ erDiagram
         text ward_name
         text zone_name
         float depth_to_water_m
+    }
+
+    groundwater_wris {
+        text station_code PK
+        date reading_date PK
+        text station_name
+        float latitude
+        float longitude
+        float depth_to_water_m
+        text acquisition_mode "Manual or Telemetric"
+        text agency "CGWB"
+        text district
+        text well_type "Dug Well / Bore Well / Piezometer"
+        float well_depth_m
+        text well_aquifer_type "Unconfined / Confined / Semi Confined"
     }
 
     water_estimate_daily {

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -62,6 +62,7 @@
 - Not all wards report every month -coverage varies
 - Measurement methodology may differ across wards
 - New year datasets require adding the resource ID to the scraper config
+- For fresher station-level readings, see [CGWB Station-Level Groundwater Time Series](#cgwb-station-level-groundwater-time-series---india-wris), which is pulled daily from the India WRIS Ground Water Level API and is plotted as a station overlay on top of the OpenCity ward choropleth.
 
 ## Water Bodies Census — data.gov.in
 
@@ -226,6 +227,47 @@
 - Block boundaries from India WRIS ArcGIS may not align exactly with GCC administrative boundaries
 - Some blocks cover areas beyond Chennai city limits
 - To regenerate: `npx tsx scripts/fetch-wris-groundwater.ts`
+
+## CGWB Station-Level Groundwater Time Series - India WRIS
+
+| | |
+|---|---|
+| **Source** | [India WRIS Ground Water Level API](https://indiawris.gov.in/Dataset/Ground%20Water%20Level) / CGWB |
+| **Method** | Python scraper `neer-vazhvu-api/app/scrapers/wris.py` pulling daily station-level readings for Chennai district; upserted into Supabase via `pipeline.py` |
+| **Frequency** | Daily fetch (as part of the monthly pipeline run); historical backfill via `neer-vazhvu-api/scripts/backfill_wris_metadata.py` |
+| **Coverage** | ~35 CGWB stations in Chennai district (mix of Manual dug wells and Telemetric DWLR bore wells) |
+| **Fields** | `station_code`, `station_name`, `latitude`, `longitude`, `reading_date`, `depth_to_water_m`, `acquisition_mode` (Manual / Telemetric), `agency`, `district`, `well_type` (Dug Well / Bore Well / Piezometer), `well_depth_m`, `well_aquifer_type` (Unconfined / Confined / Semi Confined) |
+| **Storage** | Supabase tables `groundwater_wris` (raw time series) and `groundwater_wris_latest` view (per-station latest reading + quality flag) |
+
+**Why this source?**
+- OpenCity's ward-level dataset is monthly-to-quarterly and often lags by months. CGWB stations give near-daily readings from telemetric DWLRs so the dashboard can surface fresher context next to the ward choropleth.
+- Each reading is tied to a specific well with known depth and aquifer type, which lets users distinguish a 6m dug well sampling the shallow unconfined aquifer from a 200m bore well piezometer tapping a deeper confined aquifer (the two can differ by tens of metres and must not be conflated).
+- Station points complement the ward choropleth with ground-truth measurements.
+
+**Manual vs Telemetric stations:**
+- **Manual (CGWB field crew):** quarterly / seasonal cadence, usually shallow dug wells in the unconfined aquifer. Readings are hand-logged by CGWB ground staff and reflect the shallow water table users actually pump from.
+- **Telemetric (DWLR):** Digital Water Level Recorders that transmit readings daily. Usually installed on deeper bore wells or piezometers tapping confined/semi-confined aquifers. Higher cadence but much more sensitive to sensor failure.
+
+**Data quality pipeline (`groundwater_wris_latest` view):**
+The view enriches each station's latest reading with a `data_quality_flag` so stale or broken sensors don't silently poison the map. Migrations `014_groundwater_wris_metadata_and_quality.sql` → `016_groundwater_wris_stuck_detection_v2.sql` define it:
+- **`stuck`** - Telemetric station with >=10 readings in the last 60 days whose **median daily |delta|** is < 1cm (0.01 m). This is a robust detector: a single one-off step change won't blow it out the way a pure range-based test would, but a sensor that has flat-lined for weeks will be caught. Current catches: ADAYAR_1, Pallavaram_2, Taramani NITTR PZ.
+- **`stale`** - mode-aware freshness threshold. Telemetric stations become stale if the latest reading is older than 14 days (a DWLR should report daily). Manual stations only become stale if the latest reading is older than 180 days (CGWB resurveys them seasonally).
+- **`ok`** - station has at least one recent reading and is neither stuck nor stale.
+- **`unknown`** - no recent data and mode behaviour cannot be judged.
+
+The view also returns `recent_count` and `recent_range_m` so downstream UIs can explain *why* a station was flagged.
+
+**How the frontend uses the flag:**
+- Suspect stations render with a neutral grey fill and a dashed amber border on the groundwater map, so they're visually distinct from trustworthy readings.
+- The WRIS station panel shows a prominent amber "Possible sensor failure" banner on stuck stations and a muted "Data is old" banner on stale stations, with context explaining which kind of station it is.
+- The depth-view legend has a filterable "CGWB sensor status" sub-section so reviewers can hide stuck or stale markers entirely.
+
+**Known limitations:**
+- The WRIS public API is rate-limited and occasionally returns empty responses; the scraper retries on transient failures.
+- A handful of stations have `Not Available` metadata fields - these are normalized to NULL in the stations API route.
+- The stuck-sensor detector currently only flags Telemetric stations. Manual stations with flat readings are assumed to be seasonal and left alone.
+- Well metadata (`well_type`, `well_depth_m`, `well_aquifer_type`) is backfilled from the WRIS metadata endpoint; stations added after the last backfill will have NULLs until the next pipeline run.
+- To backfill metadata on existing rows: `cd neer-vazhvu-api && python scripts/backfill_wris_metadata.py`
 
 ## Flood Risk Data - OpenCity Chennai
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks res
 - **Choropleth Map** - Depth to water table across all 200 GCC wards, color-coded by CGWB classification (Healthy to Crisis)
 - **Risk Score View** - Toggle between depth choropleth and composite risk score choropleth (Low / Moderate / High / Critical) when pipeline data is available
 - **CGWB Exploitation View** - Block-level groundwater exploitation from India WRIS/CGWB (2011-2024), showing Safe/Semi-Critical/Critical/Over-Exploited classification with development percentage trends
+- **Live CGWB Station Overlay** - ~35 CGWB/India WRIS stations in Chennai district plotted as circle markers over the ward choropleth, mixing Manual (quarterly dug wells) and Telemetric (daily DWLR bore wells) with well type, well depth, and aquifer type in the station panel
+- **Sensor Data Quality Layer** - Each station is scored server-side with a `stuck` / `stale` / `ok` flag (stuck detection uses median daily delta < 1cm over 60 days; stale is mode-aware - 14 days for DWLR, 180 days for manual). Suspect stations render with a dashed amber ring and get an explicit warning banner in the panel, and the legend exposes filters so reviewers can hide them
 - **Ward Detail Panel** - Click any ward for depth, year-over-year trend, historical chart, and composite risk score breakdown
 - **Block Detail Panel** - Click any exploitation block for development %, availability, draft totals, and historical trend bar chart with 100% threshold line
 - **Risk Score Breakdown** - Each of the four components (groundwater depth 40%, trend 30%, reservoir stress 20%, seasonal 10%) shown with weighted contribution bars
@@ -164,6 +166,7 @@ Earth Engine Phase 1 jobs live under `neer-vazhvu-api/app/gee/` and write small 
 | NGT Southern Bench / TNPCB / CPCB | 7 major industrial pollution sources - facility data, pollutant types, incident records, NGT orders | Manually curated |
 | [IMD Gridded Rainfall (via imdlib)](https://imdlib.readthedocs.io/) | Monthly rainfall at 0.25 deg resolution for Chennai (1970-2025), long-term normals | One-time generation |
 | [India WRIS / CGWB](https://indiawris.gov.in/) | Block-level groundwater exploitation (%), classification (Safe to Over-Exploited), block boundaries (2011-2024) | Static fetch |
+| [India WRIS Ground Water Level API](https://indiawris.gov.in/Dataset/Ground%20Water%20Level) | CGWB station-level time series (~35 Chennai stations, depth to water, Manual vs Telemetric/DWLR, well type, well depth, aquifer type) with server-side stuck/stale sensor detection | Daily scrape |
 | [OpenCity Chennai (Flood Data)](https://data.opencity.in/) | CFLOWS flood hazard zones, 2015 flood hotspots/depth, 2020 Cyclone Nivar hotspots, return period maps | Static fetch |
 | [GCC Storm Water Drain Survey](https://data.opencity.in/) | 10,308 drain segments with type, depth, width, material, status across 197 wards | Static fetch |
 | [CMWSSB Sewerage Network](https://data.opencity.in/) | 8 STPs, 348 pumping stations, 3,834 pumping mains with pipe material and size | Static fetch |

--- a/neer-vazhvu-api/app/etl/pipeline.py
+++ b/neer-vazhvu-api/app/etl/pipeline.py
@@ -373,9 +373,7 @@ async def run_daily() -> list[dict]:
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
 
-    steps.append(
-        await _run_step("fetch_wris", _step_fetch_wris, required=False)
-    )
+    steps.append(await _run_step("fetch_wris", _step_fetch_wris, required=False))
 
     # ETL
     step = await _run_step("compute_estimate", _step_compute_estimate)
@@ -425,9 +423,7 @@ async def run_post_scrape() -> list[dict]:
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
 
-    steps.append(
-        await _run_step("fetch_wris", _step_fetch_wris, required=False)
-    )
+    steps.append(await _run_step("fetch_wris", _step_fetch_wris, required=False))
 
     step = await _run_step("compute_estimate", _step_compute_estimate)
     steps.append(step)

--- a/neer-vazhvu-api/app/etl/pipeline.py
+++ b/neer-vazhvu-api/app/etl/pipeline.py
@@ -23,6 +23,7 @@ from app.scrapers.cmwssb import scrape_cmwssb
 from app.scrapers.nasa_power import fetch_nasa_power
 from app.scrapers.open_meteo import fetch_open_meteo
 from app.scrapers.opencity import fetch_groundwater, GROUNDWATER_RESOURCES
+from app.scrapers.wris import fetch_wris_groundwater
 from app.utils.timezone import ist_today
 
 logger = logging.getLogger(__name__)
@@ -201,6 +202,47 @@ async def _step_fetch_opencity() -> dict:
     return {"rows_affected": len(rows)}
 
 
+async def _step_fetch_wris() -> dict:
+    """Fetch CGWB station-level groundwater from India WRIS API.
+
+    Fetches both manual (seasonal) and telemetric (DWLR) readings.
+    Runs weekly or on-demand. Covers the last 90 days by default to
+    catch any backfilled data.
+    """
+    supabase = get_supabase()
+    today = ist_today()
+    start = today - timedelta(days=90)
+
+    records = await fetch_wris_groundwater(start_date=start, end_date=today)
+
+    rows = [
+        {
+            "station_code": r.station_code,
+            "station_name": r.station_name,
+            "latitude": r.latitude,
+            "longitude": r.longitude,
+            "reading_date": r.reading_date.isoformat(),
+            "depth_to_water_m": r.depth_to_water_m,
+            "acquisition_mode": r.acquisition_mode,
+            "agency": r.agency,
+            "district": r.district,
+            "source": "cgwb",
+        }
+        for r in records
+    ]
+
+    if rows:
+        # Upsert in batches of 200 to avoid payload limits
+        batch_size = 200
+        for i in range(0, len(rows), batch_size):
+            batch = rows[i : i + batch_size]
+            supabase.table("groundwater_wris").upsert(
+                batch, on_conflict="station_code,reading_date"
+            ).execute()
+
+    return {"rows_affected": len(rows)}
+
+
 async def _step_compute_estimate() -> dict:
     """Step 4: Compute daily days-left estimate."""
     supabase = get_supabase()
@@ -331,6 +373,10 @@ async def run_daily() -> list[dict]:
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
 
+    steps.append(
+        await _run_step("fetch_wris", _step_fetch_wris, required=False)
+    )
+
     # ETL
     step = await _run_step("compute_estimate", _step_compute_estimate)
     steps.append(step)
@@ -379,6 +425,10 @@ async def run_post_scrape() -> list[dict]:
         await _run_step("fetch_opencity", _step_fetch_opencity, required=False)
     )
 
+    steps.append(
+        await _run_step("fetch_wris", _step_fetch_wris, required=False)
+    )
+
     step = await _run_step("compute_estimate", _step_compute_estimate)
     steps.append(step)
     if step["status"] == "error":
@@ -390,6 +440,14 @@ async def run_post_scrape() -> list[dict]:
         return steps
 
     step = await _run_step("briefing", _step_briefing)
+    steps.append(step)
+    return steps
+
+
+async def run_wris_fetch() -> list[dict]:
+    """Fetch WRIS groundwater data (on-demand or weekly)."""
+    steps = []
+    step = await _run_step("fetch_wris", _step_fetch_wris)
     steps.append(step)
     return steps
 

--- a/neer-vazhvu-api/app/etl/pipeline.py
+++ b/neer-vazhvu-api/app/etl/pipeline.py
@@ -226,6 +226,9 @@ async def _step_fetch_wris() -> dict:
             "acquisition_mode": r.acquisition_mode,
             "agency": r.agency,
             "district": r.district,
+            "well_type": r.well_type,
+            "well_depth_m": r.well_depth_m,
+            "well_aquifer_type": r.well_aquifer_type,
             "source": "cgwb",
         }
         for r in records

--- a/neer-vazhvu-api/app/models/groundwater.py
+++ b/neer-vazhvu-api/app/models/groundwater.py
@@ -27,3 +27,10 @@ class WrisGroundwaterRecord(BaseModel):
     agency: str = "CGWB"
     state: str = "Tamil Nadu"
     district: str = "Chennai"
+    # Well metadata (from WRIS API): helps users distinguish a 6m dug well in
+    # the unconfined aquifer from a 200m bore well in a confined aquifer.
+    well_type: str | None = None  # e.g. "Dug Well", "Bore Well", "Piezometer"
+    well_depth_m: float | None = None  # total well depth in metres
+    well_aquifer_type: str | None = (
+        None  # e.g. "Unconfined", "Confined", "Semi Confined"
+    )

--- a/neer-vazhvu-api/app/models/groundwater.py
+++ b/neer-vazhvu-api/app/models/groundwater.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from pydantic import BaseModel
 
 
@@ -10,3 +12,18 @@ class GroundwaterRecord(BaseModel):
     year: int
     month: int
     depth_to_water_m: float | None = None
+
+
+class WrisGroundwaterRecord(BaseModel):
+    """A single CGWB station groundwater reading from India WRIS."""
+
+    station_code: str
+    station_name: str
+    latitude: float | None = None
+    longitude: float | None = None
+    reading_date: date
+    depth_to_water_m: float
+    acquisition_mode: str = "Manual"  # "Manual" or "Telemetric"
+    agency: str = "CGWB"
+    state: str = "Tamil Nadu"
+    district: str = "Chennai"

--- a/neer-vazhvu-api/app/routers/pipeline.py
+++ b/neer-vazhvu-api/app/routers/pipeline.py
@@ -66,6 +66,23 @@ async def run_intelligence(authorization: str | None = Header(default=None)):
     return {"success": True, "steps": results}
 
 
+@router.post("/run-wris-fetch")
+async def run_wris_fetch_endpoint(
+    authorization: str | None = Header(default=None),
+):
+    """Fetch CGWB station-level groundwater from India WRIS API.
+
+    Fetches manual (seasonal) + telemetric (DWLR) readings for Chennai.
+    Can be run on-demand or weekly.
+    """
+    verify_cron_auth(authorization)
+
+    from app.etl.pipeline import run_wris_fetch
+
+    results = await run_wris_fetch()
+    return {"success": True, "steps": results}
+
+
 @router.post("/run-census-fetch")
 async def run_census_fetch(authorization: str | None = Header(default=None)):
     """One-time/periodic fetch of water bodies census from data.gov.in.

--- a/neer-vazhvu-api/app/scrapers/wris.py
+++ b/neer-vazhvu-api/app/scrapers/wris.py
@@ -1,0 +1,148 @@
+"""
+India WRIS (Water Resources Information System) Client.
+
+Fetches station-level groundwater depth data from the India WRIS public API.
+Covers both manual (seasonal, ~16 stations) and telemetric/DWLR (near-daily,
+~6 stations) readings for Chennai district.
+
+API docs: https://indiawris.gov.in/swagger-ui/index.html
+"""
+
+import logging
+from datetime import date, datetime
+
+import httpx
+
+from app.models.groundwater import WrisGroundwaterRecord
+
+logger = logging.getLogger(__name__)
+
+WRIS_API_BASE = "https://indiawris.gov.in/Dataset/Ground%20Water%20Level"
+PAGE_SIZE = 1000
+MAX_PAGES = 50  # safety cap
+
+
+async def fetch_wris_groundwater(
+    start_date: date,
+    end_date: date,
+    state: str = "Tamil Nadu",
+    district: str = "Chennai",
+    agency: str = "CGWB",
+) -> list[WrisGroundwaterRecord]:
+    """
+    Fetch groundwater level readings from India WRIS API.
+
+    Returns both manual (seasonal) and telemetric (DWLR) readings.
+    For telemetric stations with multiple readings per day, we keep the
+    daily average to reduce noise and storage.
+    """
+    all_records: list[dict] = []
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        for page in range(MAX_PAGES):
+            url = (
+                f"{WRIS_API_BASE}"
+                f"?stateName={state}"
+                f"&districtName={district}"
+                f"&agencyName={agency}"
+                f"&startdate={start_date.isoformat()}"
+                f"&enddate={end_date.isoformat()}"
+                f"&download=false"
+                f"&page={page}"
+                f"&size={PAGE_SIZE}"
+            )
+            response = await client.post(url, headers={"Accept": "application/json"})
+            response.raise_for_status()
+
+            data = response.json()
+            if data.get("statusCode") != 200:
+                raise ValueError(f"WRIS API error: {data.get('message')}")
+
+            records = data.get("data", [])
+            if not records:
+                break
+
+            all_records.extend(records)
+            logger.info(
+                "WRIS page %d: %d records (cumulative: %d)",
+                page,
+                len(records),
+                len(all_records),
+            )
+
+            if len(records) < PAGE_SIZE:
+                break
+
+    logger.info("WRIS total raw records: %d", len(all_records))
+
+    # Deduplicate: for telemetric stations with multiple readings per day,
+    # keep the daily average
+    return _deduplicate_daily(all_records)
+
+
+def _deduplicate_daily(raw: list[dict]) -> list[WrisGroundwaterRecord]:
+    """
+    Group by (station_code, date) and average the values.
+    Filters out obvious outliers (e.g. positive values > 50m which are sensor errors).
+    """
+    from collections import defaultdict
+
+    # Group: (station_code, date_str) -> list of values + metadata
+    groups: dict[tuple[str, str], dict] = defaultdict(
+        lambda: {"values": [], "meta": None}
+    )
+
+    for r in raw:
+        station_code = r.get("stationCode", "")
+        data_time = r.get("dataTime", "")
+        value = r.get("dataValue")
+
+        if not station_code or not data_time or value is None:
+            continue
+
+        # Filter obvious sensor errors
+        if abs(value) > 50:
+            continue
+
+        date_str = data_time[:10]  # YYYY-MM-DD
+        key = (station_code, date_str)
+        groups[key]["values"].append(value)
+
+        if groups[key]["meta"] is None:
+            groups[key]["meta"] = r
+
+    results: list[WrisGroundwaterRecord] = []
+    for (station_code, date_str), group in groups.items():
+        meta = group["meta"]
+        values = group["values"]
+        if not values or meta is None:
+            continue
+
+        avg_value = sum(values) / len(values)
+
+        try:
+            reading_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+
+        results.append(
+            WrisGroundwaterRecord(
+                station_code=station_code,
+                station_name=meta.get("stationName", ""),
+                latitude=meta.get("latitude"),
+                longitude=meta.get("longitude"),
+                reading_date=reading_date,
+                depth_to_water_m=round(avg_value, 3),
+                acquisition_mode=meta.get("dataAcquisitionMode", "Manual"),
+                agency=meta.get("agencyName", "CGWB"),
+                state=meta.get("state", "Tamil Nadu"),
+                district=meta.get("district", "Chennai"),
+            )
+        )
+
+    logger.info(
+        "WRIS deduplicated: %d daily readings from %d raw records",
+        len(results),
+        len(raw),
+    )
+    return results

--- a/neer-vazhvu-api/app/scrapers/wris.py
+++ b/neer-vazhvu-api/app/scrapers/wris.py
@@ -125,6 +125,12 @@ def _deduplicate_daily(raw: list[dict]) -> list[WrisGroundwaterRecord]:
         except ValueError:
             continue
 
+        well_depth_raw = meta.get("wellDepth")
+        try:
+            well_depth_m = float(well_depth_raw) if well_depth_raw is not None else None
+        except (TypeError, ValueError):
+            well_depth_m = None
+
         results.append(
             WrisGroundwaterRecord(
                 station_code=station_code,
@@ -137,6 +143,9 @@ def _deduplicate_daily(raw: list[dict]) -> list[WrisGroundwaterRecord]:
                 agency=meta.get("agencyName", "CGWB"),
                 state=meta.get("state", "Tamil Nadu"),
                 district=meta.get("district", "Chennai"),
+                well_type=meta.get("wellType"),
+                well_depth_m=well_depth_m,
+                well_aquifer_type=meta.get("wellAquiferType"),
             )
         )
 

--- a/neer-vazhvu-api/scripts/backfill_wris_metadata.py
+++ b/neer-vazhvu-api/scripts/backfill_wris_metadata.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+One-shot WRIS backfill: re-fetch the full Chennai history and upsert so the
+new well_type / well_depth_m / well_aquifer_type columns get populated on
+existing rows.
+
+Usage:
+    cd neer-vazhvu-api
+    python scripts/backfill_wris_metadata.py
+"""
+
+import asyncio
+import os
+import sys
+from datetime import date
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from supabase import create_client  # noqa: E402
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from app.scrapers.wris import fetch_wris_groundwater  # noqa: E402
+
+
+def _get_env(key: str) -> str:
+    value = os.environ.get(key)
+    if not value:
+        print(f"ERROR: {key} environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+async def main() -> int:
+    supabase_url = _get_env("SUPABASE_URL")
+    supabase_key = _get_env("SUPABASE_SERVICE_KEY")
+    supabase = create_client(supabase_url, supabase_key)
+
+    start = date(2024, 1, 1)
+    end = date.today()
+    print(f"Fetching WRIS Chennai records {start} → {end}…", flush=True)
+
+    records = await fetch_wris_groundwater(start_date=start, end_date=end)
+    print(f"  Got {len(records)} deduplicated daily records", flush=True)
+
+    rows = [
+        {
+            "station_code": r.station_code,
+            "station_name": r.station_name,
+            "latitude": r.latitude,
+            "longitude": r.longitude,
+            "reading_date": r.reading_date.isoformat(),
+            "depth_to_water_m": r.depth_to_water_m,
+            "acquisition_mode": r.acquisition_mode,
+            "agency": r.agency,
+            "district": r.district,
+            "well_type": r.well_type,
+            "well_depth_m": r.well_depth_m,
+            "well_aquifer_type": r.well_aquifer_type,
+            "source": "cgwb",
+        }
+        for r in records
+    ]
+
+    batch_size = 200
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        supabase.table("groundwater_wris").upsert(
+            batch, on_conflict="station_code,reading_date"
+        ).execute()
+        print(f"  Upserted {i + len(batch)}/{len(rows)}", flush=True)
+
+    print("Done.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Separator } from "@/components/ui/separator";
+import type { ReactNode } from "react";
 import { useLanguage } from "@/lib/i18n/context";
 
 const LOST_WATER_BODY_SOURCES: {
@@ -24,6 +24,84 @@ const LOST_WATER_BODY_SOURCES: {
   { name: "Muttukadu Backwaters", status: "Partially encroached", source: "CMDA Coastal Regulation Zone / Care Earth Trust" },
   { name: "Chetpet Lake", status: "Severely reduced", source: "GCC / Care Earth Trust / Madras High Court order 2018" },
 ];
+
+/**
+ * Collapsible top-level section using a native <details> element. The About
+ * page carries a lot of methodology; reviewers want to scan parent headers
+ * and expand only what they care about. Native <details> keeps this
+ * accessible by default (keyboard, screen readers, "find in page" still
+ * searches hidden content in modern browsers) and requires no JS state.
+ */
+function Section({
+  id,
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  id?: string;
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      id={id}
+      open={defaultOpen}
+      className="group rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/30 open:shadow-sm"
+    >
+      <summary className="flex items-center justify-between gap-3 cursor-pointer list-none select-none p-4 sm:p-5 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/40 [&::-webkit-details-marker]:hidden">
+        <h2 className="text-lg sm:text-xl font-semibold text-slate-900 dark:text-slate-100">
+          {title}
+        </h2>
+        <svg
+          className="w-5 h-5 text-slate-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </summary>
+      <div className="px-4 sm:px-5 pb-4 sm:pb-5 pt-1 space-y-5">{children}</div>
+    </details>
+  );
+}
+
+/**
+ * A bordered block used to group related content under a parent Section.
+ * Not collapsible - the user opts in by opening the parent Section, then
+ * scans h3 sub-sections inside it.
+ */
+function SubSection({
+  id,
+  title,
+  children,
+}: {
+  id?: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      id={id}
+      className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 sm:p-5 bg-slate-50/50 dark:bg-slate-900/40 space-y-3"
+    >
+      <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+/** Thin uppercase divider used between grouped DataSource lists. */
+function DataSourceGroupHeader({ title }: { title: string }) {
+  return (
+    <h3 className="text-xs font-semibold tracking-wider uppercase text-slate-500 dark:text-slate-400 pt-2 pb-1">
+      {title}
+    </h3>
+  );
+}
 
 function DataSource({
   name,
@@ -60,422 +138,352 @@ export function AboutContent() {
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-2">{t("about.title")}</h1>
-      <p className="text-lg text-slate-600 dark:text-slate-400 mb-8">
+      <p className="text-lg text-slate-600 dark:text-slate-400 mb-6">
         {t("about.intro")}
       </p>
+      <p className="text-xs text-slate-500 dark:text-slate-500 mb-6 italic">
+        {t("about.collapsed_hint")}
+      </p>
 
-      <Separator className="my-8" />
+      <div className="space-y-3">
 
-      <section className="space-y-6">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.days_heading")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.days_intro")}
-        </p>
-        <div className="space-y-3">
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-red-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.pessimistic")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.pessimistic_desc")}</span>
-            </div>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-yellow-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.current_trend")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.current_desc")}</span>
-            </div>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-green-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.seasonal")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.seasonal_desc")}</span>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.assumptions")}</h2>
-        {/* Desktop table */}
-        <div className="overflow-x-auto hidden sm:block">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-slate-500 dark:text-slate-400 border-b">
-                <th className="pb-2 font-medium">{t("about.param")}</th>
-                <th className="pb-2 font-medium">{t("about.default")}</th>
-                <th className="pb-2 font-medium">{t("about.source_col")}</th>
-              </tr>
-            </thead>
-            <tbody className="text-slate-700 dark:text-slate-300">
-              <tr className="border-b border-slate-100 dark:border-slate-800">
-                <td className="py-2">{t("about.row_consumption")}</td>
-                <td className="py-2 font-mono">830 MLD</td>
-                <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.src_cmwssb_report")}</td>
-              </tr>
-              <tr className="border-b border-slate-100 dark:border-slate-800">
-                <td className="py-2">{t("about.row_desalination")}</td>
-                <td className="py-2 font-mono">190 MLD</td>
-                <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.row_desalination_source")}</td>
-              </tr>
-              <tr className="border-b border-slate-100 dark:border-slate-800">
-                <td className="py-2">{t("about.row_groundwater")}</td>
-                <td className="py-2 font-mono">{t("about.not_modeled")}</td>
-                <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.src_conservative")}</td>
-              </tr>
-              <tr className="border-b border-slate-100 dark:border-slate-800">
-                <td className="py-2">{t("about.row_evaporation")}</td>
-                <td className="py-2 font-mono">{t("about.not_modeled")}</td>
-                <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.planned_v2")}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        {/* Mobile cards */}
-        <div className="sm:hidden space-y-3">
-          {[
-            { param: t("about.row_consumption"), value: "830 MLD", source: t("about.src_cmwssb_report") },
-            { param: t("about.row_desalination"), value: "190 MLD", source: t("about.row_desalination_source") },
-            { param: t("about.row_groundwater"), value: t("about.not_modeled"), source: t("about.src_conservative") },
-            { param: t("about.row_evaporation"), value: t("about.not_modeled"), source: t("about.planned_v2") },
-          ].map((row) => (
-            <div key={row.param} className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm">
-              <div className="font-medium text-slate-900 dark:text-slate-100">{row.param}</div>
-              <div className="font-mono text-slate-700 dark:text-slate-300 mt-1">{row.value}</div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{row.source}</div>
-            </div>
-          ))}
-        </div>
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          {t("about.adjust_note")}
-        </p>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section id="data-sources" className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.data_sources")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.data_pipeline")}
-          {" "}{t("about.data_pipeline2")}
-        </p>
-        <div className="space-y-3">
-          <DataSource
-            name="CMWSSB Lake Level Page"
-            url="https://cmwssb.tn.gov.in/lake-level"
-            description={t("about.ds_cmwssb_desc")}
-            frequency={t("about.freq_daily_scraped")}
-          />
-          <DataSource
-            name="Open-Meteo"
-            url="https://open-meteo.com/"
-            description={t("about.ds_open_meteo_desc")}
-            frequency={t("about.freq_daily")}
-          />
-          <DataSource
-            name="NASA POWER (fallback)"
-            url="https://power.larc.nasa.gov/"
-            description={t("about.ds_nasa_desc")}
-            frequency={t("about.freq_daily_lag")}
-          />
-          <DataSource
-            name="OpenCity Chennai (Groundwater)"
-            url="https://data.opencity.in/"
-            description={t("about.ds_opencity_gw_desc")}
-            frequency={t("about.freq_monthly")}
-          />
-          <DataSource
-            name="OpenCity Chennai (Lake Storage)"
-            url="https://data.opencity.in/"
-            description={t("about.ds_opencity_lake_desc")}
-            frequency={t("about.freq_historical")}
-          />
-          <DataSource
-            name="First Census of Water Bodies (data.gov.in)"
-            url="https://data.gov.in/resource/state-wise-data-first-census-water-bodies-tamil-nadu"
-            description={t("about.ds_census_wb_desc")}
-            frequency={t("about.freq_one_time")}
-          />
-          <DataSource
-            name="Kaggle Chennai Water Management"
-            url="https://www.kaggle.com/datasets/sudalairajkumar/chennai-water-management"
-            description={t("about.ds_kaggle_desc")}
-            frequency={t("about.freq_one_time")}
-          />
-          <DataSource
-            name="OpenStreetMap (Overpass API)"
-            url="https://overpass-api.de/"
-            description={t("about.ds_osm_desc")}
-            frequency={t("about.freq_static")}
-          />
-          <DataSource
-            name="NDWI Water Detection (via Sentinel-2)"
-            url="https://en.wikipedia.org/wiki/Normalized_difference_water_index"
-            description={t("about.ds_ndwi_desc")}
-            frequency={t("about.freq_periodic_summary")}
-          />
-          <DataSource
-            name="JRC Global Surface Water (Monthly Recurrence)"
-            url="https://developers.google.com/earth-engine/datasets/catalog/JRC_GSW1_4_MonthlyRecurrence"
-            description={t("about.ds_gee_jrc_desc")}
-            frequency={t("about.freq_historical_monthly")}
-          />
-          <DataSource
-            name="CHIRPS Daily Rainfall"
-            url="https://developers.google.com/earth-engine/datasets/catalog/UCSB-CHG_CHIRPS_DAILY"
-            description={t("about.ds_gee_chirps_desc")}
-            frequency={t("about.freq_daily")}
-          />
-          <DataSource
-            name="Copernicus Sentinel-2 (via Earth Engine)"
-            url="https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED"
-            description={t("about.ds_sentinel2_desc")}
-            frequency={t("about.freq_evidence_refresh")}
-          />
-          <DataSource
-            name="HydroBASINS / MERIT Hydro"
-            url="https://www.hydrosheds.org/products/hydrobasins"
-            description={t("about.ds_gee_catchments_desc")}
-            frequency={t("about.freq_static_fetch")}
-          />
-          <DataSource
-            name="Care Earth Trust / NGT / CMDA: Lost Water Bodies"
-            url="https://www.careearth.org/"
-            description={t("about.ds_careearth_desc")}
-            frequency={t("about.freq_manual")}
-          />
-          <DataSource
-            name="CPCB National Water Monitoring Programme (NWMP)"
-            url="https://cpcb.nic.in/nwmp-data-2024/"
-            description={t("about.ds_cpcb_desc")}
-            frequency={t("about.freq_annual")}
-          />
-          <DataSource
-            name="Nethaji Mariappan et al. (2017): Cooum Sewage Inlets"
-            url="https://neptjournal.com/upload-images/NL-61-47-(45)B-3437.pdf"
-            description={t("about.ds_sewage_inlets_desc")}
-            frequency={t("about.freq_one_time")}
-          />
-          <DataSource
-            name="NGT Southern Bench / TNPCB / CPCB: Industrial Pollution Sources"
-            url="https://www.tnpcb.gov.in/"
-            description={t("about.ds_ngt_desc")}
-            frequency={t("about.freq_manual")}
-          />
-          <DataSource
-            name="OpenCity Chennai (Flood Hazard Data)"
-            url="https://data.opencity.in/"
-            description={t("about.ds_flood_desc")}
-            frequency={t("about.freq_static")}
-          />
-          <DataSource
-            name="GCC Storm Water Drain Survey"
-            url="https://data.opencity.in/dataset/chennai-stormwater-drain-swd-maps"
-            description={t("about.ds_swd_desc")}
-            frequency={t("about.freq_static")}
-          />
-          <DataSource
-            name="CMWSSB Sewerage Network"
-            url="https://data.opencity.in/dataset/chennai-sewerage-collection-system"
-            description={t("about.ds_sewerage_desc")}
-            frequency={t("about.freq_static")}
-          />
-          <DataSource
-            name="IMD Gridded Rainfall (via imdlib)"
-            url="https://imdlib.readthedocs.io/"
-            description={t("about.ds_imd_desc")}
-            frequency={t("about.freq_one_time_gen")}
-          />
-          <DataSource
-            name="India WRIS / CGWB"
-            url="https://indiawris.gov.in/"
-            description={t("about.ds_cgwb_desc")}
-            frequency={t("about.freq_static_fetch")}
-          />
-          <DataSource
-            name="Chennai Rivers Restoration Trust (CRRT)"
-            url="https://www.crrt.tn.gov.in/"
-            description={t("about.ds_crrt_desc")}
-            frequency={t("about.freq_manual")}
-          />
-          <DataSource
-            name="Anthropic Claude API"
-            url="https://docs.anthropic.com/"
-            description={t("about.ds_anthropic_desc")}
-            frequency={t("about.freq_daily_monthly")}
-          />
-        </div>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section id="satellite-context" className="space-y-6">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.gee_heading")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.gee_intro")}
-        </p>
-
-        <div className="space-y-4">
-          <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
-            <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_surface_title")}</h3>
-            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              {t("about.gee_surface_desc")}
+        {/* ──────────────────────────────────────────────────────────────
+            1. Reading this dashboard
+            - Days of Water Left methodology
+            - Default assumptions
+            ────────────────────────────────────────────────────────────── */}
+        <Section title={t("about.group_reading")}>
+          <SubSection title={t("about.days_heading")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.days_intro")}
             </p>
-            <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
-              <li>{t("about.gee_surface_step1")}</li>
-              <li>{t("about.gee_surface_step2")}</li>
-              <li>{t("about.gee_surface_step3")}</li>
-              <li>{t("about.gee_surface_step4")}</li>
-            </ul>
-          </div>
+            <div className="space-y-3">
+              <div className="flex gap-3">
+                <span className="w-2 h-2 rounded-full bg-red-500 mt-2 flex-shrink-0" />
+                <div>
+                  <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.pessimistic")}</span>
+                  <span className="text-slate-600 dark:text-slate-400"> {t("about.pessimistic_desc")}</span>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <span className="w-2 h-2 rounded-full bg-yellow-500 mt-2 flex-shrink-0" />
+                <div>
+                  <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.current_trend")}</span>
+                  <span className="text-slate-600 dark:text-slate-400"> {t("about.current_desc")}</span>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <span className="w-2 h-2 rounded-full bg-green-500 mt-2 flex-shrink-0" />
+                <div>
+                  <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.seasonal")}</span>
+                  <span className="text-slate-600 dark:text-slate-400"> {t("about.seasonal_desc")}</span>
+                </div>
+              </div>
+            </div>
+          </SubSection>
 
-          <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
-            <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_catchment_title")}</h3>
-            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              {t("about.gee_catchment_desc")}
+          <SubSection title={t("about.assumptions")}>
+            {/* Desktop table */}
+            <div className="overflow-x-auto hidden sm:block">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-slate-500 dark:text-slate-400 border-b">
+                    <th className="pb-2 font-medium">{t("about.param")}</th>
+                    <th className="pb-2 font-medium">{t("about.default")}</th>
+                    <th className="pb-2 font-medium">{t("about.source_col")}</th>
+                  </tr>
+                </thead>
+                <tbody className="text-slate-700 dark:text-slate-300">
+                  <tr className="border-b border-slate-100 dark:border-slate-800">
+                    <td className="py-2">{t("about.row_consumption")}</td>
+                    <td className="py-2 font-mono">830 MLD</td>
+                    <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.src_cmwssb_report")}</td>
+                  </tr>
+                  <tr className="border-b border-slate-100 dark:border-slate-800">
+                    <td className="py-2">{t("about.row_desalination")}</td>
+                    <td className="py-2 font-mono">190 MLD</td>
+                    <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.row_desalination_source")}</td>
+                  </tr>
+                  <tr className="border-b border-slate-100 dark:border-slate-800">
+                    <td className="py-2">{t("about.row_groundwater")}</td>
+                    <td className="py-2 font-mono">{t("about.not_modeled")}</td>
+                    <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.src_conservative")}</td>
+                  </tr>
+                  <tr className="border-b border-slate-100 dark:border-slate-800">
+                    <td className="py-2">{t("about.row_evaporation")}</td>
+                    <td className="py-2 font-mono">{t("about.not_modeled")}</td>
+                    <td className="py-2 text-slate-500 dark:text-slate-400">{t("about.planned_v2")}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            {/* Mobile cards */}
+            <div className="sm:hidden space-y-3">
+              {[
+                { param: t("about.row_consumption"), value: "830 MLD", source: t("about.src_cmwssb_report") },
+                { param: t("about.row_desalination"), value: "190 MLD", source: t("about.row_desalination_source") },
+                { param: t("about.row_groundwater"), value: t("about.not_modeled"), source: t("about.src_conservative") },
+                { param: t("about.row_evaporation"), value: t("about.not_modeled"), source: t("about.planned_v2") },
+              ].map((row) => (
+                <div key={row.param} className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm">
+                  <div className="font-medium text-slate-900 dark:text-slate-100">{row.param}</div>
+                  <div className="font-mono text-slate-700 dark:text-slate-300 mt-1">{row.value}</div>
+                  <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{row.source}</div>
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {t("about.adjust_note")}
             </p>
-            <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
-              <li>{t("about.gee_catchment_step1")}</li>
-              <li>{t("about.gee_catchment_step2")}</li>
-              <li>{t("about.gee_catchment_step3")}</li>
-              <li>{t("about.gee_catchment_step4")}</li>
-            </ul>
-          </div>
+          </SubSection>
+        </Section>
 
-          <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
-            <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_evidence_title")}</h3>
-            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              {t("about.gee_evidence_desc")}
+        {/* ──────────────────────────────────────────────────────────────
+            2. What each page shows - one SubSection per map/page
+            ────────────────────────────────────────────────────────────── */}
+        <Section id="pages" title={t("about.group_pages")}>
+          {/* 2.1 Dashboard & reservoirs (includes forecasting + GEE catchment) */}
+          <SubSection id="page-dashboard" title={t("about.page_dashboard_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.forecast_intro")}
             </p>
-            <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
-              <li>{t("about.gee_evidence_step1")}</li>
-              <li>{t("about.gee_evidence_step2")}</li>
-              <li>{t("about.gee_evidence_step3")}</li>
-              <li>{t("about.gee_evidence_step4")}</li>
+            <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200 pt-2">{t("about.technique")}</h4>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.technique_before_link")} <span className="font-mono text-sm bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">AutoARIMA</span> {t("about.technique_after_link")}{" "}
+              <a href="https://nixtla.github.io/statsforecast/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">statsforecast</a>{" "}
+              <span className="font-medium">{t("about.technique_exogenous_term")}</span> {t("about.technique_after_term")}
+            </p>
+            <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-1.5 text-sm">
+              <li>{t("about.tech_bullet_independent")}</li>
+              <li>{t("about.tech_bullet_retrained")}</li>
+              <li>
+                <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_exogenous_label")}</span> {t("about.tech_exogenous_desc")}
+              </li>
+              <li>
+                <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_future_label")}</span> {t("about.tech_future_desc")}
+              </li>
+              <li>
+                <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_fallback_label")}</span> {t("about.tech_fallback_desc")}
+              </li>
+              <li>{t("about.tech_bullet_clamped")}</li>
             </ul>
-          </div>
 
-          <div className="rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/20 p-4">
-            <h3 className="text-base font-semibold text-blue-900 dark:text-blue-100">{t("about.gee_thresholds_title")}</h3>
-            <ul className="list-disc list-inside text-sm text-blue-800 dark:text-blue-200 space-y-2 mt-3">
-              <li>{t("about.gee_thresholds_water")}</li>
-              <li>{t("about.gee_thresholds_rain")}</li>
-              <li>{t("about.gee_thresholds_confidence")}</li>
-              <li>{t("about.gee_thresholds_scope")}</li>
-            </ul>
-          </div>
-        </div>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section className="space-y-6">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.intelligence")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.intelligence_intro")}
-        </p>
-        <div className="space-y-3">
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-orange-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ward_risk_title")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.ward_risk_desc")}</span>
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40 mt-3">
+              <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_catchment_title")}</h4>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                {t("about.gee_catchment_desc")}
+              </p>
+              <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
+                <li>{t("about.gee_catchment_step1")}</li>
+                <li>{t("about.gee_catchment_step2")}</li>
+                <li>{t("about.gee_catchment_step3")}</li>
+                <li>{t("about.gee_catchment_step4")}</li>
+              </ul>
             </div>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-purple-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.daily_briefing_title")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.daily_briefing_desc")}</span>
+          </SubSection>
+
+          {/* 2.2 Groundwater page (choropleth + CGWB stations + ward risk) */}
+          <SubSection id="page-groundwater" title={t("about.page_gw_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.gw_map_desc1")}
+            </p>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.gw_map_desc2")}
+            </p>
+
+            {/* Ward risk composite lives on this page - move the existing blurb
+                here so readers see it alongside the choropleth description. */}
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
+              <div className="flex gap-3">
+                <span className="w-2 h-2 rounded-full bg-orange-500 mt-2 flex-shrink-0" />
+                <div>
+                  <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ward_risk_title")}</span>
+                  <span className="text-slate-600 dark:text-slate-400"> {t("about.ward_risk_desc")}</span>
+                </div>
+              </div>
             </div>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-blue-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ai_narrative_title")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.ai_narrative_desc")}</span>
+
+            {/* CGWB live station overlay + sensor QA explainer. Reviewers keep
+                asking why some markers look different - document it so they
+                can find it next to the groundwater page explainer. */}
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40 space-y-4">
+              <div>
+                <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+                  {t("about.gw_cgwb_stations_title")}
+                </h4>
+                <p className="text-sm text-slate-600 dark:text-slate-400 mt-2">
+                  {t("about.gw_cgwb_stations_intro")}
+                </p>
+              </div>
+
+              <div>
+                <h5 className="text-xs font-semibold text-slate-800 dark:text-slate-200 uppercase tracking-wide">
+                  {t("about.gw_cgwb_modes_title")}
+                </h5>
+                <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-2">
+                  <li>{t("about.gw_cgwb_modes_manual")}</li>
+                  <li>{t("about.gw_cgwb_modes_telem")}</li>
+                  <li>{t("about.gw_cgwb_modes_meta")}</li>
+                </ul>
+              </div>
+
+              <div>
+                <h5 className="text-xs font-semibold text-slate-800 dark:text-slate-200 uppercase tracking-wide">
+                  {t("about.gw_cgwb_quality_title")}
+                </h5>
+                <p className="text-sm text-slate-600 dark:text-slate-400 mt-2">
+                  {t("about.gw_cgwb_quality_intro")}
+                </p>
+                <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-2">
+                  <li>
+                    <span className="font-mono text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 px-1.5 py-0.5 rounded">stuck</span>{" "}
+                    {t("about.gw_cgwb_quality_stuck")}
+                  </li>
+                  <li>
+                    <span className="font-mono text-xs bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 px-1.5 py-0.5 rounded">stale</span>{" "}
+                    {t("about.gw_cgwb_quality_stale")}
+                  </li>
+                  <li>
+                    <span className="font-mono text-xs bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 px-1.5 py-0.5 rounded">ok</span>{" "}
+                    {t("about.gw_cgwb_quality_ok")}
+                  </li>
+                </ul>
+                <p className="text-sm text-slate-600 dark:text-slate-400 mt-3">
+                  {t("about.gw_cgwb_quality_ui")}
+                </p>
+              </div>
             </div>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-indigo-500 mt-2 flex-shrink-0" />
-            <div>
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ward_profile_title")}</span>
-              <span className="text-slate-600 dark:text-slate-400"> {t("about.ward_profile_desc")}</span>
+          </SubSection>
+
+          {/* 2.3 Water bodies & restoration (includes GEE NDWI + lost WBs + restoration priority) */}
+          <SubSection id="page-water-bodies" title={t("about.page_wb_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.wb_map_desc")}
+            </p>
+
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
+              <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_surface_title")}</h4>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                {t("about.gee_surface_desc")}
+              </p>
+              <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
+                <li>{t("about.gee_surface_step1")}</li>
+                <li>{t("about.gee_surface_step2")}</li>
+                <li>{t("about.gee_surface_step3")}</li>
+                <li>{t("about.gee_surface_step4")}</li>
+              </ul>
             </div>
-          </div>
-        </div>
-      </section>
 
-      <Separator className="my-8" />
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40">
+              <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{t("about.gee_evidence_title")}</h4>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                {t("about.gee_evidence_desc")}
+              </p>
+              <ul className="list-disc list-inside text-sm text-slate-600 dark:text-slate-400 space-y-2 mt-3">
+                <li>{t("about.gee_evidence_step1")}</li>
+                <li>{t("about.gee_evidence_step2")}</li>
+                <li>{t("about.gee_evidence_step3")}</li>
+                <li>{t("about.gee_evidence_step4")}</li>
+              </ul>
+            </div>
 
-      <section className="space-y-6">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.forecasting")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.forecast_intro")}
-        </p>
+            <div className="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/20 p-4">
+              <h4 className="text-sm font-semibold text-blue-900 dark:text-blue-100">{t("about.gee_thresholds_title")}</h4>
+              <ul className="list-disc list-inside text-sm text-blue-800 dark:text-blue-200 space-y-2 mt-3">
+                <li>{t("about.gee_thresholds_water")}</li>
+                <li>{t("about.gee_thresholds_rain")}</li>
+                <li>{t("about.gee_thresholds_confidence")}</li>
+                <li>{t("about.gee_thresholds_scope")}</li>
+              </ul>
+            </div>
 
-        <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{t("about.technique")}</h3>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.technique_before_link")} <span className="font-mono text-sm bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded">AutoARIMA</span> {t("about.technique_after_link")}{" "}
-          <a href="https://nixtla.github.io/statsforecast/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">statsforecast</a>{" "}
-          <span className="font-medium">{t("about.technique_exogenous_term")}</span> {t("about.technique_after_term")}
-        </p>
-        <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-1.5 text-sm">
-          <li>{t("about.tech_bullet_independent")}</li>
-          <li>{t("about.tech_bullet_retrained")}</li>
-          <li>
-            <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_exogenous_label")}</span> {t("about.tech_exogenous_desc")}
-          </li>
-          <li>
-            <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_future_label")}</span> {t("about.tech_future_desc")}
-          </li>
-          <li>
-            <span className="font-medium text-slate-700 dark:text-slate-300">{t("about.tech_fallback_label")}</span> {t("about.tech_fallback_desc")}
-          </li>
-          <li>{t("about.tech_bullet_clamped")}</li>
-        </ul>
-      </section>
+            {/* Restoration priority scoring */}
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-900/40 space-y-3">
+              <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration")}</h4>
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                {t("about.restoration_desc")}
+              </p>
+              <div className="space-y-2">
+                <div className="flex gap-3">
+                  <span className="w-2 h-2 rounded-full bg-red-500 mt-2 flex-shrink-0" />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_size")}</span>
+                  </p>
+                </div>
+                <div className="flex gap-3">
+                  <span className="w-2 h-2 rounded-full bg-orange-500 mt-2 flex-shrink-0" />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_lost")}</span>
+                  </p>
+                </div>
+                <div className="flex gap-3">
+                  <span className="w-2 h-2 rounded-full bg-yellow-500 mt-2 flex-shrink-0" />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_river")}</span>
+                  </p>
+                </div>
+                <div className="flex gap-3">
+                  <span className="w-2 h-2 rounded-full bg-purple-500 mt-2 flex-shrink-0" />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_industrial")}</span>
+                  </p>
+                </div>
+                <div className="flex gap-3">
+                  <span className="w-2 h-2 rounded-full bg-green-500 mt-2 flex-shrink-0" />
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_type")}</span>
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-slate-500 dark:text-slate-400 italic">
+                {t("about.restoration_note")}
+              </p>
+            </div>
 
-      <Separator className="my-8" />
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.gw_map")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.gw_map_desc1")}
-        </p>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.gw_map_desc2")}
-        </p>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.wb_map")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.wb_map_desc")}
-        </p>
-
-        <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">{t("about.wb_lost_heading")}</h3>
-        {/* Desktop table */}
-        <div className="overflow-x-auto hidden sm:block">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-slate-500 dark:text-slate-400 border-b">
-                <th className="pb-2 font-medium">{t("about.wb_col_name")}</th>
-                <th className="pb-2 font-medium">{t("about.wb_col_status")}</th>
-                <th className="pb-2 font-medium">{t("about.wb_col_source_ref")}</th>
-              </tr>
-            </thead>
-            <tbody className="text-slate-700 dark:text-slate-300">
+            {/* Lost water bodies table */}
+            <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200 pt-2">{t("about.wb_lost_heading")}</h4>
+            {/* Desktop table */}
+            <div className="overflow-x-auto hidden sm:block">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-slate-500 dark:text-slate-400 border-b">
+                    <th className="pb-2 font-medium">{t("about.wb_col_name")}</th>
+                    <th className="pb-2 font-medium">{t("about.wb_col_status")}</th>
+                    <th className="pb-2 font-medium">{t("about.wb_col_source_ref")}</th>
+                  </tr>
+                </thead>
+                <tbody className="text-slate-700 dark:text-slate-300">
+                  {LOST_WATER_BODY_SOURCES.map((row) => (
+                    <tr key={row.name} className="border-b border-slate-100 dark:border-slate-800">
+                      <td className="py-2 font-medium">{row.name}</td>
+                      <td className="py-2">
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
+                          row.status === "Fully lost"
+                            ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+                            : row.status === "Severely reduced"
+                            ? "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300"
+                            : "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300"
+                        }`}>
+                          {row.status === "Fully lost"
+                            ? t("about.fully_lost")
+                            : row.status === "Severely reduced"
+                            ? t("about.severely_reduced")
+                            : t("about.partially_encroached")}
+                        </span>
+                      </td>
+                      <td className="py-2 text-slate-500 dark:text-slate-400">{row.source}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {/* Mobile cards */}
+            <div className="sm:hidden space-y-3">
               {LOST_WATER_BODY_SOURCES.map((row) => (
-                <tr key={row.name} className="border-b border-slate-100 dark:border-slate-800">
-                  <td className="py-2 font-medium">{row.name}</td>
-                  <td className="py-2">
-                    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
+                <div key={row.name} className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-medium text-slate-900 dark:text-slate-100">{row.name}</span>
+                    <span className={`shrink-0 inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
                       row.status === "Fully lost"
                         ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
                         : row.status === "Severely reduced"
@@ -488,198 +496,352 @@ export function AboutContent() {
                         ? t("about.severely_reduced")
                         : t("about.partially_encroached")}
                     </span>
-                  </td>
-                  <td className="py-2 text-slate-500 dark:text-slate-400">{row.source}</td>
-                </tr>
+                  </div>
+                  <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{row.source}</div>
+                </div>
               ))}
-            </tbody>
-          </table>
-        </div>
-        {/* Mobile cards */}
-        <div className="sm:hidden space-y-3">
-          {LOST_WATER_BODY_SOURCES.map((row) => (
-            <div key={row.name} className="border border-slate-200 dark:border-slate-700 rounded-lg p-3 text-sm">
-              <div className="flex items-start justify-between gap-2">
-                <span className="font-medium text-slate-900 dark:text-slate-100">{row.name}</span>
-                <span className={`shrink-0 inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
-                  row.status === "Fully lost"
-                    ? "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
-                    : row.status === "Severely reduced"
-                    ? "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300"
-                    : "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300"
-                }`}>
-                  {row.status === "Fully lost"
-                    ? t("about.fully_lost")
-                    : row.status === "Severely reduced"
-                    ? t("about.severely_reduced")
-                    : t("about.partially_encroached")}
-                </span>
-              </div>
-              <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{row.source}</div>
             </div>
-          ))}
-        </div>
-      </section>
+          </SubSection>
 
-      <Separator className="my-8" />
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.river_map")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.river_map_desc")}
-        </p>
-      </section>
-
-      <Separator className="my-8" />
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.restoration")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.restoration_desc")}
-        </p>
-        <div className="space-y-3">
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-red-500 mt-2 flex-shrink-0" />
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_size")}</span>
+          {/* 2.4 Rivers */}
+          <SubSection id="page-rivers" title={t("about.page_rivers_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.river_map_desc")}
             </p>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-orange-500 mt-2 flex-shrink-0" />
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_lost")}</span>
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-yellow-500 mt-2 flex-shrink-0" />
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_river")}</span>
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-purple-500 mt-2 flex-shrink-0" />
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_industrial")}</span>
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <span className="w-2 h-2 rounded-full bg-green-500 mt-2 flex-shrink-0" />
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.restoration_comp_type")}</span>
-            </p>
-          </div>
-        </div>
-        <p className="text-sm text-slate-500 dark:text-slate-400 italic">
-          {t("about.restoration_note")}
-        </p>
-      </section>
+          </SubSection>
 
-      <Separator className="my-8" />
+          {/* 2.5 Flood */}
+          <SubSection id="page-flood" title={t("about.page_flood_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.page_flood_desc")}
+            </p>
+          </SubSection>
 
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.disclaimer")}</h2>
-        <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-lg p-4 space-y-3 text-sm text-slate-600 dark:text-slate-400">
-          <p>
-            <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_gov_title")}</span>{" "}
-            {t("about.disclaimer_gov_desc")}
+          {/* 2.6 My Ward */}
+          <SubSection id="page-my-ward" title={t("about.page_my_ward_title")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.page_my_ward_desc")}
+            </p>
+          </SubSection>
+        </Section>
+
+        {/* ──────────────────────────────────────────────────────────────
+            3. Intelligence & AI narratives
+            (daily briefing, AI narrative, ward profile - ward risk lives
+             with the Groundwater page because that's where it's rendered)
+            ────────────────────────────────────────────────────────────── */}
+        <Section id="intelligence" title={t("about.intelligence")}>
+          <p className="text-slate-600 dark:text-slate-400">
+            {t("about.intelligence_intro")}
           </p>
-          <p>
-            <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_info_title")}</span>{" "}
-            {t("about.disclaimer_info_desc")}
+          <div className="space-y-3">
+            <div className="flex gap-3">
+              <span className="w-2 h-2 rounded-full bg-purple-500 mt-2 flex-shrink-0" />
+              <div>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.daily_briefing_title")}</span>
+                <span className="text-slate-600 dark:text-slate-400"> {t("about.daily_briefing_desc")}</span>
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <span className="w-2 h-2 rounded-full bg-blue-500 mt-2 flex-shrink-0" />
+              <div>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ai_narrative_title")}</span>
+                <span className="text-slate-600 dark:text-slate-400"> {t("about.ai_narrative_desc")}</span>
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <span className="w-2 h-2 rounded-full bg-indigo-500 mt-2 flex-shrink-0" />
+              <div>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.ward_profile_title")}</span>
+                <span className="text-slate-600 dark:text-slate-400"> {t("about.ward_profile_desc")}</span>
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* ──────────────────────────────────────────────────────────────
+            4. Data Source Index - grouped by data domain
+            ────────────────────────────────────────────────────────────── */}
+        <Section id="data-sources" title={t("about.data_sources")}>
+          <p className="text-slate-600 dark:text-slate-400">
+            {t("about.data_pipeline")}
+            {" "}{t("about.data_pipeline2")}
           </p>
-          <p>
-            <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_privacy_title")}</span>{" "}
-            {t("about.disclaimer_privacy_desc")}
-          </p>
-        </div>
-      </section>
+          <div className="space-y-3">
+            <DataSourceGroupHeader title={t("about.ds_group_reservoir")} />
+            <DataSource
+              name="CMWSSB Lake Level Page"
+              url="https://cmwssb.tn.gov.in/lake-level"
+              description={t("about.ds_cmwssb_desc")}
+              frequency={t("about.freq_daily_scraped")}
+            />
+            <DataSource
+              name="Open-Meteo"
+              url="https://open-meteo.com/"
+              description={t("about.ds_open_meteo_desc")}
+              frequency={t("about.freq_daily")}
+            />
+            <DataSource
+              name="NASA POWER (fallback)"
+              url="https://power.larc.nasa.gov/"
+              description={t("about.ds_nasa_desc")}
+              frequency={t("about.freq_daily_lag")}
+            />
+            <DataSource
+              name="OpenCity Chennai (Lake Storage)"
+              url="https://data.opencity.in/"
+              description={t("about.ds_opencity_lake_desc")}
+              frequency={t("about.freq_historical")}
+            />
+            <DataSource
+              name="IMD Gridded Rainfall (via imdlib)"
+              url="https://imdlib.readthedocs.io/"
+              description={t("about.ds_imd_desc")}
+              frequency={t("about.freq_one_time_gen")}
+            />
 
-      <Separator className="my-8" />
+            <DataSourceGroupHeader title={t("about.ds_group_gw")} />
+            <DataSource
+              name="India WRIS Ground Water Level API (CGWB Stations)"
+              url="https://indiawris.gov.in/Dataset/Ground%20Water%20Level"
+              description={t("about.ds_wris_stations_desc")}
+              frequency={t("about.freq_daily")}
+            />
+            <DataSource
+              name="India WRIS / CGWB (Block Exploitation)"
+              url="https://indiawris.gov.in/"
+              description={t("about.ds_cgwb_desc")}
+              frequency={t("about.freq_static_fetch")}
+            />
+            <DataSource
+              name="OpenCity Chennai (Groundwater)"
+              url="https://data.opencity.in/"
+              description={t("about.ds_opencity_gw_desc")}
+              frequency={t("about.freq_monthly")}
+            />
 
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.limitations")}</h2>
-        <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2 text-sm">
-          <li>{t("about.limit1")}</li>
-          <li>{t("about.limit2")}</li>
-          <li>{t("about.limit3")}</li>
-          <li>{t("about.limit4")}</li>
-          <li>{t("about.limit5")}</li>
-          <li>{t("about.limit6")}</li>
-          <li>{t("about.limit7")}</li>
-          <li>{t("about.limit8")}</li>
-        </ul>
-      </section>
+            <DataSourceGroupHeader title={t("about.ds_group_wb")} />
+            <DataSource
+              name="First Census of Water Bodies (data.gov.in)"
+              url="https://data.gov.in/resource/state-wise-data-first-census-water-bodies-tamil-nadu"
+              description={t("about.ds_census_wb_desc")}
+              frequency={t("about.freq_one_time")}
+            />
+            <DataSource
+              name="Kaggle Chennai Water Management"
+              url="https://www.kaggle.com/datasets/sudalairajkumar/chennai-water-management"
+              description={t("about.ds_kaggle_desc")}
+              frequency={t("about.freq_one_time")}
+            />
+            <DataSource
+              name="Care Earth Trust / NGT / CMDA: Lost Water Bodies"
+              url="https://www.careearth.org/"
+              description={t("about.ds_careearth_desc")}
+              frequency={t("about.freq_manual")}
+            />
 
-      <Separator className="my-8" />
+            <DataSourceGroupHeader title={t("about.ds_group_rivers")} />
+            <DataSource
+              name="Chennai Rivers Restoration Trust (CRRT)"
+              url="https://www.crrt.tn.gov.in/"
+              description={t("about.ds_crrt_desc")}
+              frequency={t("about.freq_manual")}
+            />
+            <DataSource
+              name="CPCB National Water Monitoring Programme (NWMP)"
+              url="https://cpcb.nic.in/nwmp-data-2024/"
+              description={t("about.ds_cpcb_desc")}
+              frequency={t("about.freq_annual")}
+            />
+            <DataSource
+              name="Nethaji Mariappan et al. (2017): Cooum Sewage Inlets"
+              url="https://neptjournal.com/upload-images/NL-61-47-(45)B-3437.pdf"
+              description={t("about.ds_sewage_inlets_desc")}
+              frequency={t("about.freq_one_time")}
+            />
+            <DataSource
+              name="NGT Southern Bench / TNPCB / CPCB: Industrial Pollution Sources"
+              url="https://www.tnpcb.gov.in/"
+              description={t("about.ds_ngt_desc")}
+              frequency={t("about.freq_manual")}
+            />
 
-      <section id="data-quality" className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.data_quality")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.dq_intro")}
-        </p>
-        <div className="space-y-3">
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
-            <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1">
-              {t("about.dq_census_units_title")}
-            </h4>
-            <p className="text-sm text-amber-700 dark:text-amber-300">
-              {t("about.dq_census_units_desc")}
-            </p>
+            <DataSourceGroupHeader title={t("about.ds_group_flood")} />
+            <DataSource
+              name="OpenCity Chennai (Flood Hazard Data)"
+              url="https://data.opencity.in/"
+              description={t("about.ds_flood_desc")}
+              frequency={t("about.freq_static")}
+            />
+            <DataSource
+              name="GCC Storm Water Drain Survey"
+              url="https://data.opencity.in/dataset/chennai-stormwater-drain-swd-maps"
+              description={t("about.ds_swd_desc")}
+              frequency={t("about.freq_static")}
+            />
+            <DataSource
+              name="CMWSSB Sewerage Network"
+              url="https://data.opencity.in/dataset/chennai-sewerage-collection-system"
+              description={t("about.ds_sewerage_desc")}
+              frequency={t("about.freq_static")}
+            />
+
+            <DataSourceGroupHeader title={t("about.ds_group_satellite")} />
+            <DataSource
+              name="NDWI Water Detection (via Sentinel-2)"
+              url="https://en.wikipedia.org/wiki/Normalized_difference_water_index"
+              description={t("about.ds_ndwi_desc")}
+              frequency={t("about.freq_periodic_summary")}
+            />
+            <DataSource
+              name="JRC Global Surface Water (Monthly Recurrence)"
+              url="https://developers.google.com/earth-engine/datasets/catalog/JRC_GSW1_4_MonthlyRecurrence"
+              description={t("about.ds_gee_jrc_desc")}
+              frequency={t("about.freq_historical_monthly")}
+            />
+            <DataSource
+              name="CHIRPS Daily Rainfall"
+              url="https://developers.google.com/earth-engine/datasets/catalog/UCSB-CHG_CHIRPS_DAILY"
+              description={t("about.ds_gee_chirps_desc")}
+              frequency={t("about.freq_daily")}
+            />
+            <DataSource
+              name="Copernicus Sentinel-2 (via Earth Engine)"
+              url="https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED"
+              description={t("about.ds_sentinel2_desc")}
+              frequency={t("about.freq_evidence_refresh")}
+            />
+            <DataSource
+              name="HydroBASINS / MERIT Hydro"
+              url="https://www.hydrosheds.org/products/hydrobasins"
+              description={t("about.ds_gee_catchments_desc")}
+              frequency={t("about.freq_static_fetch")}
+            />
+
+            <DataSourceGroupHeader title={t("about.ds_group_base")} />
+            <DataSource
+              name="OpenStreetMap (Overpass API)"
+              url="https://overpass-api.de/"
+              description={t("about.ds_osm_desc")}
+              frequency={t("about.freq_static")}
+            />
+
+            <DataSourceGroupHeader title={t("about.ds_group_ai")} />
+            <DataSource
+              name="Anthropic Claude API"
+              url="https://docs.anthropic.com/"
+              description={t("about.ds_anthropic_desc")}
+              frequency={t("about.freq_daily_monthly")}
+            />
           </div>
-          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
-            <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1">
-              {t("about.dq_census_capacity_title")}
-            </h4>
-            <p className="text-sm text-amber-700 dark:text-amber-300">
-              {t("about.dq_census_capacity_desc")}
-            </p>
-          </div>
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-            <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
-              {t("about.dq_census_shape_title")}
-            </h4>
-            <p className="text-sm text-blue-700 dark:text-blue-300">
-              {t("about.dq_census_shape_desc")}
-            </p>
-          </div>
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-            <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
-              {t("about.dq_satellite_baseline_title")}
-            </h4>
-            <p className="text-sm text-blue-700 dark:text-blue-300">
-              {t("about.dq_satellite_baseline_desc")}
-            </p>
-          </div>
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-            <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
-              {t("about.dq_catchment_geometry_title")}
-            </h4>
-            <p className="text-sm text-blue-700 dark:text-blue-300">
-              {t("about.dq_catchment_geometry_desc")}
-            </p>
-          </div>
-        </div>
-      </section>
+        </Section>
 
-      <Separator className="my-8" />
+        {/* ──────────────────────────────────────────────────────────────
+            5. Data quality & limitations - merged section
+            ────────────────────────────────────────────────────────────── */}
+        <Section id="data-quality" title={t("about.group_quality")}>
+          <SubSection title={t("about.data_quality")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.dq_intro")}
+            </p>
+            <div className="space-y-3">
+              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+                <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1">
+                  {t("about.dq_census_units_title")}
+                </h4>
+                <p className="text-sm text-amber-700 dark:text-amber-300">
+                  {t("about.dq_census_units_desc")}
+                </p>
+              </div>
+              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+                <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-1">
+                  {t("about.dq_census_capacity_title")}
+                </h4>
+                <p className="text-sm text-amber-700 dark:text-amber-300">
+                  {t("about.dq_census_capacity_desc")}
+                </p>
+              </div>
+              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+                <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
+                  {t("about.dq_census_shape_title")}
+                </h4>
+                <p className="text-sm text-blue-700 dark:text-blue-300">
+                  {t("about.dq_census_shape_desc")}
+                </p>
+              </div>
+              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+                <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
+                  {t("about.dq_satellite_baseline_title")}
+                </h4>
+                <p className="text-sm text-blue-700 dark:text-blue-300">
+                  {t("about.dq_satellite_baseline_desc")}
+                </p>
+              </div>
+              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+                <h4 className="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-1">
+                  {t("about.dq_catchment_geometry_title")}
+                </h4>
+                <p className="text-sm text-blue-700 dark:text-blue-300">
+                  {t("about.dq_catchment_geometry_desc")}
+                </p>
+              </div>
+            </div>
+          </SubSection>
 
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("about.open_source")}</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          {t("about.open_source_desc")}
-        </p>
-        <a
-          href="https://github.com/SundareshPrasanna/neer-vazhvu"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 rounded-lg text-sm font-medium hover:bg-slate-800 dark:hover:bg-slate-200 transition-colors"
-        >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
-          </svg>
-          {t("about.view_github")}
-        </a>
-      </section>
+          <SubSection title={t("about.limitations")}>
+            <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2 text-sm">
+              <li>{t("about.limit1")}</li>
+              <li>{t("about.limit2")}</li>
+              <li>{t("about.limit3")}</li>
+              <li>{t("about.limit4")}</li>
+              <li>{t("about.limit5")}</li>
+              <li>{t("about.limit6")}</li>
+              <li>{t("about.limit7")}</li>
+              <li>{t("about.limit8")}</li>
+            </ul>
+          </SubSection>
+        </Section>
+
+        {/* ──────────────────────────────────────────────────────────────
+            6. About the project - disclaimer + open source
+            ────────────────────────────────────────────────────────────── */}
+        <Section id="about-project" title={t("about.group_project")}>
+          <SubSection title={t("about.disclaimer")}>
+            <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-lg p-4 space-y-3 text-sm text-slate-600 dark:text-slate-400">
+              <p>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_gov_title")}</span>{" "}
+                {t("about.disclaimer_gov_desc")}
+              </p>
+              <p>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_info_title")}</span>{" "}
+                {t("about.disclaimer_info_desc")}
+              </p>
+              <p>
+                <span className="font-semibold text-slate-800 dark:text-slate-200">{t("about.disclaimer_privacy_title")}</span>{" "}
+                {t("about.disclaimer_privacy_desc")}
+              </p>
+            </div>
+          </SubSection>
+
+          <SubSection title={t("about.open_source")}>
+            <p className="text-slate-600 dark:text-slate-400">
+              {t("about.open_source_desc")}
+            </p>
+            <a
+              href="https://github.com/SundareshPrasanna/neer-vazhvu"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 rounded-lg text-sm font-medium hover:bg-slate-800 dark:hover:bg-slate-200 transition-colors"
+            >
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+              </svg>
+              {t("about.view_github")}
+            </a>
+          </SubSection>
+        </Section>
+
+      </div>
     </div>
   );
 }

--- a/src/app/api/groundwater/stations/route.ts
+++ b/src/app/api/groundwater/stations/route.ts
@@ -39,10 +39,13 @@ export async function GET(request: NextRequest) {
   const cutoff = cutoffDate.toISOString().slice(0, 10);
 
   if (stationCode) {
-    // Return time series for a specific station
+    // Return time series for a specific station, along with the latest-view
+    // metadata (well_type, quality flag, etc.) so the panel can display it.
     let query = supabase
       .from("groundwater_wris")
-      .select("station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode")
+      .select(
+        "station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode, well_type, well_depth_m, well_aquifer_type",
+      )
       .eq("station_code", stationCode)
       .gte("reading_date", cutoff)
       .order("reading_date", { ascending: true })
@@ -52,27 +55,51 @@ export async function GET(request: NextRequest) {
       query = query.eq("acquisition_mode", modeFilter);
     }
 
-    const { data, error } = await query;
+    const [timeseriesRes, latestRes] = await Promise.all([
+      query,
+      supabase
+        .from("groundwater_wris_latest")
+        .select(
+          "station_code, station_name, latitude, longitude, acquisition_mode, well_type, well_depth_m, well_aquifer_type, recent_count, recent_range_m, data_quality_flag",
+        )
+        .eq("station_code", stationCode)
+        .maybeSingle(),
+    ]);
 
-    if (error) {
-      logRouteError("/api/groundwater/stations", error);
+    if (timeseriesRes.error) {
+      logRouteError("/api/groundwater/stations", timeseriesRes.error);
+      return internalServerError();
+    }
+    if (latestRes.error) {
+      logRouteError("/api/groundwater/stations", latestRes.error);
       return internalServerError();
     }
 
-    if (!data || data.length === 0) {
+    const data = timeseriesRes.data;
+    const latest = latestRes.data;
+
+    if ((!data || data.length === 0) && !latest) {
       return NextResponse.json({ station: null, readings: [] });
     }
 
-    const first = data[0];
+    const meta = latest ?? data?.[0];
     return NextResponse.json({
-      station: {
-        stationCode: first.station_code,
-        stationName: first.station_name,
-        latitude: first.latitude,
-        longitude: first.longitude,
-        acquisitionMode: first.acquisition_mode,
-      },
-      readings: data.map((r) => ({
+      station: meta
+        ? {
+            stationCode: meta.station_code,
+            stationName: meta.station_name,
+            latitude: meta.latitude,
+            longitude: meta.longitude,
+            acquisitionMode: meta.acquisition_mode,
+            wellType: normalizeMetaString(meta.well_type),
+            wellDepthM: meta.well_depth_m as number | null,
+            wellAquiferType: normalizeMetaString(meta.well_aquifer_type),
+            recentCount: latest?.recent_count ?? null,
+            recentRangeM: latest?.recent_range_m ?? null,
+            dataQualityFlag: (latest?.data_quality_flag as string | undefined) ?? null,
+          }
+        : null,
+      readings: (data ?? []).map((r) => ({
         date: r.reading_date,
         depthM: r.depth_to_water_m,
       })),
@@ -82,7 +109,9 @@ export async function GET(request: NextRequest) {
   // No station specified: return latest reading per station from the view
   let listQuery = supabase
     .from("groundwater_wris_latest")
-    .select("station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode");
+    .select(
+      "station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode, well_type, well_depth_m, well_aquifer_type, recent_count, recent_range_m, data_quality_flag",
+    );
 
   if (modeFilter) {
     listQuery = listQuery.eq("acquisition_mode", modeFilter);
@@ -104,6 +133,12 @@ export async function GET(request: NextRequest) {
       latestDate: r.reading_date as string,
       latestDepthM: r.depth_to_water_m as number,
       acquisitionMode: r.acquisition_mode as string,
+      wellType: normalizeMetaString(r.well_type),
+      wellDepthM: r.well_depth_m as number | null,
+      wellAquiferType: normalizeMetaString(r.well_aquifer_type),
+      recentCount: r.recent_count as number | null,
+      recentRangeM: r.recent_range_m as number | null,
+      dataQualityFlag: (r.data_quality_flag as string | null) ?? null,
     }))
     .sort((a, b) => a.stationName.localeCompare(b.stationName));
 
@@ -111,4 +146,17 @@ export async function GET(request: NextRequest) {
     stations,
     totalStations: stations.length,
   });
+}
+
+/**
+ * WRIS returns the metadata strings inconsistently: sometimes null, sometimes
+ * an empty string, sometimes the literal "Not Available". Normalize them all
+ * to null so the UI can reliably hide missing fields.
+ */
+function normalizeMetaString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase() === "not available") return null;
+  return trimmed;
 }

--- a/src/app/api/groundwater/stations/route.ts
+++ b/src/app/api/groundwater/stations/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { internalServerError, logRouteError } from "@/lib/api-error";
+
+function isSupabaseConfigured(): boolean {
+  return !!(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+}
+
+/**
+ * GET /api/groundwater/stations
+ *
+ * Returns CGWB monitoring station data from India WRIS.
+ *
+ * Query params:
+ *   - station: station_code (optional, filter to one station)
+ *   - mode: "Manual" | "Telemetric" (optional filter)
+ *   - days: number of days of history (default 90, max 730) - only used with station param
+ *
+ * Without station param: returns latest reading per station from the
+ *   groundwater_wris_latest view (one row per station, regardless of age).
+ * With station param: returns full time series for that station within the
+ *   `days` window.
+ */
+export async function GET(request: NextRequest) {
+  if (!isSupabaseConfigured()) {
+    return NextResponse.json({ stations: [], message: "Supabase not configured" });
+  }
+
+  const { createServerClient } = await import("@/lib/supabase/server");
+  const supabase = createServerClient();
+
+  const { searchParams } = new URL(request.url);
+  const stationCode = searchParams.get("station");
+  const modeFilter = searchParams.get("mode");
+  const daysParam = searchParams.get("days");
+  const days = Math.min(Math.max(parseInt(daysParam || "90", 10) || 90, 1), 730);
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+  const cutoff = cutoffDate.toISOString().slice(0, 10);
+
+  if (stationCode) {
+    // Return time series for a specific station
+    let query = supabase
+      .from("groundwater_wris")
+      .select("station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode")
+      .eq("station_code", stationCode)
+      .gte("reading_date", cutoff)
+      .order("reading_date", { ascending: true })
+      .limit(1000);
+
+    if (modeFilter) {
+      query = query.eq("acquisition_mode", modeFilter);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      logRouteError("/api/groundwater/stations", error);
+      return internalServerError();
+    }
+
+    if (!data || data.length === 0) {
+      return NextResponse.json({ station: null, readings: [] });
+    }
+
+    const first = data[0];
+    return NextResponse.json({
+      station: {
+        stationCode: first.station_code,
+        stationName: first.station_name,
+        latitude: first.latitude,
+        longitude: first.longitude,
+        acquisitionMode: first.acquisition_mode,
+      },
+      readings: data.map((r) => ({
+        date: r.reading_date,
+        depthM: r.depth_to_water_m,
+      })),
+    });
+  }
+
+  // No station specified: return latest reading per station from the view
+  let listQuery = supabase
+    .from("groundwater_wris_latest")
+    .select("station_code, station_name, latitude, longitude, reading_date, depth_to_water_m, acquisition_mode");
+
+  if (modeFilter) {
+    listQuery = listQuery.eq("acquisition_mode", modeFilter);
+  }
+
+  const { data: latestRows, error: latestError } = await listQuery;
+
+  if (latestError) {
+    logRouteError("/api/groundwater/stations", latestError);
+    return internalServerError();
+  }
+
+  const stations = (latestRows || [])
+    .map((r) => ({
+      stationCode: r.station_code as string,
+      stationName: r.station_name as string,
+      latitude: r.latitude as number | null,
+      longitude: r.longitude as number | null,
+      latestDate: r.reading_date as string,
+      latestDepthM: r.depth_to_water_m as number,
+      acquisitionMode: r.acquisition_mode as string,
+    }))
+    .sort((a, b) => a.stationName.localeCompare(b.stationName));
+
+  return NextResponse.json({
+    stations,
+    totalStations: stations.length,
+  });
+}

--- a/src/app/groundwater/page.tsx
+++ b/src/app/groundwater/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { WardDetailPanel } from "@/components/groundwater/ward-detail-panel";
 import { BlockDetailPanel } from "@/components/groundwater/block-detail-panel";
+import { WrisStationPanel } from "@/components/groundwater/wris-station-panel";
 import { GroundwaterLegend } from "@/components/groundwater/legend";
 import type {
   GroundwaterWard,
@@ -13,6 +14,8 @@ import type {
   RiskApiResponse,
   ViewMode,
   GWBlock,
+  WrisStation,
+  WrisStationsResponse,
 } from "@/types/groundwater";
 import { useLanguage } from "@/lib/i18n/context";
 import { useLockBodyScroll } from "@/lib/hooks/use-lock-body-scroll";
@@ -52,8 +55,10 @@ function GroundwaterPageContent() {
   const [data, setData] = useState<GroundwaterApiResponse | null>(null);
   const [riskApiData, setRiskApiData] = useState<RiskApiResponse | null>(null);
   const [blocks, setBlocks] = useState<GWBlock[]>([]);
+  const [wrisStations, setWrisStations] = useState<WrisStation[]>([]);
   const [selectedWard, setSelectedWard] = useState<GroundwaterWard | null>(null);
   const [selectedBlock, setSelectedBlock] = useState<GWBlock | null>(null);
+  const [selectedWrisStation, setSelectedWrisStation] = useState<WrisStation | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(
     (searchParams.get("view") as ViewMode) || "depth"
   );
@@ -68,11 +73,15 @@ function GroundwaterPageContent() {
       fetch("/api/groundwater").then((r) => r.json()),
       fetch("/api/groundwater/risk").then((r) => r.json()),
       fetch("/data/gwr-blocks.json").then((r) => r.json()),
+      fetch("/api/groundwater/stations")
+        .then((r) => r.json())
+        .catch(() => ({ stations: [] })),
     ])
-      .then(([gw, risk, gwrBlocks]: [GroundwaterApiResponse, RiskApiResponse, { blocks: GWBlock[] }]) => {
+      .then(([gw, risk, gwrBlocks, wris]: [GroundwaterApiResponse, RiskApiResponse, { blocks: GWBlock[] }, WrisStationsResponse]) => {
         setData(gw);
         setRiskApiData(risk);
         setBlocks(gwrBlocks.blocks ?? []);
+        setWrisStations(wris.stations ?? []);
         setLoading(false);
 
         // Deep link: pre-select ward from ?ward= param
@@ -166,13 +175,16 @@ function GroundwaterPageContent() {
           viewMode={viewMode}
           selectedWardNumber={selectedWard?.wardNumber}
           flyToWard={flyToWard}
-          onWardSelect={(w) => { setSelectedWard(w); setSelectedBlock(null); setFlyToWard(null); }}
-          onBlockSelect={(b) => { setSelectedBlock(b); setSelectedWard(null); setFlyToWard(null); }}
+          onWardSelect={(w) => { setSelectedWard(w); setSelectedBlock(null); setSelectedWrisStation(null); setFlyToWard(null); }}
+          onBlockSelect={(b) => { setSelectedBlock(b); setSelectedWard(null); setSelectedWrisStation(null); setFlyToWard(null); }}
+          onWrisStationSelect={(s) => { setSelectedWrisStation(s); setSelectedWard(null); setSelectedBlock(null); setFlyToWard(null); }}
+          wrisStations={wrisStations}
+          selectedWrisStationCode={selectedWrisStation?.stationCode ?? null}
           hiddenCategories={hiddenCategories}
         />
 
         {/* Legend overlay - shifts up on mobile when bottom sheet is open */}
-        <div className={`absolute sm:bottom-4 z-[1000] transition-[bottom] duration-300 left-2 right-auto md:left-auto md:right-4 ${(selectedWard || selectedBlock) ? "bottom-[148px] md:bottom-4" : "bottom-2"}`}>
+        <div className={`absolute sm:bottom-4 z-[1000] transition-[bottom] duration-300 left-2 right-auto md:left-auto md:right-4 ${(selectedWard || selectedBlock || selectedWrisStation) ? "bottom-[148px] md:bottom-4" : "bottom-2"}`}>
           <GroundwaterLegend
             viewMode={viewMode}
             hiddenCategories={hiddenCategories}
@@ -316,6 +328,14 @@ function GroundwaterPageContent() {
           <BlockDetailPanel
             block={selectedBlock}
             onClose={() => setSelectedBlock(null)}
+          />
+        </BottomSheet>
+      )}
+      {selectedWrisStation && (
+        <BottomSheet onClose={() => setSelectedWrisStation(null)}>
+          <WrisStationPanel
+            station={selectedWrisStation}
+            onClose={() => setSelectedWrisStation(null)}
           />
         </BottomSheet>
       )}

--- a/src/app/groundwater/page.tsx
+++ b/src/app/groundwater/page.tsx
@@ -274,6 +274,9 @@ function GroundwaterPageContent() {
                 onClick={() => {
                   setViewMode("risk");
                   setSelectedBlock(null);
+                  // CGWB station overlay only renders in depth view, so drop
+                  // any open station panel to avoid a stranded detail pane.
+                  setSelectedWrisStation(null);
                   setHiddenCategories(new Set());
                   // Keep current ward selection; only default if none selected
                   if (!selectedWard && data && data.wards.length > 0) {
@@ -294,6 +297,8 @@ function GroundwaterPageContent() {
               onClick={() => {
                 setViewMode("exploitation");
                 setSelectedWard(null);
+                // CGWB station overlay only renders in depth view.
+                setSelectedWrisStation(null);
                 setHiddenCategories(new Set());
                 // Keep current block selection; only default if none selected
                 if (!selectedBlock && blocks.length > 0) {

--- a/src/components/groundwater/legend.tsx
+++ b/src/components/groundwater/legend.tsx
@@ -42,6 +42,33 @@ export function GroundwaterLegend({ viewMode, hiddenCategories, onToggleCategory
   const items = viewMode === "exploitation" ? EXPLOIT_ITEMS : viewMode === "risk" ? RISK_ITEMS : DEPTH_ITEMS;
   const title = viewMode === "exploitation" ? t("legend.exploit_title") : viewMode === "risk" ? t("legend.risk_title") : t("legend.depth_title");
 
+  // "CGWB sensor status" sub-section only applies to the depth view where
+  // WRIS station circle markers are overlaid. These are filterable so users
+  // can hide suspect/old readings from the map.
+  const WRIS_ITEMS = [
+    {
+      id: "wris_stuck",
+      tKey: "legend.wris_stuck",
+      // Amber dashed ring - matches the marker style in ward-map.tsx
+      render: (
+        <span
+          className="w-4 h-4 rounded-full flex-shrink-0 border-2 border-dashed"
+          style={{ borderColor: "#b45309", backgroundColor: "#94a3b8" }}
+        />
+      ),
+    },
+    {
+      id: "wris_stale",
+      tKey: "legend.wris_stale",
+      render: (
+        <span
+          className="w-4 h-4 rounded-full flex-shrink-0 border"
+          style={{ borderColor: "#475569", backgroundColor: "#94a3b8", opacity: 0.6 }}
+        />
+      ),
+    },
+  ];
+
   return (
     <div className="bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 p-3">
       <button
@@ -73,6 +100,32 @@ export function GroundwaterLegend({ viewMode, hiddenCategories, onToggleCategory
             </button>
           );
         })}
+
+        {viewMode === "depth" && (
+          <>
+            <div className="pt-2 mt-1 border-t border-slate-200 dark:border-slate-700">
+              <h5 className="text-[10px] font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+                {t("legend.wris_status_title")}
+              </h5>
+            </div>
+            {WRIS_ITEMS.map((item) => {
+              const hidden = hiddenCategories?.has(item.id) ?? false;
+              return (
+                <button
+                  key={item.id}
+                  onClick={() => onToggleCategory?.(item.id)}
+                  className={`flex items-center gap-2 text-xs whitespace-nowrap w-full text-left transition-opacity ${hidden ? "opacity-30" : ""} ${onToggleCategory ? "cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50 -mx-1 px-1 rounded" : ""}`}
+                  title={t(`${item.tKey}.tooltip`)}
+                >
+                  {item.render}
+                  <span className="text-slate-500 dark:text-slate-400">
+                    {t(item.tKey)}
+                  </span>
+                </button>
+              );
+            })}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/groundwater/ward-map.tsx
+++ b/src/components/groundwater/ward-map.tsx
@@ -7,7 +7,7 @@ import L from "leaflet";
 import type { Layer, LeafletMouseEvent } from "leaflet";
 import type { Feature } from "geojson";
 import { getGroundwaterColor, getGroundwaterStatus, getRiskColor, getBlockClassColor } from "@/types/groundwater";
-import type { GroundwaterWard, WardRiskData, ViewMode, GWBlock, GWStation } from "@/types/groundwater";
+import type { GroundwaterWard, WardRiskData, ViewMode, GWBlock, GWStation, WrisStation } from "@/types/groundwater";
 import { useLanguage } from "@/lib/i18n/context";
 import { getWardGeoJSON } from "@/lib/data/ward-geo";
 import { useMapTiles } from "@/lib/utils/map-tiles";
@@ -43,10 +43,13 @@ interface WardMapProps {
   flyToWard?: number | null;
   onWardSelect: (ward: GroundwaterWard | null) => void;
   onBlockSelect?: (block: GWBlock | null) => void;
+  onWrisStationSelect?: (station: WrisStation | null) => void;
+  wrisStations?: WrisStation[];
+  selectedWrisStationCode?: string | null;
   hiddenCategories?: Set<string>;
 }
 
-export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumber, flyToWard, onWardSelect, onBlockSelect, hiddenCategories }: WardMapProps) {
+export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumber, flyToWard, onWardSelect, onBlockSelect, onWrisStationSelect, wrisStations, selectedWrisStationCode, hiddenCategories }: WardMapProps) {
   const { t, language } = useLanguage();
   const tiles = useMapTiles();
   const [wardGeoJSON, setWardGeoJSON] = useState<GeoJSON.FeatureCollection | null>(null);
@@ -241,6 +244,44 @@ export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumbe
           )}
           {/* key includes viewMode so highlight remounts on top after choropleth remounts */}
           <SelectedWardHighlight key={`highlight-${viewMode}`} wardNumber={selectedWardNumber ?? null} />
+
+          {/* Live CGWB stations overlay (India WRIS) - only on depth view */}
+          {viewMode === "depth" && wrisStations?.map((s) => {
+            if (s.latitude == null || s.longitude == null) return null;
+            const depth = Math.abs(s.latestDepthM);
+            const fillColor = getGroundwaterColor(depth);
+            const isSelected = selectedWrisStationCode === s.stationCode;
+            return (
+              <CircleMarker
+                key={s.stationCode}
+                center={[s.latitude, s.longitude]}
+                radius={isSelected ? 8 : 6}
+                pathOptions={{
+                  fillColor,
+                  color: isSelected ? "#0c4a6e" : "#1e293b",
+                  weight: isSelected ? 2.5 : 1.5,
+                  fillOpacity: 0.95,
+                }}
+                eventHandlers={{
+                  click: () => onWrisStationSelect?.(s),
+                }}
+              >
+                <Tooltip>
+                  <strong>{s.stationName}</strong>
+                  <br />
+                  <span style={{ fontSize: "11px" }}>
+                    {depth.toFixed(2)}m {t("wris.depth_below_ground")}
+                  </span>
+                  <br />
+                  <span style={{ fontSize: "10px", color: "#64748b" }}>
+                    {s.acquisitionMode === "Telemetric"
+                      ? t("wris.mode_telemetric")
+                      : t("wris.mode_manual")}
+                  </span>
+                </Tooltip>
+              </CircleMarker>
+            );
+          })}
         </>
       )}
     </MapContainer>

--- a/src/components/groundwater/ward-map.tsx
+++ b/src/components/groundwater/ward-map.tsx
@@ -248,9 +248,22 @@ export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumbe
           {/* Live CGWB stations overlay (India WRIS) - only on depth view */}
           {viewMode === "depth" && wrisStations?.map((s) => {
             if (s.latitude == null || s.longitude == null) return null;
+            // Respect the legend's sensor-status filters so reviewers can hide
+            // suspect/stale stations when evaluating the map.
+            if (s.dataQualityFlag === "stuck" && hiddenCategories?.has("wris_stuck")) return null;
+            if (s.dataQualityFlag === "stale" && hiddenCategories?.has("wris_stale")) return null;
             const depth = Math.abs(s.latestDepthM);
-            const fillColor = getGroundwaterColor(depth);
             const isSelected = selectedWrisStationCode === s.stationCode;
+            const isSuspect = s.dataQualityFlag === "stuck" || s.dataQualityFlag === "stale";
+            // Stations flagged as stuck/stale get a neutral grey fill and a
+            // dashed border so they don't mislead users into thinking the
+            // depth is a real current reading.
+            const fillColor = isSuspect ? "#94a3b8" : getGroundwaterColor(depth);
+            const borderColor = isSelected
+              ? "#0c4a6e"
+              : s.dataQualityFlag === "stuck"
+                ? "#b45309"
+                : "#1e293b";
             return (
               <CircleMarker
                 key={s.stationCode}
@@ -258,9 +271,10 @@ export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumbe
                 radius={isSelected ? 8 : 6}
                 pathOptions={{
                   fillColor,
-                  color: isSelected ? "#0c4a6e" : "#1e293b",
+                  color: borderColor,
                   weight: isSelected ? 2.5 : 1.5,
-                  fillOpacity: 0.95,
+                  fillOpacity: isSuspect ? 0.55 : 0.95,
+                  dashArray: s.dataQualityFlag === "stuck" ? "2 3" : undefined,
                 }}
                 eventHandlers={{
                   click: () => onWrisStationSelect?.(s),
@@ -278,6 +292,22 @@ export function WardMap({ groundwaterData, riskData, viewMode, selectedWardNumbe
                       ? t("wris.mode_telemetric")
                       : t("wris.mode_manual")}
                   </span>
+                  {s.dataQualityFlag === "stuck" && (
+                    <>
+                      <br />
+                      <span style={{ fontSize: "10px", color: "#b45309", fontWeight: 600 }}>
+                        {t("wris.quality_stuck_title")}
+                      </span>
+                    </>
+                  )}
+                  {s.dataQualityFlag === "stale" && (
+                    <>
+                      <br />
+                      <span style={{ fontSize: "10px", color: "#64748b", fontStyle: "italic" }}>
+                        {t("wris.quality_stale_title")}
+                      </span>
+                    </>
+                  )}
                 </Tooltip>
               </CircleMarker>
             );

--- a/src/components/groundwater/wris-station-panel.tsx
+++ b/src/components/groundwater/wris-station-panel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { useTheme } from "next-themes";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getGroundwaterColor } from "@/types/groundwater";
+import type {
+  WrisStation,
+  WrisStationHistoryResponse,
+  WrisStationReading,
+} from "@/types/groundwater";
+import { useLanguage } from "@/lib/i18n/context";
+
+interface WrisStationPanelProps {
+  station: WrisStation;
+  onClose: () => void;
+}
+
+function formatDaysAgo(dateStr: string, t: (k: string, params?: Record<string, string | number>) => string): string {
+  const reading = new Date(dateStr);
+  const now = new Date();
+  const ms = now.getTime() - reading.getTime();
+  const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+  if (days <= 0) return t("wris.today");
+  if (days === 1) return t("wris.yesterday");
+  return t("wris.days_ago").replace("{n}", String(days));
+}
+
+export function WrisStationPanel({ station, onClose }: WrisStationPanelProps) {
+  const { t, language } = useLanguage();
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => setMounted(true), []);
+  const isDark = mounted && resolvedTheme === "dark";
+  const locale = language === "ta" ? "ta-IN" : "en-IN";
+
+  const [readings, setReadings] = useState<WrisStationReading[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    setError(false);
+
+    fetch(
+      `/api/groundwater/stations?station=${encodeURIComponent(station.stationCode)}&days=730`,
+      { signal: controller.signal }
+    )
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed");
+        return r.json();
+      })
+      .then((d: WrisStationHistoryResponse) => {
+        setReadings(d.readings || []);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (e.name !== "AbortError") {
+          setError(true);
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [station.stationCode]);
+
+  // Display absolute depth (negative WRIS values mean below ground)
+  const depthBelowGround = Math.abs(station.latestDepthM);
+  const color = getGroundwaterColor(depthBelowGround);
+  const modeLabel =
+    station.acquisitionMode === "Telemetric"
+      ? t("wris.mode_telemetric")
+      : t("wris.mode_manual");
+
+  // Transform readings for chart: store positive depth-below-ground
+  const chartData = readings.map((r) => ({
+    date: r.date,
+    depthM: Math.abs(r.depthM),
+  }));
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const renderTooltip = ({ active, payload }: { active?: boolean; payload?: readonly any[] }) => {
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload as { date: string; depthM: number };
+    return (
+      <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-2 text-xs">
+        <div className="text-slate-500 dark:text-slate-400">
+          {new Date(d.date).toLocaleDateString(locale, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })}
+        </div>
+        <div className="font-semibold text-sky-600 dark:text-sky-400">
+          {d.depthM.toFixed(2)}m {t("wris.depth_below_ground")}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="bg-white dark:bg-slate-900 w-full h-full p-4 sm:p-6 overflow-y-auto">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <div className="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+            {t("wris.station")}
+          </div>
+          <h3 className="font-bold text-lg text-slate-900 dark:text-slate-100 leading-tight">
+            {station.stationName}
+          </h3>
+          <div className="text-xs text-slate-400 dark:text-slate-500 font-mono mt-0.5">
+            {station.stationCode}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 hover:bg-slate-100 dark:hover:bg-slate-800 rounded"
+          aria-label={t("common.close_panel")}
+        >
+          <svg className="w-5 h-5 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="mb-6">
+        <div className="text-4xl font-bold" style={{ color }}>
+          {depthBelowGround.toFixed(2)}m
+        </div>
+        <div className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+          {t("wris.latest_reading")} - {t("wris.depth_below_ground")}
+        </div>
+        <div className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+          {new Date(station.latestDate).toLocaleDateString(locale, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+          {" - "}
+          {formatDaysAgo(station.latestDate, t)}
+        </div>
+        <Badge className="mt-2" variant="secondary">
+          {modeLabel}
+        </Badge>
+      </div>
+
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase mb-2">
+          {t("wris.history_title")}
+        </h4>
+        {loading ? (
+          <Skeleton className="h-44 w-full rounded-lg" />
+        ) : error ? (
+          <div className="h-44 flex items-center justify-center text-slate-400 dark:text-slate-500 text-sm">
+            {t("wris.history_error")}
+          </div>
+        ) : chartData.length === 0 ? (
+          <div className="h-44 flex items-center justify-center text-slate-400 dark:text-slate-500 text-sm">
+            {t("wris.history_none")}
+          </div>
+        ) : (
+          <div className="h-44">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 5, right: 5, left: -10, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={isDark ? "#334155" : "#e2e8f0"} />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 9, fill: isDark ? "#94a3b8" : "#64748b" }}
+                  tickLine={false}
+                  axisLine={false}
+                  interval="preserveStartEnd"
+                  minTickGap={40}
+                  tickFormatter={(d: string) =>
+                    new Date(d).toLocaleDateString(locale, { month: "short", year: "2-digit" })
+                  }
+                />
+                <YAxis
+                  reversed
+                  tick={{ fontSize: 9, fill: isDark ? "#94a3b8" : "#64748b" }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(v: number) => `${v}m`}
+                  width={40}
+                />
+                <Tooltip content={renderTooltip} />
+                <Line
+                  type="monotone"
+                  dataKey="depthM"
+                  stroke="#0ea5e9"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-1 text-center">
+          {t("ward.history_yaxis_note")}
+        </p>
+      </div>
+
+      <p className="text-xs text-slate-400 dark:text-slate-500">
+        {t("wris.source_note")}
+      </p>
+    </div>
+  );
+}

--- a/src/components/groundwater/wris-station-panel.tsx
+++ b/src/components/groundwater/wris-station-panel.tsx
@@ -18,6 +18,7 @@ import type {
   WrisStation,
   WrisStationHistoryResponse,
   WrisStationReading,
+  WrisDataQualityFlag,
 } from "@/types/groundwater";
 import { useLanguage } from "@/lib/i18n/context";
 
@@ -46,6 +47,7 @@ export function WrisStationPanel({ station, onClose }: WrisStationPanelProps) {
   const locale = language === "ta" ? "ta-IN" : "en-IN";
 
   const [readings, setReadings] = useState<WrisStationReading[]>([]);
+  const [serverMeta, setServerMeta] = useState<WrisStationHistoryResponse["station"] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -65,6 +67,7 @@ export function WrisStationPanel({ station, onClose }: WrisStationPanelProps) {
       })
       .then((d: WrisStationHistoryResponse) => {
         setReadings(d.readings || []);
+        setServerMeta(d.station ?? null);
         setLoading(false);
       })
       .catch((e) => {
@@ -76,6 +79,18 @@ export function WrisStationPanel({ station, onClose }: WrisStationPanelProps) {
 
     return () => controller.abort();
   }, [station.stationCode]);
+
+  // The list payload (`station`) and the detail payload (`serverMeta`) share
+  // most fields, but only the detail payload has well metadata + quality flag
+  // in older list responses. Prefer serverMeta when available.
+  const wellType = serverMeta?.wellType ?? station.wellType ?? null;
+  const wellDepthM = serverMeta?.wellDepthM ?? station.wellDepthM ?? null;
+  const wellAquiferType = serverMeta?.wellAquiferType ?? station.wellAquiferType ?? null;
+  const qualityFlag: WrisDataQualityFlag | null =
+    serverMeta?.dataQualityFlag ?? station.dataQualityFlag ?? null;
+  const recentCount = serverMeta?.recentCount ?? station.recentCount ?? null;
+  const recentRangeM = serverMeta?.recentRangeM ?? station.recentRangeM ?? null;
+  const hasWellInfo = !!(wellType || wellDepthM || wellAquiferType);
 
   // Display absolute depth (negative WRIS values mean below ground)
   const depthBelowGround = Math.abs(station.latestDepthM);
@@ -156,6 +171,94 @@ export function WrisStationPanel({ station, onClose }: WrisStationPanelProps) {
           {modeLabel}
         </Badge>
       </div>
+
+      {qualityFlag === "stuck" && (
+        <div className="mb-4 rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-3">
+          <div className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <div className="text-xs leading-relaxed text-amber-800 dark:text-amber-200">
+              <div className="font-semibold mb-0.5">
+                {t("wris.quality_stuck_title")}
+              </div>
+              <div>
+                {t("wris.quality_stuck_msg")
+                  .replace(
+                    "{range}",
+                    recentRangeM != null ? recentRangeM.toFixed(2) : "0.00",
+                  )
+                  .replace("{count}", String(recentCount ?? 60))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {qualityFlag === "stale" && (
+        <div className="mb-4 rounded-md border border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/60 p-3">
+          <div className="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
+            <div className="font-semibold mb-0.5">
+              {t("wris.quality_stale_title")}
+            </div>
+            <div>
+              {station.acquisitionMode === "Telemetric"
+                ? t("wris.quality_stale_telem")
+                : t("wris.quality_stale_manual")}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {hasWellInfo && (
+        <div className="mb-6 rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 p-3">
+          <div className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">
+            {t("wris.well_info_title")}
+          </div>
+          <dl className="grid grid-cols-3 gap-2 text-xs">
+            {wellType && (
+              <>
+                <dt className="col-span-1 text-slate-500 dark:text-slate-400">
+                  {t("wris.well_type")}
+                </dt>
+                <dd className="col-span-2 text-slate-700 dark:text-slate-200 font-medium">
+                  {wellType}
+                </dd>
+              </>
+            )}
+            {wellDepthM != null && (
+              <>
+                <dt className="col-span-1 text-slate-500 dark:text-slate-400">
+                  {t("wris.well_depth")}
+                </dt>
+                <dd className="col-span-2 text-slate-700 dark:text-slate-200 font-medium">
+                  {wellDepthM}m
+                </dd>
+              </>
+            )}
+            {wellAquiferType && (
+              <>
+                <dt className="col-span-1 text-slate-500 dark:text-slate-400">
+                  {t("wris.aquifer")}
+                </dt>
+                <dd className="col-span-2 text-slate-700 dark:text-slate-200 font-medium">
+                  {wellAquiferType}
+                </dd>
+              </>
+            )}
+          </dl>
+        </div>
+      )}
 
       <div className="mb-6">
         <h4 className="text-sm font-semibold text-slate-500 dark:text-slate-400 uppercase mb-2">

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -204,6 +204,23 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "gw_block.cgwb_note":      { en: "GW development >100% means extraction exceeds natural recharge - the aquifer is being depleted.", ta: "நிலத்தடி நீர் சுரண்டல் >100% என்றால் எடுப்பு இயற்கை நிரப்பீட்டை மீறுகிறது - நிலத்தடி நீர்வளம் குறைகிறது." },
   "gw_block.boundary_caveat": { en: "CGWB changed assessment block boundaries across years. Some blocks only appear from 2020 or 2023 onward as they were split from older compound blocks.", ta: "CGWB மதிப்பீட்டு தொகுதி எல்லைகள் ஆண்டுகளில் மாற்றப்பட்டன. சில தொகுதிகள் 2020 அல்லது 2023 முதல் மட்டுமே தோன்றும், ஏனெனில் அவை பழைய கூட்டு தொகுதிகளிலிருந்து பிரிக்கப்பட்டன." },
 
+  // ── WRIS / CGWB Live Stations (India WRIS) ─────────────────────────────────
+  "wris.station":            { en: "CGWB Station",                  ta: "CGWB நிலையம்" },
+  "wris.latest_reading":     { en: "Latest reading",                ta: "சமீபத்திய அளவீடு" },
+  "wris.depth_below_ground": { en: "below ground",                  ta: "தரைக்குக் கீழ்" },
+  "wris.acquisition_mode":   { en: "Mode",                          ta: "முறை" },
+  "wris.mode_telemetric":    { en: "Telemetric (DWLR)",             ta: "தானியங்கி (DWLR)" },
+  "wris.mode_manual":        { en: "Manual (seasonal)",             ta: "கையேடு (பருவகால)" },
+  "wris.history_title":      { en: "Recent readings",               ta: "சமீபத்திய அளவீடுகள்" },
+  "wris.history_loading":    { en: "Loading readings...",           ta: "அளவீடுகள் ஏற்றப்படுகின்றன..." },
+  "wris.history_error":      { en: "Could not load readings",       ta: "அளவீடுகளை ஏற்ற முடியவில்லை" },
+  "wris.history_none":       { en: "No readings available",         ta: "அளவீடுகள் இல்லை" },
+  "wris.legend_title":       { en: "Live CGWB stations",            ta: "நேரடி CGWB நிலையங்கள்" },
+  "wris.source_note":        { en: "Source: India WRIS - CGWB monitoring stations.", ta: "ஆதாரம்: இந்தியா WRIS - CGWB கண்காணிப்பு நிலையங்கள்." },
+  "wris.days_ago":           { en: "{n} days ago",                  ta: "{n} நாட்களுக்கு முன்" },
+  "wris.today":              { en: "today",                          ta: "இன்று" },
+  "wris.yesterday":          { en: "yesterday",                      ta: "நேற்று" },
+
   "legend.exploit_title":    { en: "GW Exploitation",              ta: "நிலத்தடி நீர் சுரண்டல்" },
   "legend.safe":             { en: "Safe (<70%)",                   ta: "பாதுகாப்பான (<70%)" },
   "legend.semi_critical_lbl": { en: "Semi Critical (70-90%)",      ta: "அரை-தீவிரம் (70-90%)" },

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -220,12 +220,28 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "wris.days_ago":           { en: "{n} days ago",                  ta: "{n} நாட்களுக்கு முன்" },
   "wris.today":              { en: "today",                          ta: "இன்று" },
   "wris.yesterday":          { en: "yesterday",                      ta: "நேற்று" },
+  "wris.well_info_title":    { en: "Well details",                   ta: "கிணற்று விவரங்கள்" },
+  "wris.well_type":          { en: "Well type",                      ta: "கிணற்று வகை" },
+  "wris.well_depth":         { en: "Well depth",                     ta: "கிணற்று ஆழம்" },
+  "wris.aquifer":            { en: "Aquifer",                        ta: "நீர் படிவு" },
+  "wris.quality_stuck_title": { en: "Possible sensor failure",       ta: "சென்சார் தோல்வியாக இருக்கலாம்" },
+  "wris.quality_stuck_msg":  { en: "This station's reading has barely moved ({range}m over the last {count} days). That's unusual for a live DWLR sensor and most likely means the probe is stuck, recalibrated, or reporting a reference value. Treat the latest depth with caution.", ta: "இந்த நிலையத்தின் அளவீடு கடந்த {count} நாட்களில் {range}மீ மட்டுமே மாறியுள்ளது. நேரடி DWLR சென்சாருக்கு இது அசாதாரணமானது. சென்சார் சிக்கியிருக்கலாம் அல்லது மீள்சீரமைக்கப்பட்டிருக்கலாம். சமீபத்திய அளவீட்டை எச்சரிக்கையுடன் பார்க்கவும்." },
+  "wris.quality_stale_title": { en: "Data is old",                   ta: "தரவு பழையது" },
+  "wris.quality_stale_telem": { en: "This DWLR station has not reported a new reading in over two weeks.", ta: "இந்த DWLR நிலையம் இரண்டு வாரங்களுக்கு மேல் புதிய அளவீட்டை அறிக்கை செய்யவில்லை." },
+  "wris.quality_stale_manual": { en: "This is a seasonal manual station. CGWB only resurveys it every few months, so the reading may be months old.", ta: "இது ஒரு பருவகால கையேடு நிலையம். CGWB சில மாதங்களுக்கு ஒருமுறை மட்டுமே மறு ஆய்வு செய்கிறது." },
 
   "legend.exploit_title":    { en: "GW Exploitation",              ta: "நிலத்தடி நீர் சுரண்டல்" },
   "legend.safe":             { en: "Safe (<70%)",                   ta: "பாதுகாப்பான (<70%)" },
   "legend.semi_critical_lbl": { en: "Semi Critical (70-90%)",      ta: "அரை-தீவிரம் (70-90%)" },
   "legend.critical_lbl":     { en: "Critical (90-100%)",            ta: "தீவிரம் (90-100%)" },
   "legend.over_exploited":   { en: "Over Exploited (>100%)",        ta: "அதிக சுரண்டல் (>100%)" },
+
+  // CGWB/WRIS sensor status sub-legend (depth view only)
+  "legend.wris_status_title": { en: "CGWB Sensor Status",           ta: "CGWB சென்சார் நிலை" },
+  "legend.wris_stuck":       { en: "Suspect sensor",                ta: "செயலிழந்த சென்சார்" },
+  "legend.wris_stuck.tooltip": { en: "Telemetric station whose reading has barely moved in 60 days - likely a stuck sensor.", ta: "60 நாட்களில் அளவீடு அசையாத தொலைமாற்றும் நிலையம் - சென்சார் செயலிழந்திருக்கலாம்." },
+  "legend.wris_stale":       { en: "Old reading",                   ta: "பழைய அளவீடு" },
+  "legend.wris_stale.tooltip": { en: "Station has not reported a fresh reading within its expected cadence (DWLR >14 days, manual >180 days).", ta: "எதிர்பார்த்த இடைவெளிக்குள் (DWLR >14 நாட்கள், கையேடு >180 நாட்கள்) புதிய அளவீடு இல்லை." },
 
   // ── Rivers Panel ──────────────────────────────────────────────────────────
   "rivers.improving":      { en: "↑ Improving", ta: "↑ மேம்படுகிறது" },
@@ -305,6 +321,7 @@ export const translations: Record<string, { en: string; ta: string }> = {
   // ── About Page ────────────────────────────────────────────────────────────
   "about.title":           { en: "About Neer Vazhvu",    ta: "நீர் வாழ்வு பற்றி" },
   "about.intro":           { en: "An open-source water intelligence dashboard for Chennai, built to make public data accessible and actionable.", ta: "சென்னைக்கான திறந்த மூல நீர் அறிவு தளம், பொதுத் தரவை அணுகக்கூடியதாகவும் செயல்திறன் மிக்கதாகவும் மாற்றுவதற்காக உருவாக்கப்பட்டது." },
+  "about.collapsed_hint":  { en: "Sections are collapsed by default. Click any heading to expand it.", ta: "பிரிவுகள் இயல்பாக மூடப்பட்டுள்ளன. ஒவ்வொரு தலைப்பையும் கிளிக் செய்து விரிவாக்கலாம்." },
   "about.days_heading":    { en: "How \u201cDays of Water Left\u201d Works", ta: "\u201cமீதமுள்ள நீர் நாட்கள்\u201d எவ்வாறு செயல்படுகிறது" },
   "about.days_intro":      { en: "We compute three scenarios based on current reservoir storage, daily consumption, and inflow patterns:", ta: "தற்போதைய நீர்த்தேக்க இருப்பு, தினசரி நுகர்வு மற்றும் வரத்து முறைகளின் அடிப்படையில் மூன்று சூழ்நிலைகளை கணக்கிடுகிறோம்:" },
   "about.pessimistic":     { en: "Pessimistic (no rain):", ta: "மோசமான (மழையில்லாமல்):" },
@@ -314,8 +331,8 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "about.seasonal":        { en: "Seasonal rains:", ta: "பருவமழை:" },
   "about.seasonal_desc":   { en: "Uses the historical average inflow for this calendar month across all available years.", ta: "அனைத்து கிடைக்கும் ஆண்டுகளிலும் இந்த காலண்டர் மாதத்திற்கான வரலாற்று சராசரி வரத்தைப் பயன்படுத்துகிறது." },
   "about.assumptions":     { en: "Default Assumptions",    ta: "இயல்பு அனுமானங்கள்" },
-  "about.data_sources":    { en: "Data Sources & Aggregation", ta: "தரவு ஆதாரங்கள் & திரட்டல்" },
-  "about.intelligence":    { en: "Intelligence Layer",     ta: "நுண்ணறிவு அடுக்கு" },
+  "about.data_sources":    { en: "Data Source Index",      ta: "தரவு ஆதார அட்டவணை" },
+  "about.intelligence":    { en: "Intelligence & AI Narratives", ta: "நுண்ணறிவு & AI கதையாடல்கள்" },
   "about.forecasting":     { en: "Reservoir Forecasting",  ta: "நீர்த்தேக்க முன்கணிப்பு" },
   "about.gw_map":          { en: "Groundwater Map",        ta: "நிலத்தடி நீர் வரைபடம்" },
   "about.wb_map":          { en: "Water Bodies Map",       ta: "நீர்நிலை வரைபடம்" },
@@ -324,6 +341,32 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "about.limitations":     { en: "Known Limitations",      ta: "அறியப்பட்ட வரம்புகள்" },
   "about.open_source":     { en: "Open Source",            ta: "திறந்த மூலம்" },
   "about.view_github":     { en: "View on GitHub",         ta: "GitHub-ல் காண்க" },
+
+  // Top-level parent groups for the restructured About page
+  "about.group_reading":   { en: "Reading this dashboard",    ta: "இந்த டாஷ்போர்டை படிப்பது எப்படி" },
+  "about.group_pages":     { en: "What each page shows",      ta: "ஒவ்வொரு பக்கமும் காட்டுவது என்ன" },
+  "about.group_quality":   { en: "Data quality & limitations", ta: "தரவு தரம் & வரம்புகள்" },
+  "about.group_project":   { en: "About the project",         ta: "திட்டம் பற்றி" },
+
+  // Page sub-section titles inside "What each page shows"
+  "about.page_dashboard_title": { en: "Dashboard & reservoirs", ta: "டாஷ்போர்டு & நீர்த்தேக்கங்கள்" },
+  "about.page_gw_title":        { en: "Groundwater page",       ta: "நிலத்தடி நீர் பக்கம்" },
+  "about.page_wb_title":        { en: "Water bodies & restoration", ta: "நீர்நிலைகள் & மறுசீரமைப்பு" },
+  "about.page_rivers_title":    { en: "Rivers page",            ta: "ஆறுகள் பக்கம்" },
+  "about.page_flood_title":     { en: "Flood page",             ta: "வெள்ள பக்கம்" },
+  "about.page_my_ward_title":   { en: "My Ward page",           ta: "என் வார்டு பக்கம்" },
+  "about.page_flood_desc":      { en: "Overlays historical flood hazard zones from OpenCity on the ward map together with the Greater Chennai Corporation storm water drain (SWD) network. The goal is to let residents see whether their street sits inside a documented hazard footprint and whether a drain is mapped nearby.", ta: "OpenCity-யின் வரலாற்று வெள்ள ஆபத்து மண்டலங்களையும், GCC மழைநீர் வடிகால் வலையமைப்பையும் வார்டு வரைபடத்தில் காட்டுகிறது. தெரு ஒரு ஆபத்து மண்டலத்தில் இருக்கிறதா, அருகில் வடிகால் உள்ளதா என்பதை குடியிருப்பவர்களுக்கு காட்டுவதே இதன் நோக்கம்." },
+  "about.page_my_ward_desc":    { en: "A single-page rollup of every spatial layer the dashboard knows about - reservoirs, groundwater depth, ward risk score, water bodies, rivers, flood zones, drains, sewerage, CGWB stations - all filtered to one ward. It is the deep-link target when you click a ward anywhere in the app.", ta: "டாஷ்போர்டு அறிந்த ஒவ்வொரு இடஞ்சார்ந்த அடுக்கும் - நீர்த்தேக்கங்கள், நிலத்தடி நீர் ஆழம், வார்டு ஆபத்து மதிப்பெண், நீர்நிலைகள், ஆறுகள், வெள்ள மண்டலங்கள், வடிகால், கழிவுநீர், CGWB நிலையங்கள் - அனைத்தும் ஒரு வார்டுக்கு வடிகட்டப்பட்ட ஒற்றை பக்க சுருக்கம். பயன்பாட்டில் எங்கும் ஒரு வார்டை கிளிக் செய்யும்போது இது ஆழமான-இணைப்பு இலக்காகும்." },
+
+  // Grouping headers inside the flat Data Source Index
+  "about.ds_group_reservoir": { en: "Reservoirs & weather",       ta: "நீர்த்தேக்கங்கள் & வானிலை" },
+  "about.ds_group_gw":        { en: "Groundwater",                ta: "நிலத்தடி நீர்" },
+  "about.ds_group_wb":        { en: "Water bodies & historical",  ta: "நீர்நிலைகள் & வரலாறு" },
+  "about.ds_group_rivers":    { en: "Rivers & pollution",         ta: "ஆறுகள் & மாசு" },
+  "about.ds_group_flood":     { en: "Flood & drainage",           ta: "வெள்ளம் & வடிகால்" },
+  "about.ds_group_satellite": { en: "Satellite & Earth Engine",   ta: "செயற்கைக்கோள் & Earth Engine" },
+  "about.ds_group_base":      { en: "Base geography",             ta: "அடிப்படை புவியியல்" },
+  "about.ds_group_ai":        { en: "AI narratives",              ta: "AI கதையாடல்கள்" },
   "about.param":           { en: "Parameter",  ta: "அளவுரு" },
   "about.default":         { en: "Default",    ta: "இயல்பு" },
   "about.source_col":      { en: "Source",     ta: "ஆதாரம்" },
@@ -376,6 +419,20 @@ export const translations: Record<string, { en: string; ta: string }> = {
   // Groundwater map descriptions
   "about.gw_map_desc1":    { en: "The choropleth map shows depth to water table in metres below ground level (mbgl) for each of Chennai\u2019s 200 GCC wards. Lower values mean the water table is closer to the surface (healthier). Thresholds are based on CGWB classification for South Indian alluvial aquifers.", ta: "நிறப்படக் வரைபடம் சென்னையின் 200 GCC வார்டுகளில் ஒவ்வொன்றிலும் நிலத்தடி நீர்மட்டம் வரையிலான ஆழத்தை மீட்டர்களில் (mbgl) காட்டுகிறது. குறைந்த மதிப்புகள் நீர்மட்டம் மேற்பரப்பிற்கு அருகாமையில் உள்ளது (ஆரோக்கியமானது). வரம்புகள் தென்னிந்திய வண்டல் நீர்வழங்கல் நிலைகளுக்கான CGWB வகைப்பாட்டை அடிப்படையாகக் கொண்டவை." },
   "about.gw_map_desc2":    { en: "Year-over-year trends compare the same month across consecutive years. A change of more than 0.5m is classified as improving or declining.", ta: "ஆண்டுக்கு ஆண்டு போக்குகள் தொடர்ச்சியான ஆண்டுகளில் அதே மாதத்தை ஒப்பிடுகின்றன. 0.5 மீட்டருக்கு மேலான மாற்றம் மேம்படுவதாக அல்லது குறைவதாக வகைப்படுத்தப்படுகிறது." },
+
+  // CGWB station overlay + sensor QA (shown below the ward choropleth description)
+  "about.gw_cgwb_stations_title": { en: "Live CGWB station overlay", ta: "நேரடி CGWB நிலையங்கள் அடுக்கு" },
+  "about.gw_cgwb_stations_intro": { en: "The ward choropleth is sourced from OpenCity's monthly ward-level groundwater dataset, which is authoritative but usually lags by weeks to months. To pair it with ground-truth readings, we also plot ~35 CGWB (Central Ground Water Board) monitoring stations in Chennai district as circle markers, pulled directly from the India WRIS Ground Water Level API.", ta: "வார்டு நிறப்படம் OpenCity-இன் மாதாந்திர வார்டு-மட்ட தரவில் இருந்து வருகிறது, இது அதிகாரப்பூர்வமானது ஆனால் வாரங்கள் அல்லது மாதங்கள் பின்தங்கி வரும். இதனுடன் நேரடி அளவீடுகளை இணைக்க, இந்திய WRIS நிலத்தடி நீர் மட்டம் API-இல் இருந்து நேரடியாக பெறப்படும் ~35 CGWB கண்காணிப்பு நிலையங்களையும் வட்ட குறிகளாக வரைபடத்தில் காட்டுகிறோம்." },
+  "about.gw_cgwb_modes_title": { en: "Manual vs Telemetric stations - why the two can differ sharply", ta: "கையேடு vs தொலை அளவீட்டு நிலையங்கள் - ஏன் இரண்டும் வித்தியாசமாக இருக்கின்றன" },
+  "about.gw_cgwb_modes_manual": { en: "Manual stations are quarterly CGWB field-crew readings, usually from shallow dug wells (~5-11 m deep) sampling the unconfined aquifer. This is the water table residents actually pump from.", ta: "கையேடு நிலையங்கள் மூன்று மாதத்திற்கு ஒருமுறை CGWB கள குழுவால் எடுக்கப்படும் அளவீடுகள், பொதுவாக ஆழமற்ற தோண்டப்பட்ட கிணறுகளில் (~5-11 மீ) இருந்து." },
+  "about.gw_cgwb_modes_telem": { en: "Telemetric stations are DWLR sensors that transmit readings daily. They are usually installed on deeper bore wells or piezometers tapping confined or semi-confined aquifers (often 19-200 m deep), so they answer a different question than the manual dug wells and the two readings should not be conflated.", ta: "தொலை அளவீட்டு நிலையங்கள் நாளொரு முறை அளவீடுகளை அனுப்பும் DWLR சென்சார்கள். இவை பொதுவாக ஆழமான ஆழ்துளை கிணறுகள் அல்லது பைசோமீட்டர்களில் பொருத்தப்படுகின்றன (பெரும்பாலும் 19-200 மீ), எனவே கையேடு கிணறுகளை விட வேறொரு கேள்விக்கு பதில் அளிக்கின்றன." },
+  "about.gw_cgwb_modes_meta": { en: "The station panel surfaces the well type, total well depth, and aquifer type from WRIS metadata so you can tell which well is which before comparing readings.", ta: "WRIS metadata-வில் இருந்து நிலைய பலகம் கிணறு வகை, மொத்த கிணறு ஆழம் மற்றும் நீர்வழங்கல் வகையை காட்டுகிறது." },
+  "about.gw_cgwb_quality_title": { en: "Sensor quality flags", ta: "சென்சார் தரக் குறிப்புகள்" },
+  "about.gw_cgwb_quality_intro": { en: "DWLRs fail silently - a broken sensor keeps reporting the same depth forever, which would poison a naive dashboard. The groundwater_wris_latest database view scores every station with a data_quality_flag so suspect readings are surfaced explicitly rather than averaged into the ward colours:", ta: "DWLR-கள் அமைதியாக செயலிழக்கும் - ஒரு உடைந்த சென்சார் என்றென்றும் அதே ஆழத்தை அறிவிக்கும். groundwater_wris_latest பார்வை ஒவ்வொரு நிலையத்திற்கும் data_quality_flag-ஐ கணக்கிடுகிறது." },
+  "about.gw_cgwb_quality_stuck": { en: "stuck - Telemetric station with >=10 readings in the last 60 days whose median daily delta is under 1cm. This is robust to one-off step changes: a genuinely steady aquifer still passes, but a flat-lined sensor gets caught.", ta: "stuck - கடந்த 60 நாட்களில் >=10 அளவீடுகள் கொண்ட தொலை அளவீட்டு நிலையம், அதன் சராசரி தினசரி மாற்றம் 1 செ.மீ-க்கும் குறைவாக இருந்தால்." },
+  "about.gw_cgwb_quality_stale": { en: "stale - The latest reading is older than the station's expected cadence. Mode-aware: Telemetric becomes stale after 14 days (a DWLR should report daily), manual only after 180 days (CGWB resurveys it seasonally).", ta: "stale - கடைசி அளவீடு எதிர்பார்த்த இடைவெளியை தாண்டியது. தொலை அளவீட்டுக்கு 14 நாட்கள், கையேடு நிலையங்களுக்கு 180 நாட்கள்." },
+  "about.gw_cgwb_quality_ok": { en: "ok - Station has at least one recent reading and is neither stuck nor stale.", ta: "ok - நிலையத்தில் சமீபத்திய அளவீடு உள்ளது மற்றும் stuck அல்லது stale அல்ல." },
+  "about.gw_cgwb_quality_ui": { en: "On the map, suspect stations render with a neutral grey fill and a dashed amber ring so they never get confused with trustworthy readings, and the station panel shows an amber 'Possible sensor failure' banner with the exact 60-day range and reading count. The legend's sensor-status sub-section exposes toggles so reviewers can hide stuck or stale markers entirely.", ta: "வரைபடத்தில், சந்தேகத்திற்குரிய நிலையங்கள் நடுநிலை சாம்பல் நிரப்பு மற்றும் பார்டர் புள்ளிக் கோட்டுடன் காட்டப்படுகின்றன." },
 
   // Water bodies map
   "about.wb_map_desc":         { en: "The Water Bodies page combines current OpenStreetMap polygons, a curated set of 15 historically significant lost or encroached water bodies, and a new satellite context layer for a reviewed Phase 1 target set. For selected lakes and reservoirs, the detail panel now shows historical persistence, current spread versus the usual seasonal baseline, and an observation freshness/confidence label.", ta: "நீர்நிலை பக்கம் தற்போதைய OpenStreetMap பல்கோணங்கள், வரலாற்று முக்கியத்துவம் வாய்ந்த 15 இழந்த அல்லது ஆக்கிரமிக்கப்பட்ட நீர்நிலைகளின் தொகுப்பு, மற்றும் மதிப்பாய்வு செய்யப்பட்ட Phase 1 இலக்கு தொகுப்பிற்கான புதிய செயற்கைக்கோள் சூழல் அடுக்கை இணைக்கிறது. தேர்ந்தெடுக்கப்பட்ட ஏரிகள் மற்றும் நீர்த்தேக்கங்களுக்கு, விவர பலகம் வரலாற்று நிலைத்தன்மை, இந்த பருவத்தின் வழக்கமான அடிப்படையுடன் ஒப்பிடும் தற்போதைய பரப்பு, மற்றும் தரவு புத்தம்புதிய/நம்பிக்கை குறிச்சொல்லைக் காட்டுகிறது." },
@@ -509,6 +566,7 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "about.ds_sewerage_desc":   { en: "CMWSSB sewerage infrastructure: 8 sewage treatment plants (STPs) with capacity, 348 pumping stations (SPS) linked to STPs, and 3,834 pumping main segments with pipe material and size.", ta: "CMWSSB கழிவுநீர் உள்கட்டமைப்பு: 8 கழிவுநீர் சுத்திகரிப்பு நிலையங்கள் (STP), 348 பம்பிங் நிலையங்கள் (SPS), மற்றும் 3,834 பம்பிங் முக்கிய குழாய் பகுதிகள்." },
   "about.ds_imd_desc":        { en: "56-year monthly rainfall history (1970-2025) from IMD's 0.25-degree gridded dataset, extracted for the Chennai grid cell. Includes annual totals and long-term monthly normals for drought/flood/Day Zero year identification.", ta: "IMD-யின் 0.25-டிகிரி கிரிட் தரவுத்தொகுப்பிலிருந்து 56 ஆண்டு மாதாந்திர மழை வரலாறு (1970-2025), சென்னை கிரிட் செல்லுக்கு பிரித்தெடுக்கப்பட்டது. வறட்சி/வெள்ளம்/டே ஜீரோ ஆண்டு அடையாளத்திற்கான வருடாந்திர மொத்தங்கள் மற்றும் நீண்டகால மாத சாதாரண மதிப்புகள் அடங்கும்." },
   "about.ds_cgwb_desc":       { en: "Block-level groundwater exploitation data (2011-2024) from CGWB via India WRIS ArcGIS API. Shows classification (Safe to Over-Exploited), development percentage, net availability, and extraction draft for ~15 blocks in and around Chennai.", ta: "இந்தியா WRIS ArcGIS API மூலம் CGWB-யிலிருந்து பிளாக்-நிலை நிலத்தடி நீர் சுரண்டல் தரவு (2011-2024). சென்னை மற்றும் சுற்றியுள்ள ~15 பிளாக்குகளுக்கு வகைப்பாடு (பாதுகாப்பானது முதல் அதிக சுரண்டல் வரை), வளர்ச்சி சதவீதம், நிகர கிடைக்கும் தன்மை மற்றும் எடுப்பு வரைவு." },
+  "about.ds_wris_stations_desc": { en: "Station-level groundwater time series for ~35 CGWB monitoring stations in Chennai district, pulled daily from the India WRIS Ground Water Level API. Mix of Manual (quarterly dug wells, unconfined aquifer) and Telemetric (daily DWLR bore wells, confined aquifer) stations with well type, well depth, and aquifer metadata. Each station is scored server-side with a stuck/stale/ok data quality flag.", ta: "இந்திய WRIS நிலத்தடி நீர் மட்டம் API-இல் இருந்து தினசரி பெறப்படும் சென்னை மாவட்டத்தில் ~35 CGWB கண்காணிப்பு நிலையங்களுக்கான நிலைய-அளவிலான நிலத்தடி நீர் நேரத்தொடர். கையேடு (கிணறு, unconfined) மற்றும் தொலை அளவீட்டு (DWLR, confined) நிலையங்கள் கலந்தவை, கிணறு வகை, ஆழம் மற்றும் நீர்வழங்கல் வகையுடன். ஒவ்வொரு நிலையமும் stuck/stale/ok தரக் குறிப்பிடு கொண்டது." },
   "about.ds_crrt_desc":       { en: "9 restoration projects across Adyar, Cooum, Buckingham Canal, and Kosasthalaiyar rivers from the Chennai Rivers Restoration Trust. Includes project status, budget, area, implementing agencies, and outcome metrics.", ta: "சென்னை ஆறுகள் புனரமைப்பு அறக்கட்டளையிலிருந்து அடையாறு, கூவம், பக்கிங்ஹாம் கால்வாய் மற்றும் கோசஸ்தலையாறு ஆறுகளில் 9 புனரமைப்பு திட்டங்கள். திட்ட நிலை, பட்ஜெட், பரப்பளவு, செயல்படுத்தும் நிறுவனங்கள் மற்றும் விளைவு அளவீடுகள் அடங்கும்." },
   "about.ds_anthropic_desc":  { en: "AI-generated city and ward narratives connecting reservoir, groundwater, and risk data (Claude Sonnet for city, Haiku for wards)", ta: "நீர்த்தேக்கம், நிலத்தடி நீர் மற்றும் ஆபத்து தரவுகளை இணைக்கும் AI-உருவாக்கிய நகர மற்றும் வார்டு கதையாடல்கள்" },
   "about.ds_gee_dw_desc":     { en: "Dynamic World water observations processed through Google Earth Engine. We use a recent 45-day water composite to estimate current visible spread for reviewed Phase 1 lakes and reservoirs.", ta: "Google Earth Engine வழியாக செயலாக்கப்பட்ட Dynamic World நீர் கண்காணிப்புகள். மதிப்பாய்வு செய்யப்பட்ட Phase 1 ஏரிகள் மற்றும் நீர்த்தேக்கங்களுக்கான தற்போதைய காணக்கூடிய பரப்பை கணிக்க, சமீபத்திய 45 நாள் நீர் ஒருங்கிணைப்பை பயன்படுத்துகிறோம்." },

--- a/src/types/groundwater.ts
+++ b/src/types/groundwater.ts
@@ -154,6 +154,18 @@ export interface GWStationsData {
 
 // ── WRIS / CGWB live station readings (India WRIS API) ───────────────────────
 
+/**
+ * Data quality flag computed by the `groundwater_wris_latest` view:
+ * - stuck:   Telemetric sensor has effectively stopped moving (range < 10cm
+ *            over last 60 days with at least 5 readings). Treat the latest
+ *            value as suspect, likely hardware failure or recalibration.
+ * - stale:   Telemetric station not reporting for >14d, or Manual station
+ *            not resurveyed for >180d.
+ * - ok:      Station is operating as expected.
+ * - unknown: Not enough data to judge.
+ */
+export type WrisDataQualityFlag = "ok" | "stuck" | "stale" | "unknown";
+
 export interface WrisStation {
   stationCode: string;
   stationName: string;
@@ -162,6 +174,12 @@ export interface WrisStation {
   latestDate: string;     // YYYY-MM-DD
   latestDepthM: number;   // negative = below ground (depth to water)
   acquisitionMode: string; // "Manual" | "Telemetric"
+  wellType: string | null;         // "Dug Well", "Bore Well", "Piezometer", etc.
+  wellDepthM: number | null;       // Total well depth in metres
+  wellAquiferType: string | null;  // "Unconfined", "Confined", "Semi-Confined"
+  recentCount: number | null;      // Number of readings in the last 60 days
+  recentRangeM: number | null;     // Max-min depth over the last 60 days
+  dataQualityFlag: WrisDataQualityFlag | null;
 }
 
 export interface WrisStationsResponse {
@@ -181,6 +199,12 @@ export interface WrisStationHistoryResponse {
     latitude: number | null;
     longitude: number | null;
     acquisitionMode: string;
+    wellType: string | null;
+    wellDepthM: number | null;
+    wellAquiferType: string | null;
+    recentCount: number | null;
+    recentRangeM: number | null;
+    dataQualityFlag: WrisDataQualityFlag | null;
   } | null;
   readings: WrisStationReading[];
 }

--- a/src/types/groundwater.ts
+++ b/src/types/groundwater.ts
@@ -152,6 +152,39 @@ export interface GWStationsData {
   stations: GWStation[];
 }
 
+// ── WRIS / CGWB live station readings (India WRIS API) ───────────────────────
+
+export interface WrisStation {
+  stationCode: string;
+  stationName: string;
+  latitude: number | null;
+  longitude: number | null;
+  latestDate: string;     // YYYY-MM-DD
+  latestDepthM: number;   // negative = below ground (depth to water)
+  acquisitionMode: string; // "Manual" | "Telemetric"
+}
+
+export interface WrisStationsResponse {
+  stations: WrisStation[];
+  totalStations: number;
+}
+
+export interface WrisStationReading {
+  date: string;     // YYYY-MM-DD
+  depthM: number;   // negative = below ground
+}
+
+export interface WrisStationHistoryResponse {
+  station: {
+    stationCode: string;
+    stationName: string;
+    latitude: number | null;
+    longitude: number | null;
+    acquisitionMode: string;
+  } | null;
+  readings: WrisStationReading[];
+}
+
 const BLOCK_CLASS_COLORS: Record<GWBlockClass, string> = {
   "Safe": "#22c55e",
   "Semi Critical": "#eab308",

--- a/supabase/migrations/012_groundwater_wris.sql
+++ b/supabase/migrations/012_groundwater_wris.sql
@@ -1,0 +1,33 @@
+-- =============================================================
+-- 012_groundwater_wris.sql
+-- CGWB station-level groundwater data from India WRIS API
+-- Supplements ward-level OpenCity data with near-daily readings
+-- =============================================================
+
+-- Station-level groundwater readings (manual + telemetric/DWLR)
+-- Uses existing 'cgwb' value from data_source enum
+CREATE TABLE IF NOT EXISTS groundwater_wris (
+  id                  BIGSERIAL PRIMARY KEY,
+  station_code        TEXT NOT NULL,
+  station_name        TEXT NOT NULL,
+  latitude            NUMERIC(8,5),
+  longitude           NUMERIC(8,5),
+  reading_date        DATE NOT NULL,
+  depth_to_water_m    NUMERIC(8,3) NOT NULL,
+  acquisition_mode    TEXT NOT NULL DEFAULT 'Manual',
+  agency              TEXT NOT NULL DEFAULT 'CGWB',
+  district            TEXT NOT NULL DEFAULT 'Chennai',
+  source              data_source NOT NULL DEFAULT 'cgwb',
+  ingested_at         TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(station_code, reading_date)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_gwris_station_date ON groundwater_wris(station_code, reading_date DESC);
+CREATE INDEX IF NOT EXISTS idx_gwris_date ON groundwater_wris(reading_date DESC);
+CREATE INDEX IF NOT EXISTS idx_gwris_mode ON groundwater_wris(acquisition_mode);
+
+-- RLS: public read
+ALTER TABLE groundwater_wris ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Public read groundwater_wris"
+  ON groundwater_wris FOR SELECT USING (true);

--- a/supabase/migrations/013_groundwater_wris_latest.sql
+++ b/supabase/migrations/013_groundwater_wris_latest.sql
@@ -1,0 +1,22 @@
+-- =============================================================
+-- 013_groundwater_wris_latest.sql
+-- View: latest reading per CGWB station from groundwater_wris
+-- Avoids client-side dedup over thousands of rows when listing stations
+-- =============================================================
+
+CREATE OR REPLACE VIEW groundwater_wris_latest AS
+SELECT DISTINCT ON (station_code)
+  station_code,
+  station_name,
+  latitude,
+  longitude,
+  reading_date,
+  depth_to_water_m,
+  acquisition_mode,
+  agency,
+  district
+FROM groundwater_wris
+ORDER BY station_code, reading_date DESC;
+
+-- View inherits RLS from base table, but be explicit:
+GRANT SELECT ON groundwater_wris_latest TO anon, authenticated;

--- a/supabase/migrations/014_groundwater_wris_metadata_and_quality.sql
+++ b/supabase/migrations/014_groundwater_wris_metadata_and_quality.sql
@@ -1,0 +1,73 @@
+-- =============================================================
+-- 014_groundwater_wris_metadata_and_quality.sql
+-- Add well metadata (type, depth, aquifer) to groundwater_wris and
+-- extend the latest view with a sensor data-quality flag.
+-- See 015 for the mode-aware quality flag refinement.
+-- =============================================================
+
+-- 1. Metadata columns: captured from WRIS API "wellType", "wellDepth",
+--    "wellAquiferType". They are nullable because older rows predate
+--    the metadata-aware scrape; backfill happens via the next ETL run.
+ALTER TABLE groundwater_wris
+  ADD COLUMN IF NOT EXISTS well_type         TEXT,
+  ADD COLUMN IF NOT EXISTS well_depth_m      NUMERIC(8,2),
+  ADD COLUMN IF NOT EXISTS well_aquifer_type TEXT;
+
+-- 2. Recreate the latest view with metadata + quality flag.
+DROP VIEW IF EXISTS groundwater_wris_latest;
+
+CREATE VIEW groundwater_wris_latest AS
+WITH latest AS (
+  SELECT DISTINCT ON (station_code)
+    station_code,
+    station_name,
+    latitude,
+    longitude,
+    reading_date,
+    depth_to_water_m,
+    acquisition_mode,
+    agency,
+    district,
+    well_type,
+    well_depth_m,
+    well_aquifer_type
+  FROM groundwater_wris
+  ORDER BY station_code, reading_date DESC
+),
+recent AS (
+  SELECT
+    station_code,
+    COUNT(*)                                      AS recent_count,
+    MAX(depth_to_water_m) - MIN(depth_to_water_m) AS recent_range_m
+  FROM groundwater_wris
+  WHERE reading_date >= CURRENT_DATE - INTERVAL '60 days'
+  GROUP BY station_code
+)
+SELECT
+  l.station_code,
+  l.station_name,
+  l.latitude,
+  l.longitude,
+  l.reading_date,
+  l.depth_to_water_m,
+  l.acquisition_mode,
+  l.agency,
+  l.district,
+  l.well_type,
+  l.well_depth_m,
+  l.well_aquifer_type,
+  COALESCE(r.recent_count, 0)::INT AS recent_count,
+  r.recent_range_m,
+  CASE
+    WHEN COALESCE(r.recent_count, 0) >= 5 AND r.recent_range_m < 0.10
+      THEN 'stuck'
+    WHEN l.reading_date < CURRENT_DATE - INTERVAL '60 days'
+      THEN 'stale'
+    WHEN COALESCE(r.recent_count, 0) >= 3
+      THEN 'ok'
+    ELSE 'unknown'
+  END AS data_quality_flag
+FROM latest l
+LEFT JOIN recent r USING (station_code);
+
+GRANT SELECT ON groundwater_wris_latest TO anon, authenticated;

--- a/supabase/migrations/015_groundwater_wris_quality_mode_aware.sql
+++ b/supabase/migrations/015_groundwater_wris_quality_mode_aware.sql
@@ -1,0 +1,81 @@
+-- =============================================================
+-- 015_groundwater_wris_quality_mode_aware.sql
+-- Refine groundwater_wris_latest's data_quality_flag so it understands
+-- the difference between Telemetric (DWLR, daily) and Manual (CGWB
+-- field crew, ~quarterly) stations.
+--
+-- Quality flag heuristic:
+--   stuck   - Telemetric station with >=5 readings in the last 60 days AND
+--             range < 0.10m (sensor not moving). This is what catches
+--             stations like ADAYAR_1 whose sensor flatlined at -29.85m.
+--   stale   - Telemetric: latest reading >14 days old (DWLR should report daily)
+--             Manual:    latest reading >180 days old (seasonal cadence)
+--   ok      - has at least one reading and not stuck/stale
+--   unknown - no recent data and unknown mode behaviour
+-- =============================================================
+
+DROP VIEW IF EXISTS groundwater_wris_latest;
+
+CREATE VIEW groundwater_wris_latest AS
+WITH latest AS (
+  SELECT DISTINCT ON (station_code)
+    station_code,
+    station_name,
+    latitude,
+    longitude,
+    reading_date,
+    depth_to_water_m,
+    acquisition_mode,
+    agency,
+    district,
+    well_type,
+    well_depth_m,
+    well_aquifer_type
+  FROM groundwater_wris
+  ORDER BY station_code, reading_date DESC
+),
+recent AS (
+  SELECT
+    station_code,
+    COUNT(*)                                      AS recent_count,
+    MAX(depth_to_water_m) - MIN(depth_to_water_m) AS recent_range_m
+  FROM groundwater_wris
+  WHERE reading_date >= CURRENT_DATE - INTERVAL '60 days'
+  GROUP BY station_code
+)
+SELECT
+  l.station_code,
+  l.station_name,
+  l.latitude,
+  l.longitude,
+  l.reading_date,
+  l.depth_to_water_m,
+  l.acquisition_mode,
+  l.agency,
+  l.district,
+  l.well_type,
+  l.well_depth_m,
+  l.well_aquifer_type,
+  COALESCE(r.recent_count, 0)::INT AS recent_count,
+  r.recent_range_m,
+  CASE
+    WHEN l.acquisition_mode = 'Telemetric'
+         AND COALESCE(r.recent_count, 0) >= 5
+         AND r.recent_range_m < 0.10
+      THEN 'stuck'
+    WHEN l.acquisition_mode = 'Telemetric'
+         AND l.reading_date < CURRENT_DATE - INTERVAL '14 days'
+      THEN 'stale'
+    WHEN l.acquisition_mode = 'Manual'
+         AND l.reading_date < CURRENT_DATE - INTERVAL '180 days'
+      THEN 'stale'
+    WHEN COALESCE(r.recent_count, 0) >= 1
+      THEN 'ok'
+    WHEN l.acquisition_mode = 'Manual'
+      THEN 'ok'
+    ELSE 'unknown'
+  END AS data_quality_flag
+FROM latest l
+LEFT JOIN recent r USING (station_code);
+
+GRANT SELECT ON groundwater_wris_latest TO anon, authenticated;

--- a/supabase/migrations/016_groundwater_wris_stuck_detection_v2.sql
+++ b/supabase/migrations/016_groundwater_wris_stuck_detection_v2.sql
@@ -1,0 +1,108 @@
+-- =============================================================
+-- 016_groundwater_wris_stuck_detection_v2.sql
+-- Improve the stuck-sensor detector.
+--
+-- Problem with the v1 heuristic (migration 015): it used the absolute
+-- range (max-min) of the last 60 days, with a 10cm threshold. That's
+-- brittle: a single one-off step change (a recalibration or a one-day
+-- glitch) blows the range well past 10cm even if the sensor is clearly
+-- flatlined before and after.
+--
+-- v2 heuristic: compute the median of |day-to-day changes| in the last
+-- 60 days. A healthy DWLR in Chennai moves a few cm per day due to
+-- pumping and recharge cycles. A stuck sensor moves <1cm/day median.
+-- Median is robust to single-step jumps.
+--
+-- Concrete Chennai data (as of 2026-04-07):
+--   ADAYAR_1           median=0.00cm/d  -> stuck
+--   Pallavaram_2       median=0.50cm/d  -> stuck (v1 missed this)
+--   Taramani NITTR PZ  median=0.70cm/d  -> stuck (v1 missed this)
+--   Guindy CLRI        median=1.80cm/d  -> healthy
+--   Washermenpet       median=3.10cm/d  -> healthy
+--
+-- Threshold: median daily delta < 1.0cm with at least 10 readings in
+-- the 60-day window. Also keep the old range in the view so the panel
+-- UI can still show "range X.XXm over last 60 days" context.
+-- =============================================================
+
+DROP VIEW IF EXISTS groundwater_wris_latest;
+
+CREATE VIEW groundwater_wris_latest AS
+WITH latest AS (
+  SELECT DISTINCT ON (station_code)
+    station_code,
+    station_name,
+    latitude,
+    longitude,
+    reading_date,
+    depth_to_water_m,
+    acquisition_mode,
+    agency,
+    district,
+    well_type,
+    well_depth_m,
+    well_aquifer_type
+  FROM groundwater_wris
+  ORDER BY station_code, reading_date DESC
+),
+recent_deltas AS (
+  SELECT
+    station_code,
+    depth_to_water_m,
+    ABS(
+      depth_to_water_m
+      - LAG(depth_to_water_m) OVER (
+          PARTITION BY station_code
+          ORDER BY reading_date
+        )
+    ) AS delta_m
+  FROM groundwater_wris
+  WHERE reading_date >= CURRENT_DATE - INTERVAL '60 days'
+),
+recent AS (
+  SELECT
+    station_code,
+    COUNT(*)                                               AS recent_count,
+    MAX(depth_to_water_m) - MIN(depth_to_water_m)          AS recent_range_m,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY delta_m)
+      FILTER (WHERE delta_m IS NOT NULL)                   AS median_daily_delta_m
+  FROM recent_deltas
+  GROUP BY station_code
+)
+SELECT
+  l.station_code,
+  l.station_name,
+  l.latitude,
+  l.longitude,
+  l.reading_date,
+  l.depth_to_water_m,
+  l.acquisition_mode,
+  l.agency,
+  l.district,
+  l.well_type,
+  l.well_depth_m,
+  l.well_aquifer_type,
+  COALESCE(r.recent_count, 0)::INT AS recent_count,
+  r.recent_range_m,
+  r.median_daily_delta_m,
+  CASE
+    WHEN l.acquisition_mode = 'Telemetric'
+         AND COALESCE(r.recent_count, 0) >= 10
+         AND r.median_daily_delta_m < 0.01
+      THEN 'stuck'
+    WHEN l.acquisition_mode = 'Telemetric'
+         AND l.reading_date < CURRENT_DATE - INTERVAL '14 days'
+      THEN 'stale'
+    WHEN l.acquisition_mode = 'Manual'
+         AND l.reading_date < CURRENT_DATE - INTERVAL '180 days'
+      THEN 'stale'
+    WHEN COALESCE(r.recent_count, 0) >= 1
+      THEN 'ok'
+    WHEN l.acquisition_mode = 'Manual'
+      THEN 'ok'
+    ELSE 'unknown'
+  END AS data_quality_flag
+FROM latest l
+LEFT JOIN recent r USING (station_code);
+
+GRANT SELECT ON groundwater_wris_latest TO anon, authenticated;


### PR DESCRIPTION
## Summary

Adds a live CGWB groundwater station overlay fed by the India WRIS API, a mode-aware sensor quality flag so reviewers can spot stuck/stale telemetry at a glance, and a full documentation refresh (ARCHITECTURE, DATA_SOURCES, README, About page).

- Closes the data freshness gap on the groundwater map: OpenCity ward-level data only goes through March 2024, but India WRIS publishes near-real-time CGWB station readings through today.
- Backfills 8,592 readings (2024-01-01 to 2026-04-05) across 35 Chennai monitoring stations: 17 Telemetric (DWLR, near-daily) + 18 Manual (seasonal).
- Adds an interactive station overlay on the depth view with click-to-view time series, plus a sensor-quality layer (stuck / stale / ok) that is filterable from the legend.

## Backend

- New scraper [`app/scrapers/wris.py`](neer-vazhvu-api/app/scrapers/wris.py): paginates the India WRIS API, deduplicates telemetric multi-reading days into a daily average, filters sensor errors.
- New `WrisGroundwaterRecord` model.
- Migrations:
  - `012_groundwater_wris.sql` - station readings table (uses existing `cgwb` enum value to avoid `ALTER TYPE ... ADD VALUE` transaction issue).
  - `013_groundwater_wris_latest.sql` - `DISTINCT ON (station_code)` view to bypass Supabase's 1000-row default cap when listing stations.
  - `014_groundwater_wris_metadata_and_quality.sql` - station metadata columns (well depth, aquifer, mode) + initial `data_quality_flag` function.
  - `015_groundwater_wris_quality_mode_aware.sql` - mode-aware stale thresholds (>14d telemetric, >180d manual) so seasonal manual wells are not mislabelled as dead sensors.
  - `016_groundwater_wris_stuck_detection_v2.sql` - stuck-sensor detector: telemetric stations whose median daily delta stays under 1cm for 60 days are flagged `stuck` so operators can tell the difference between a healthy flat line and a frozen transducer.
- Pipeline: `_step_fetch_wris` wired into `run_daily` and `run_post_scrape` (non-required), plus `run_wris_fetch` entry point and `/run-wris-fetch` cron endpoint.
- One-shot backfill script [`scripts/backfill_wris_metadata.py`](neer-vazhvu-api/scripts/backfill_wris_metadata.py) to hydrate station metadata for existing rows.

## Frontend

- `/api/groundwater/stations` (Next.js route): list view (latest reading per station, served from the SQL view) and per-station time series, now including `data_quality_flag` so the client can show the sensor status badge.
- `WrisStationPanel` component: bottom sheet with latest reading, days-ago label, acquisition-mode badge, sensor-quality pill, well metadata, and a Recharts time series chart matching the existing `WardHistoryChart` style.
- `WardMap`: live CGWB station markers overlaid on the depth view, colored by `abs(latest depth)` using the existing groundwater color scale; stuck/stale markers can be hidden from the legend.
- `Legend`: new CGWB sensor status section with stuck/stale toggles and tooltip copy explaining the thresholds.
- `wris.*` and `legend.wris_*` i18n keys added in en + ta.

## About page restructure

The About page had grown to 14 flat sections. Restructured into **six collapsible parent groups**, all collapsed by default via native `<details>` (no JS state):

1. **Reading this dashboard** - Days of Water Left + default assumptions
2. **What each page shows** - one sub-card per page: Dashboard & reservoirs (forecasting + GEE catchment), Groundwater (choropleth + ward risk + CGWB stations + sensor quality), Water bodies & restoration (NDWI + evidence + restoration priority + lost water bodies), Rivers, Flood, My Ward
3. **Intelligence & AI narratives**
4. **Data source index** - 8 grouped headers: reservoirs & weather, groundwater, water bodies, rivers, flood & drainage, satellite & Earth Engine, base geography, AI narratives
5. **Data quality & limitations**
6. **About the project** (disclaimer + open source)

Introduces `SubSection` and `DataSourceGroupHeader` helpers and a new block of 24 `about.*` translation keys.

## Docs

- [`ARCHITECTURE.md`](ARCHITECTURE.md) - added `WRIS_ST` external source, `groundwater_wris` core table, daily pipeline row, ERD entity.
- [`DATA_SOURCES.md`](DATA_SOURCES.md) - new "CGWB Station-Level Groundwater Time Series - India WRIS" section documenting fields, cadence, stuck/stale taxonomy, frontend UI behavior, and backfill command.
- [`README.md`](README.md) - added "Live CGWB Station Overlay" and "Sensor Data Quality Layer" feature bullets plus a row in the data sources table.

## Notes / known follow-ups

- Sign convention varies between station types: Manual stations report positive meters below ground; Telemetric report negative values (likely below sensor/MSL). The UI normalizes via `Math.abs()` for now - worth confirming with WRIS docs before relying on the exact magnitudes.
- Some Telemetric `station_code`s share the name "Govt higher secondary school" at different lat/lons - each is its own station, fine for now but could surface a more specific block name later.
- WRIS fetch only runs when triggered manually or via the daily pipeline; consider a separate weekly cron if we want a slower cadence for just this dataset.

## Test plan

- [x] `/groundwater` page loads, depth view shows new colored station dots over the ward choropleth
- [x] Hovering a marker shows station name, depth, and Telemetric/Manual badge
- [ ] Clicking a marker opens the bottom-sheet panel with a populated time series and a sensor quality pill (stuck / stale / ok)
- [x] Legend stuck/stale toggles hide the corresponding markers on the map
- [x] Telemetric stations show ~daily readings; Manual stations show only a handful of points
- [x] Switching to risk/exploitation views hides the WRIS overlay
- [x] Mobile bottom sheet legend offset still looks right with the new panel
- [x] `curl /api/groundwater/stations` returns 35 stations with `data_quality_flag` populated; `curl /api/groundwater/stations?station=TNGW0025` returns a long time series
- [x] `/about` page: all 6 parent sections collapsed on first load, clicking any header expands it; Tamil translations render for every new key