### PR TITLE
Add locality/area search with ward and zone hierarchy

### DIFF
--- a/public/data/chennai-localities.json
+++ b/public/data/chennai-localities.json
@@ -1,0 +1,4686 @@
+[
+  {
+    "name": "AA Block",
+    "type": "neighbourhood",
+    "lat": 13.0834977,
+    "lng": 80.2164744,
+    "ward_number": 100,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "AB Block",
+    "type": "neighbourhood",
+    "lat": 13.0835934,
+    "lng": 80.2141151,
+    "ward_number": 100,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Abhiramapuram",
+    "name_ta": "அபிராமபுரம்",
+    "type": "suburb",
+    "lat": 13.0310236,
+    "lng": 80.2582995,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "AC Block",
+    "type": "neighbourhood",
+    "lat": 13.0837153,
+    "lng": 80.2113538,
+    "ward_number": 100,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Adambakkam",
+    "name_ta": "ஆதம்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9822215,
+    "lng": 80.209121,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Adyar",
+    "name_ta": "அடையாறு",
+    "type": "suburb",
+    "lat": 13.00645,
+    "lng": 80.2577791,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "AGS Colony",
+    "type": "neighbourhood",
+    "lat": 12.9745922,
+    "lng": 80.2564334,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "AGS Officers Colony",
+    "type": "neighbourhood",
+    "lat": 12.9789702,
+    "lng": 80.2097046,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Alapakkam",
+    "name_ta": "அலப்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.049901,
+    "lng": 80.1654347,
+    "ward_number": 146,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "All India Radio Housing Board",
+    "type": "neighbourhood",
+    "lat": 13.1872085,
+    "lng": 80.3123029,
+    "ward_number": 3,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Alwarpet",
+    "name_ta": "ஆழ்வார்பேட்டை",
+    "type": "suburb",
+    "lat": 13.0338602,
+    "lng": 80.2545491,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Alwarthiru Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0407334,
+    "lng": 80.1859659,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Ambattur",
+    "name_ta": "அம்பத்தூர்",
+    "type": "suburb",
+    "lat": 13.1193746,
+    "lng": 80.1507648,
+    "ward_number": 81,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Aminjikarai",
+    "name_ta": "அமைந்தக்கரை",
+    "type": "suburb",
+    "lat": 13.0721399,
+    "lng": 80.2205453,
+    "ward_number": 106,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Anis Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0372741,
+    "lng": 80.1881482,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Anna Nagar",
+    "name_ta": "அண்ணா நகர்",
+    "type": "suburb",
+    "lat": 13.0872004,
+    "lng": 80.2164421,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Anna Nagar East",
+    "name_ta": "அண்ணா நகர் கிழக்கு",
+    "type": "neighbourhood",
+    "lat": 13.0852124,
+    "lng": 80.2258887,
+    "ward_number": 102,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Anna Nagar West",
+    "name_ta": "அண்ணா நகர் மேற்கு",
+    "type": "suburb",
+    "lat": 13.0940791,
+    "lng": 80.1922978,
+    "ward_number": 89,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Annai Sathya Nagar Nesapakkam",
+    "type": "neighbourhood",
+    "lat": 13.0357157,
+    "lng": 80.1884526,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Arumbakkam",
+    "name_ta": "அரும்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.074371,
+    "lng": 80.2081312,
+    "ward_number": 105,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Arunachalapuram",
+    "type": "neighbourhood",
+    "lat": 13.0087347,
+    "lng": 80.2608522,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ashok Nagar",
+    "name_ta": "அஷோக் நகர்",
+    "type": "suburb",
+    "lat": 13.0400731,
+    "lng": 80.2159247,
+    "ward_number": 132,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Aspiran Garden",
+    "type": "neighbourhood",
+    "lat": 13.0862695,
+    "lng": 80.2370386,
+    "ward_number": 98,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Avvai Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9773778,
+    "lng": 80.2538832,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Ayanavaram",
+    "name_ta": "அயனாவரம்",
+    "type": "suburb",
+    "lat": 13.0946157,
+    "lng": 80.23541,
+    "ward_number": 98,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Aziz Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0486971,
+    "lng": 80.2281137,
+    "ward_number": 134,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Baby Nagar",
+    "name_ta": "பேபி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9803651,
+    "lng": 80.2291946,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Bakhtavachalam Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9778604,
+    "lng": 80.179105,
+    "ward_number": 166,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Bakthavatchalam Nagar",
+    "type": "neighbourhood",
+    "lat": 13.003406,
+    "lng": 80.2530941,
+    "ward_number": 175,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Balaji Nagar",
+    "name_ta": "பாலாஜி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9721642,
+    "lng": 80.1905716,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Basin Bridge",
+    "name_ta": "பேசின் பிரிட்ஜ்",
+    "type": "suburb",
+    "lat": 13.1080471,
+    "lng": 80.2699078,
+    "ward_number": 46,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Besant Nagar",
+    "name_ta": "பெசன்ட் நகர்",
+    "type": "suburb",
+    "lat": 12.9996907,
+    "lng": 80.2682259,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Bharathipuram",
+    "type": "neighbourhood",
+    "lat": 13.0776651,
+    "lng": 80.2222538,
+    "ward_number": 102,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Bharathiyar Nagar",
+    "name_ta": "பாரதியார் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.1858089,
+    "lng": 80.3155515,
+    "ward_number": 5,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Bhuvaneswary Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9699099,
+    "lng": 80.2219533,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Central Government Officers Quarters, General Pool Accomodation",
+    "type": "neighbourhood",
+    "lat": 13.0021964,
+    "lng": 80.2652826,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Chepauk",
+    "name_ta": "சேப்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0645131,
+    "lng": 80.2831179,
+    "ward_number": 114,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Cherian Nagar",
+    "type": "neighbourhood",
+    "lat": 13.138415,
+    "lng": 80.2971562,
+    "ward_number": 39,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Chetpet",
+    "name_ta": "சேத்துப்பட்டு",
+    "type": "suburb",
+    "lat": 13.0717448,
+    "lng": 80.2437973,
+    "ward_number": 107,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Chinna Kodungaiyur",
+    "name_ta": "சின்ன கொடுங்கையூர்",
+    "type": "suburb",
+    "lat": 13.1438219,
+    "lng": 80.2501492,
+    "ward_number": 34,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Chintadripet",
+    "name_ta": "சிந்தாதிரிப்பேட்டை",
+    "type": "suburb",
+    "lat": 13.0761258,
+    "lng": 80.270781,
+    "ward_number": 62,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Choolai",
+    "name_ta": "சூலை",
+    "type": "suburb",
+    "lat": 13.0906283,
+    "lng": 80.2621417,
+    "ward_number": 78,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Chowdhary Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0386857,
+    "lng": 80.1809343,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CIT Colony",
+    "name_ta": "சி ஐ டி காலனி",
+    "type": "neighbourhood",
+    "lat": 13.04131,
+    "lng": 80.2604719,
+    "ward_number": 119,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CIT Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0293843,
+    "lng": 80.2342825,
+    "ward_number": 141,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 1",
+    "type": "neighbourhood",
+    "lat": 13.2265373,
+    "lng": 80.3236635,
+    "ward_number": 1,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 10",
+    "type": "neighbourhood",
+    "lat": 13.163186,
+    "lng": 80.2995095,
+    "ward_number": 10,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 100",
+    "type": "neighbourhood",
+    "lat": 13.088311,
+    "lng": 80.2097295,
+    "ward_number": 99,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 101",
+    "type": "neighbourhood",
+    "lat": 13.0855255,
+    "lng": 80.2205185,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 102",
+    "type": "neighbourhood",
+    "lat": 13.08381,
+    "lng": 80.228186,
+    "ward_number": 102,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 103",
+    "type": "neighbourhood",
+    "lat": 13.0820165,
+    "lng": 80.2403305,
+    "ward_number": 103,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 104",
+    "type": "neighbourhood",
+    "lat": 13.0824755,
+    "lng": 80.2485625,
+    "ward_number": 103,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 105",
+    "type": "neighbourhood",
+    "lat": 13.0680234,
+    "lng": 80.2096695,
+    "ward_number": 105,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 106",
+    "type": "neighbourhood",
+    "lat": 13.07101,
+    "lng": 80.2228435,
+    "ward_number": 106,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 107",
+    "type": "neighbourhood",
+    "lat": 13.0724655,
+    "lng": 80.240134,
+    "ward_number": 107,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 108",
+    "type": "neighbourhood",
+    "lat": 13.0636262,
+    "lng": 80.2173493,
+    "ward_number": 108,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 109",
+    "type": "neighbourhood",
+    "lat": 13.063094,
+    "lng": 80.227249,
+    "ward_number": 109,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 11",
+    "type": "neighbourhood",
+    "lat": 13.1548385,
+    "lng": 80.3026645,
+    "ward_number": 11,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 110",
+    "type": "neighbourhood",
+    "lat": 13.061398,
+    "lng": 80.238091,
+    "ward_number": 110,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 111",
+    "type": "neighbourhood",
+    "lat": 13.0588185,
+    "lng": 80.2541305,
+    "ward_number": 111,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 112",
+    "type": "neighbourhood",
+    "lat": 13.058895,
+    "lng": 80.2247575,
+    "ward_number": 109,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 113",
+    "type": "neighbourhood",
+    "lat": 13.055152,
+    "lng": 80.2411175,
+    "ward_number": 110,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 114",
+    "type": "neighbourhood",
+    "lat": 13.0626525,
+    "lng": 80.2795785,
+    "ward_number": 114,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 115",
+    "type": "neighbourhood",
+    "lat": 13.0560935,
+    "lng": 80.265819,
+    "ward_number": 115,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 116",
+    "type": "neighbourhood",
+    "lat": 13.0543945,
+    "lng": 80.2780245,
+    "ward_number": 116,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 117",
+    "type": "neighbourhood",
+    "lat": 13.043069,
+    "lng": 80.2402445,
+    "ward_number": 136,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 118",
+    "type": "neighbourhood",
+    "lat": 13.046303,
+    "lng": 80.255492,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 119",
+    "type": "neighbourhood",
+    "lat": 13.046359,
+    "lng": 80.264312,
+    "ward_number": 119,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 12",
+    "type": "neighbourhood",
+    "lat": 13.1513585,
+    "lng": 80.296658,
+    "ward_number": 12,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 120",
+    "type": "neighbourhood",
+    "lat": 13.0497665,
+    "lng": 80.2760065,
+    "ward_number": 120,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 121",
+    "type": "neighbourhood",
+    "lat": 13.043922,
+    "lng": 80.272067,
+    "ward_number": 121,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 122",
+    "type": "neighbourhood",
+    "lat": 13.02889,
+    "lng": 80.246745,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 123",
+    "type": "neighbourhood",
+    "lat": 13.0311755,
+    "lng": 80.2569895,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 124",
+    "type": "neighbourhood",
+    "lat": 13.035578,
+    "lng": 80.267549,
+    "ward_number": 124,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 125",
+    "type": "neighbourhood",
+    "lat": 13.03575,
+    "lng": 80.2757395,
+    "ward_number": 125,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 126",
+    "type": "neighbourhood",
+    "lat": 13.025912,
+    "lng": 80.268814,
+    "ward_number": 126,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "CMWSSB Division 127",
+    "type": "neighbourhood",
+    "lat": 13.0675225,
+    "lng": 80.1999765,
+    "ward_number": 127,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 128",
+    "type": "neighbourhood",
+    "lat": 13.045586,
+    "lng": 80.19179,
+    "ward_number": 128,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 129",
+    "type": "neighbourhood",
+    "lat": 13.052918,
+    "lng": 80.203323,
+    "ward_number": 129,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 13",
+    "type": "neighbourhood",
+    "lat": 13.1478025,
+    "lng": 80.2937815,
+    "ward_number": 13,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 130",
+    "type": "neighbourhood",
+    "lat": 13.0535565,
+    "lng": 80.212985,
+    "ward_number": 130,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 131",
+    "type": "neighbourhood",
+    "lat": 13.041117,
+    "lng": 80.202769,
+    "ward_number": 131,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 132",
+    "type": "neighbourhood",
+    "lat": 13.0388665,
+    "lng": 80.212816,
+    "ward_number": 132,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 133",
+    "type": "neighbourhood",
+    "lat": 13.041686,
+    "lng": 80.2187125,
+    "ward_number": 133,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 134",
+    "type": "neighbourhood",
+    "lat": 13.049064,
+    "lng": 80.2246945,
+    "ward_number": 134,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 135",
+    "type": "neighbourhood",
+    "lat": 13.040058,
+    "lng": 80.2239995,
+    "ward_number": 135,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 136",
+    "type": "neighbourhood",
+    "lat": 13.0410995,
+    "lng": 80.2363005,
+    "ward_number": 136,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 137",
+    "type": "neighbourhood",
+    "lat": 13.0359655,
+    "lng": 80.195513,
+    "ward_number": 137,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 138",
+    "type": "neighbourhood",
+    "lat": 13.031365,
+    "lng": 80.203898,
+    "ward_number": 138,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 139",
+    "type": "neighbourhood",
+    "lat": 13.02693,
+    "lng": 80.214703,
+    "ward_number": 139,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 14",
+    "type": "neighbourhood",
+    "lat": 13.1472615,
+    "lng": 80.3011915,
+    "ward_number": 14,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 140",
+    "type": "neighbourhood",
+    "lat": 13.0302995,
+    "lng": 80.2216065,
+    "ward_number": 140,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 141",
+    "type": "neighbourhood",
+    "lat": 13.0308185,
+    "lng": 80.232467,
+    "ward_number": 141,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 142",
+    "type": "neighbourhood",
+    "lat": 13.021627,
+    "lng": 80.220026,
+    "ward_number": 142,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "CMWSSB Division 143",
+    "type": "neighbourhood",
+    "lat": 13.0736735,
+    "lng": 80.168858,
+    "ward_number": 143,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 144",
+    "type": "neighbourhood",
+    "lat": 13.064553,
+    "lng": 80.1745785,
+    "ward_number": 147,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 145",
+    "type": "neighbourhood",
+    "lat": 13.0658715,
+    "lng": 80.185124,
+    "ward_number": 145,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 146",
+    "type": "neighbourhood",
+    "lat": 13.052,
+    "lng": 80.1644445,
+    "ward_number": 146,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 147",
+    "type": "neighbourhood",
+    "lat": 13.051876,
+    "lng": 80.1708915,
+    "ward_number": 147,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 148",
+    "type": "neighbourhood",
+    "lat": 13.0568925,
+    "lng": 80.183901,
+    "ward_number": 148,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 149",
+    "type": "neighbourhood",
+    "lat": 13.047228,
+    "lng": 80.178593,
+    "ward_number": 149,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 15",
+    "type": "neighbourhood",
+    "lat": 13.212664,
+    "lng": 80.289956,
+    "ward_number": 15,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 150",
+    "type": "neighbourhood",
+    "lat": 13.0376071,
+    "lng": 80.1534915,
+    "ward_number": 150,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 151",
+    "type": "neighbourhood",
+    "lat": 13.0317805,
+    "lng": 80.16507,
+    "ward_number": 153,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 152",
+    "type": "neighbourhood",
+    "lat": 13.0405505,
+    "lng": 80.1791125,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 153",
+    "type": "neighbourhood",
+    "lat": 13.0280625,
+    "lng": 80.156331,
+    "ward_number": 153,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 154",
+    "type": "neighbourhood",
+    "lat": 13.029879,
+    "lng": 80.176934,
+    "ward_number": 154,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 155",
+    "type": "neighbourhood",
+    "lat": 13.0300945,
+    "lng": 80.1833735,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 156",
+    "type": "neighbourhood",
+    "lat": 13.0194645,
+    "lng": 80.160972,
+    "ward_number": 156,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 157",
+    "type": "neighbourhood",
+    "lat": 13.0128836,
+    "lng": 80.174381,
+    "ward_number": 157,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 158",
+    "type": "neighbourhood",
+    "lat": 13.0163775,
+    "lng": 80.187452,
+    "ward_number": 158,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 159",
+    "type": "neighbourhood",
+    "lat": 12.9924765,
+    "lng": 80.1696015,
+    "ward_number": 159,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 16",
+    "type": "neighbourhood",
+    "lat": 13.193332,
+    "lng": 80.2770105,
+    "ward_number": 16,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 160",
+    "type": "neighbourhood",
+    "lat": 13.00425,
+    "lng": 80.208089,
+    "ward_number": 160,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 161",
+    "type": "neighbourhood",
+    "lat": 12.996707,
+    "lng": 80.202156,
+    "ward_number": 161,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 162",
+    "type": "neighbourhood",
+    "lat": 12.991405,
+    "lng": 80.1920355,
+    "ward_number": 162,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 163",
+    "type": "neighbourhood",
+    "lat": 12.99073,
+    "lng": 80.2014755,
+    "ward_number": 163,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 164",
+    "type": "neighbourhood",
+    "lat": 12.987362,
+    "lng": 80.1869735,
+    "ward_number": 164,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 165",
+    "type": "neighbourhood",
+    "lat": 12.9828645,
+    "lng": 80.1997885,
+    "ward_number": 165,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 166",
+    "type": "neighbourhood",
+    "lat": 12.9783715,
+    "lng": 80.1791445,
+    "ward_number": 166,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 167",
+    "type": "neighbourhood",
+    "lat": 12.9772025,
+    "lng": 80.186315,
+    "ward_number": 167,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "CMWSSB Division 168",
+    "type": "neighbourhood",
+    "lat": 12.977806,
+    "lng": 80.1955685,
+    "ward_number": 168,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 169",
+    "type": "neighbourhood",
+    "lat": 12.971272,
+    "lng": 80.202539,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 17",
+    "type": "neighbourhood",
+    "lat": 13.184068,
+    "lng": 80.23184,
+    "ward_number": 17,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 170",
+    "type": "neighbourhood",
+    "lat": 13.017874,
+    "lng": 80.2118225,
+    "ward_number": 170,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 171",
+    "type": "neighbourhood",
+    "lat": 13.018864,
+    "lng": 80.2312135,
+    "ward_number": 171,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 172",
+    "type": "neighbourhood",
+    "lat": 13.010837,
+    "lng": 80.2438925,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 173",
+    "type": "neighbourhood",
+    "lat": 13.0187535,
+    "lng": 80.263153,
+    "ward_number": 173,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 174",
+    "type": "neighbourhood",
+    "lat": 12.99744,
+    "lng": 80.2254515,
+    "ward_number": 174,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 175",
+    "type": "neighbourhood",
+    "lat": 13.002534,
+    "lng": 80.2532175,
+    "ward_number": 175,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 176",
+    "type": "neighbourhood",
+    "lat": 13.0036355,
+    "lng": 80.2661705,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 177",
+    "type": "neighbourhood",
+    "lat": 12.9872425,
+    "lng": 80.2111045,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 178",
+    "type": "neighbourhood",
+    "lat": 12.978262,
+    "lng": 80.216255,
+    "ward_number": 178,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 179",
+    "type": "neighbourhood",
+    "lat": 12.977351,
+    "lng": 80.2261185,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 18",
+    "type": "neighbourhood",
+    "lat": 13.1788775,
+    "lng": 80.2679275,
+    "ward_number": 18,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 180",
+    "type": "neighbourhood",
+    "lat": 12.987258,
+    "lng": 80.2445055,
+    "ward_number": 180,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 181",
+    "type": "neighbourhood",
+    "lat": 12.989987,
+    "lng": 80.263797,
+    "ward_number": 181,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 182",
+    "type": "neighbourhood",
+    "lat": 12.9808515,
+    "lng": 80.260959,
+    "ward_number": 182,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "CMWSSB Division 183",
+    "type": "neighbourhood",
+    "lat": 12.9733125,
+    "lng": 80.254583,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 184",
+    "type": "neighbourhood",
+    "lat": 12.9693825,
+    "lng": 80.2383235,
+    "ward_number": 184,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 185",
+    "type": "neighbourhood",
+    "lat": 12.9622345,
+    "lng": 80.2539075,
+    "ward_number": 185,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 186",
+    "type": "neighbourhood",
+    "lat": 12.9588685,
+    "lng": 80.2387725,
+    "ward_number": 186,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 187",
+    "type": "neighbourhood",
+    "lat": 12.9626855,
+    "lng": 80.193012,
+    "ward_number": 187,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 188",
+    "type": "neighbourhood",
+    "lat": 12.9536845,
+    "lng": 80.204077,
+    "ward_number": 188,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 189",
+    "type": "neighbourhood",
+    "lat": 12.9471015,
+    "lng": 80.2185385,
+    "ward_number": 189,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 19",
+    "type": "neighbourhood",
+    "lat": 13.172994,
+    "lng": 80.239429,
+    "ward_number": 19,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 190",
+    "type": "neighbourhood",
+    "lat": 12.9250755,
+    "lng": 80.210134,
+    "ward_number": 190,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 191",
+    "type": "neighbourhood",
+    "lat": 12.918755,
+    "lng": 80.202424,
+    "ward_number": 191,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "CMWSSB Division 192",
+    "type": "neighbourhood",
+    "lat": 12.9481015,
+    "lng": 80.255081,
+    "ward_number": 192,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 193",
+    "type": "neighbourhood",
+    "lat": 12.9446325,
+    "lng": 80.241141,
+    "ward_number": 193,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 194",
+    "type": "neighbourhood",
+    "lat": 12.9359885,
+    "lng": 80.2374225,
+    "ward_number": 194,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 195",
+    "type": "neighbourhood",
+    "lat": 12.926277,
+    "lng": 80.235774,
+    "ward_number": 195,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 196",
+    "type": "neighbourhood",
+    "lat": 12.9223615,
+    "lng": 80.2504235,
+    "ward_number": 196,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 197",
+    "type": "neighbourhood",
+    "lat": 12.9065595,
+    "lng": 80.228426,
+    "ward_number": 197,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 198",
+    "type": "neighbourhood",
+    "lat": 12.891091,
+    "lng": 80.232528,
+    "ward_number": 197,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "CMWSSB Division 2",
+    "type": "neighbourhood",
+    "lat": 13.215643,
+    "lng": 80.3174425,
+    "ward_number": 2,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 20",
+    "type": "neighbourhood",
+    "lat": 13.1690925,
+    "lng": 80.254554,
+    "ward_number": 20,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 21",
+    "type": "neighbourhood",
+    "lat": 13.167235,
+    "lng": 80.270146,
+    "ward_number": 21,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "CMWSSB Division 22",
+    "type": "neighbourhood",
+    "lat": 13.1694255,
+    "lng": 80.208355,
+    "ward_number": 22,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 23",
+    "type": "neighbourhood",
+    "lat": 13.1590815,
+    "lng": 80.208932,
+    "ward_number": 23,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 24",
+    "type": "neighbourhood",
+    "lat": 13.141554,
+    "lng": 80.1905475,
+    "ward_number": 24,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 25",
+    "type": "neighbourhood",
+    "lat": 13.15015,
+    "lng": 80.2057505,
+    "ward_number": 25,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 26",
+    "type": "neighbourhood",
+    "lat": 13.145318,
+    "lng": 80.2175995,
+    "ward_number": 26,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 27",
+    "type": "neighbourhood",
+    "lat": 13.1583285,
+    "lng": 80.234937,
+    "ward_number": 27,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 28",
+    "type": "neighbourhood",
+    "lat": 13.15628,
+    "lng": 80.2487285,
+    "ward_number": 28,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 29",
+    "type": "neighbourhood",
+    "lat": 13.1546475,
+    "lng": 80.261915,
+    "ward_number": 29,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 3",
+    "type": "neighbourhood",
+    "lat": 13.196969,
+    "lng": 80.3130165,
+    "ward_number": 3,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 30",
+    "type": "neighbourhood",
+    "lat": 13.1467355,
+    "lng": 80.2353355,
+    "ward_number": 30,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 31",
+    "type": "neighbourhood",
+    "lat": 13.13815,
+    "lng": 80.2332855,
+    "ward_number": 31,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 32",
+    "type": "neighbourhood",
+    "lat": 13.1323855,
+    "lng": 80.2073985,
+    "ward_number": 32,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 33",
+    "type": "neighbourhood",
+    "lat": 13.1321305,
+    "lng": 80.231436,
+    "ward_number": 33,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "CMWSSB Division 34",
+    "type": "neighbourhood",
+    "lat": 13.1388565,
+    "lng": 80.249735,
+    "ward_number": 34,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 35",
+    "type": "neighbourhood",
+    "lat": 13.130208,
+    "lng": 80.250176,
+    "ward_number": 35,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 36",
+    "type": "neighbourhood",
+    "lat": 13.124,
+    "lng": 80.2539295,
+    "ward_number": 36,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 37",
+    "type": "neighbourhood",
+    "lat": 13.131953,
+    "lng": 80.26831,
+    "ward_number": 37,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 38",
+    "type": "neighbourhood",
+    "lat": 13.1330631,
+    "lng": 80.2816885,
+    "ward_number": 38,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 39",
+    "type": "neighbourhood",
+    "lat": 13.1384795,
+    "lng": 80.2936755,
+    "ward_number": 39,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 4",
+    "type": "neighbourhood",
+    "lat": 13.185538,
+    "lng": 80.304484,
+    "ward_number": 4,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 40",
+    "type": "neighbourhood",
+    "lat": 13.1363065,
+    "lng": 80.289567,
+    "ward_number": 40,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 41",
+    "type": "neighbourhood",
+    "lat": 13.124806,
+    "lng": 80.275714,
+    "ward_number": 41,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 42",
+    "type": "neighbourhood",
+    "lat": 13.1295114,
+    "lng": 80.2846044,
+    "ward_number": 38,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 44",
+    "type": "neighbourhood",
+    "lat": 13.117629,
+    "lng": 80.2483065,
+    "ward_number": 44,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 45",
+    "type": "neighbourhood",
+    "lat": 13.1137725,
+    "lng": 80.258548,
+    "ward_number": 45,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 46",
+    "type": "neighbourhood",
+    "lat": 13.11235,
+    "lng": 80.2667625,
+    "ward_number": 46,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 47",
+    "type": "neighbourhood",
+    "lat": 13.1154775,
+    "lng": 80.2753016,
+    "ward_number": 47,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 48",
+    "type": "neighbourhood",
+    "lat": 13.1172402,
+    "lng": 80.28223,
+    "ward_number": 48,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 49",
+    "type": "neighbourhood",
+    "lat": 13.1177802,
+    "lng": 80.2892557,
+    "ward_number": 49,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 5",
+    "type": "neighbourhood",
+    "lat": 13.1784415,
+    "lng": 80.309911,
+    "ward_number": 5,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 50",
+    "type": "neighbourhood",
+    "lat": 13.1129925,
+    "lng": 80.296612,
+    "ward_number": 50,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 51",
+    "type": "neighbourhood",
+    "lat": 13.1127785,
+    "lng": 80.2848675,
+    "ward_number": 48,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "CMWSSB Division 52",
+    "type": "neighbourhood",
+    "lat": 13.107194,
+    "lng": 80.2891595,
+    "ward_number": 52,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 53",
+    "type": "neighbourhood",
+    "lat": 13.1062775,
+    "lng": 80.276023,
+    "ward_number": 53,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 54",
+    "type": "neighbourhood",
+    "lat": 13.0999435,
+    "lng": 80.2768725,
+    "ward_number": 54,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 55",
+    "type": "neighbourhood",
+    "lat": 13.0998375,
+    "lng": 80.2831185,
+    "ward_number": 55,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 56",
+    "type": "neighbourhood",
+    "lat": 13.1006452,
+    "lng": 80.287211,
+    "ward_number": 56,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 57",
+    "type": "neighbourhood",
+    "lat": 13.092618,
+    "lng": 80.279703,
+    "ward_number": 57,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 58",
+    "type": "neighbourhood",
+    "lat": 13.0843165,
+    "lng": 80.2645535,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 59",
+    "type": "neighbourhood",
+    "lat": 13.0776925,
+    "lng": 80.2778575,
+    "ward_number": 59,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 6",
+    "type": "neighbourhood",
+    "lat": 13.178326,
+    "lng": 80.2949835,
+    "ward_number": 6,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 60",
+    "type": "neighbourhood",
+    "lat": 13.084413,
+    "lng": 80.289149,
+    "ward_number": 60,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 61",
+    "type": "neighbourhood",
+    "lat": 13.070978,
+    "lng": 80.2582985,
+    "ward_number": 61,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 62",
+    "type": "neighbourhood",
+    "lat": 13.07445,
+    "lng": 80.270243,
+    "ward_number": 62,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 63",
+    "type": "neighbourhood",
+    "lat": 13.067348,
+    "lng": 80.2661115,
+    "ward_number": 63,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 64",
+    "type": "neighbourhood",
+    "lat": 13.123836,
+    "lng": 80.21592,
+    "ward_number": 64,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 65",
+    "type": "neighbourhood",
+    "lat": 13.12034,
+    "lng": 80.210752,
+    "ward_number": 64,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 66",
+    "type": "neighbourhood",
+    "lat": 13.11848,
+    "lng": 80.226157,
+    "ward_number": 66,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 67",
+    "type": "neighbourhood",
+    "lat": 13.11217,
+    "lng": 80.225808,
+    "ward_number": 66,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 68",
+    "type": "neighbourhood",
+    "lat": 13.1194005,
+    "lng": 80.2371625,
+    "ward_number": 68,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 69",
+    "type": "neighbourhood",
+    "lat": 13.1125765,
+    "lng": 80.240853,
+    "ward_number": 69,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 7",
+    "type": "neighbourhood",
+    "lat": 13.1582955,
+    "lng": 80.28331,
+    "ward_number": 7,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 70",
+    "type": "neighbourhood",
+    "lat": 13.108974,
+    "lng": 80.2514975,
+    "ward_number": 70,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 71",
+    "type": "neighbourhood",
+    "lat": 13.1027565,
+    "lng": 80.2473735,
+    "ward_number": 71,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 72",
+    "type": "neighbourhood",
+    "lat": 13.103171,
+    "lng": 80.266742,
+    "ward_number": 72,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 73",
+    "type": "neighbourhood",
+    "lat": 13.101248,
+    "lng": 80.2595955,
+    "ward_number": 73,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 74",
+    "type": "neighbourhood",
+    "lat": 13.092366,
+    "lng": 80.2458635,
+    "ward_number": 74,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 75",
+    "type": "neighbourhood",
+    "lat": 13.0945305,
+    "lng": 80.2518585,
+    "ward_number": 75,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 76",
+    "type": "neighbourhood",
+    "lat": 13.0966005,
+    "lng": 80.2583185,
+    "ward_number": 76,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 77",
+    "type": "neighbourhood",
+    "lat": 13.09529,
+    "lng": 80.2674805,
+    "ward_number": 77,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "CMWSSB Division 78",
+    "type": "neighbourhood",
+    "lat": 13.090193,
+    "lng": 80.2616475,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "CMWSSB Division 79",
+    "type": "neighbourhood",
+    "lat": 13.132145,
+    "lng": 80.152232,
+    "ward_number": 79,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 8",
+    "type": "neighbourhood",
+    "lat": 13.166382,
+    "lng": 80.306687,
+    "ward_number": 8,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 80",
+    "type": "neighbourhood",
+    "lat": 13.1316055,
+    "lng": 80.159166,
+    "ward_number": 80,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 81",
+    "type": "neighbourhood",
+    "lat": 13.1197345,
+    "lng": 80.15151,
+    "ward_number": 81,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 82",
+    "type": "neighbourhood",
+    "lat": 13.12817,
+    "lng": 80.1689,
+    "ward_number": 82,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 83",
+    "type": "neighbourhood",
+    "lat": 13.1235685,
+    "lng": 80.188463,
+    "ward_number": 83,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 84",
+    "type": "neighbourhood",
+    "lat": 13.1066655,
+    "lng": 80.179608,
+    "ward_number": 84,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 85",
+    "type": "neighbourhood",
+    "lat": 13.106241,
+    "lng": 80.1572235,
+    "ward_number": 85,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 86",
+    "type": "neighbourhood",
+    "lat": 13.0919205,
+    "lng": 80.160931,
+    "ward_number": 86,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 87",
+    "type": "neighbourhood",
+    "lat": 13.09496,
+    "lng": 80.1829345,
+    "ward_number": 87,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 88",
+    "type": "neighbourhood",
+    "lat": 13.096204,
+    "lng": 80.1903005,
+    "ward_number": 88,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 89",
+    "type": "neighbourhood",
+    "lat": 13.091131,
+    "lng": 80.1849805,
+    "ward_number": 87,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 9",
+    "type": "neighbourhood",
+    "lat": 13.162877,
+    "lng": 80.306183,
+    "ward_number": 9,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "CMWSSB Division 90",
+    "type": "neighbourhood",
+    "lat": 13.086623,
+    "lng": 80.193566,
+    "ward_number": 90,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 91",
+    "type": "neighbourhood",
+    "lat": 13.081328,
+    "lng": 80.171346,
+    "ward_number": 143,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "CMWSSB Division 92",
+    "type": "neighbourhood",
+    "lat": 13.0804245,
+    "lng": 80.178748,
+    "ward_number": 91,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 93",
+    "type": "neighbourhood",
+    "lat": 13.079966,
+    "lng": 80.189684,
+    "ward_number": 90,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "CMWSSB Division 94",
+    "type": "neighbourhood",
+    "lat": 13.110405,
+    "lng": 80.20261,
+    "ward_number": 94,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 95",
+    "type": "neighbourhood",
+    "lat": 13.101414,
+    "lng": 80.2058325,
+    "ward_number": 95,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 96",
+    "type": "neighbourhood",
+    "lat": 13.10273,
+    "lng": 80.2280345,
+    "ward_number": 96,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 97",
+    "type": "neighbourhood",
+    "lat": 13.093819,
+    "lng": 80.2274975,
+    "ward_number": 97,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 98",
+    "type": "neighbourhood",
+    "lat": 13.091103,
+    "lng": 80.238072,
+    "ward_number": 98,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "CMWSSB Division 99",
+    "type": "neighbourhood",
+    "lat": 13.0861955,
+    "lng": 80.2031065,
+    "ward_number": 99,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Damodarapuram",
+    "type": "neighbourhood",
+    "lat": 13.0018073,
+    "lng": 80.2629813,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Dandhesswaram",
+    "type": "neighbourhood",
+    "lat": 12.9826389,
+    "lng": 80.224188,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Devendra Nagar",
+    "name_ta": "தேவேந்திர நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9787571,
+    "lng": 80.25546,
+    "ward_number": 182,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Doveton",
+    "type": "neighbourhood",
+    "lat": 13.0873218,
+    "lng": 80.258079,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Dr Ambedkar Nagar",
+    "name_ta": "டாக்டர் அம்பேத்கர் நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9900554,
+    "lng": 80.2074843,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Dwaraka Nagar",
+    "type": "suburb",
+    "lat": 13.1941304,
+    "lng": 80.2742752,
+    "ward_number": 16,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "E Block",
+    "type": "neighbourhood",
+    "lat": 13.0869258,
+    "lng": 80.2194441,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "East Abhiramapuram",
+    "type": "neighbourhood",
+    "lat": 13.0342682,
+    "lng": 80.2617914,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Edayanchavadi",
+    "name_ta": "இடையன்சாவடி",
+    "type": "suburb",
+    "lat": 13.2169796,
+    "lng": 80.2850172,
+    "ward_number": 15,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "Egmore",
+    "name_ta": "எழும்பூர்",
+    "type": "suburb",
+    "lat": 13.0728321,
+    "lng": 80.2576906,
+    "ward_number": 61,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Ekkattuthangal",
+    "name_ta": "ஈக்காட்டுத்தாங்கல்",
+    "type": "suburb",
+    "lat": 13.0242453,
+    "lng": 80.2065506,
+    "ward_number": 170,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ellaiamman Colony",
+    "type": "neighbourhood",
+    "lat": 13.0469862,
+    "lng": 80.2519362,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Ennore",
+    "name_ta": "எண்ணூர்",
+    "type": "suburb",
+    "lat": 13.2258262,
+    "lng": 80.3243551,
+    "ward_number": 1,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Ernavur",
+    "name_ta": "எர்ணாவூர்",
+    "type": "suburb",
+    "lat": 13.1893545,
+    "lng": 80.3111383,
+    "ward_number": 3,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Evening Bazaar",
+    "type": "neighbourhood",
+    "lat": 13.0849322,
+    "lng": 80.2787202,
+    "ward_number": 59,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "F Block",
+    "type": "neighbourhood",
+    "lat": 13.0868298,
+    "lng": 80.2216363,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Flower Bazaar",
+    "name_ta": "பூக்கடை",
+    "type": "neighbourhood",
+    "lat": 13.089344,
+    "lng": 80.2819705,
+    "ward_number": 57,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Foreshore Estate",
+    "name_ta": "பட்டினம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0249209,
+    "lng": 80.2776875,
+    "ward_number": 126,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Ganapathy Colony",
+    "name_ta": "கணபதி காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0508508,
+    "lng": 80.2597323,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Gandhi Nagar",
+    "name_ta": "காந்தி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0412679,
+    "lng": 80.1871827,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Gandhinagar",
+    "name_ta": "காந்தி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0089932,
+    "lng": 80.2538632,
+    "ward_number": 175,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ganesapuram",
+    "name_ta": "கணேசபுரம்",
+    "type": "neighbourhood",
+    "lat": 13.0308533,
+    "lng": 80.2450086,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Gangai Nagar",
+    "name_ta": "கங்கை நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9835252,
+    "lng": 80.2159236,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Gemini",
+    "name_ta": "ஜெமினி",
+    "type": "neighbourhood",
+    "lat": 13.0521036,
+    "lng": 80.2500075,
+    "ward_number": 113,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "George Town",
+    "name_ta": "முத்தியால்பேட்டை",
+    "type": "suburb",
+    "lat": 13.0920917,
+    "lng": 80.2822426,
+    "ward_number": 57,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "GOCHS Colony",
+    "name_ta": "ஜிஓசிஹெச்எஸ் காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9978724,
+    "lng": 80.2691711,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Gopalapuram",
+    "name_ta": "கோபாலபுரம்",
+    "type": "suburb",
+    "lat": 13.0497324,
+    "lng": 80.2582028,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Government Estate",
+    "type": "neighbourhood",
+    "lat": 13.0673606,
+    "lng": 80.2767992,
+    "ward_number": 59,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Govindaswamy Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9685697,
+    "lng": 80.2459158,
+    "ward_number": 184,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Grace Garden",
+    "type": "neighbourhood",
+    "lat": 13.11809,
+    "lng": 80.2914726,
+    "ward_number": 49,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Guindy",
+    "name_ta": "கிண்டி",
+    "type": "suburb",
+    "lat": 13.0087095,
+    "lng": 80.2203646,
+    "ward_number": 174,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "ICF Colony",
+    "type": "suburb",
+    "lat": 13.0995307,
+    "lng": 80.2202379,
+    "ward_number": 96,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Indra Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0370804,
+    "lng": 80.1887213,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Injambakkam",
+    "name_ta": "ஈஞ்சம்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9189367,
+    "lng": 80.251295,
+    "ward_number": 196,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Isha Garden",
+    "type": "neighbourhood",
+    "lat": 12.9138218,
+    "lng": 80.2020278,
+    "ward_number": 191,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Island Grounds",
+    "name_ta": "தீவு மைதானம்",
+    "type": "suburb",
+    "lat": 13.0742005,
+    "lng": 80.2793622,
+    "ward_number": 60,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Jafferkhanpet",
+    "name_ta": "ஜாஃபர்கான் பேட்டை",
+    "type": "suburb",
+    "lat": 13.0299401,
+    "lng": 80.2056195,
+    "ward_number": 138,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "JagannathaPuram",
+    "type": "neighbourhood",
+    "lat": 12.9846819,
+    "lng": 80.2218917,
+    "ward_number": 178,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Jalladampet",
+    "type": "suburb",
+    "lat": 12.9197533,
+    "lng": 80.2016924,
+    "ward_number": 191,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Janaki Nagar",
+    "name_ta": "ஜானகி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0401703,
+    "lng": 80.1820728,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Jayachandran Nagar",
+    "name_ta": "ஜெயச்சந்திரன் நகர்",
+    "type": "suburb",
+    "lat": 12.9216334,
+    "lng": 80.1987877,
+    "ward_number": 191,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Jayendra Colony",
+    "name_ta": "ஜெயேந்திர காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9698277,
+    "lng": 80.2482316,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Jeevarathinam Nagar",
+    "type": "neighbourhood",
+    "lat": 13.002057,
+    "lng": 80.2606946,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Jeth Nagar",
+    "type": "neighbourhood",
+    "lat": 13.027831,
+    "lng": 80.262238,
+    "ward_number": 126,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Jothiammal Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0195105,
+    "lng": 80.2288972,
+    "ward_number": 171,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Judge's Colony",
+    "type": "neighbourhood",
+    "lat": 12.9759601,
+    "lng": 80.2481745,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "K.K.Nagar",
+    "type": "suburb",
+    "lat": 13.0407235,
+    "lng": 80.1992108,
+    "ward_number": 137,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Kadapakkam",
+    "type": "suburb",
+    "lat": 13.1984914,
+    "lng": 80.2652515,
+    "ward_number": 16,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "Kaladipet",
+    "type": "neighbourhood",
+    "lat": 13.1515971,
+    "lng": 80.2987772,
+    "ward_number": 12,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Kamakoti Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9410358,
+    "lng": 80.2132684,
+    "ward_number": 189,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Kamarajar Colony",
+    "name_ta": "காமராஜர் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0499741,
+    "lng": 80.2201288,
+    "ward_number": 134,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Kamatchi Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9445831,
+    "lng": 80.2158648,
+    "ward_number": 189,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Kandaswamy Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9661782,
+    "lng": 80.2548185,
+    "ward_number": 185,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Kannagi Nagar",
+    "name_ta": "கண்ணகி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.927645,
+    "lng": 80.2396671,
+    "ward_number": 195,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Kannammapet",
+    "name_ta": "கண்ணம்மாபேட்டை",
+    "type": "neighbourhood",
+    "lat": 13.0323256,
+    "lng": 80.2280783,
+    "ward_number": 141,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Kannan Nagar",
+    "name_ta": "கண்ணன் நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9699068,
+    "lng": 80.1893164,
+    "ward_number": 167,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Kannappa Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9755547,
+    "lng": 80.2569078,
+    "ward_number": 182,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Karampakkam",
+    "name_ta": "காரம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0394382,
+    "lng": 80.1535619,
+    "ward_number": 150,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Karapakkam",
+    "name_ta": "காரப்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9117073,
+    "lng": 80.2277203,
+    "ward_number": 197,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Kargil Nagar",
+    "type": "suburb",
+    "lat": 13.1730186,
+    "lng": 80.2922411,
+    "ward_number": 6,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Karpagam Avenue",
+    "type": "neighbourhood",
+    "lat": 13.0219794,
+    "lng": 80.2678296,
+    "ward_number": 173,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Karpagam Garden",
+    "name_ta": "கற்பகம் கார்டன்",
+    "type": "neighbourhood",
+    "lat": 13.0071776,
+    "lng": 80.2615446,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Karthikeyapuram",
+    "type": "neighbourhood",
+    "lat": 12.9625935,
+    "lng": 80.1945242,
+    "ward_number": 187,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Kasturibai Nagar",
+    "name_ta": "கஸ்தூரிபாய் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0040436,
+    "lng": 80.2509384,
+    "ward_number": 175,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Kathirvedu",
+    "name_ta": "கதிர்வேடு",
+    "type": "suburb",
+    "lat": 13.1487214,
+    "lng": 80.203556,
+    "ward_number": 25,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Kathivakkam",
+    "name_ta": "கத்திவாக்கம்",
+    "type": "suburb",
+    "lat": 13.2141807,
+    "lng": 80.3187499,
+    "ward_number": 2,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Kaveri Rangan Colony",
+    "name_ta": "காவேரி ரங்கன் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0537639,
+    "lng": 80.2012328,
+    "ward_number": 129,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Kellys",
+    "type": "neighbourhood",
+    "lat": 13.0828189,
+    "lng": 80.2433281,
+    "ward_number": 103,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Kesavaperumalpuram",
+    "type": "neighbourhood",
+    "lat": 13.0211245,
+    "lng": 80.2541184,
+    "ward_number": 173,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Kilpauk",
+    "name_ta": "கீழ்ப்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0832149,
+    "lng": 80.2379864,
+    "ward_number": 103,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Kilpauk Garden",
+    "type": "neighbourhood",
+    "lat": 13.0845407,
+    "lng": 80.2311064,
+    "ward_number": 102,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Kodambakkam",
+    "name_ta": "கோடம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.049207,
+    "lng": 80.2242829,
+    "ward_number": 134,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Kodungaiyur",
+    "name_ta": "கொடுங்கையூர்",
+    "type": "suburb",
+    "lat": 13.1327533,
+    "lng": 80.2444773,
+    "ward_number": 35,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Kolathur",
+    "name_ta": "கொளத்தூர்",
+    "type": "suburb",
+    "lat": 13.1241127,
+    "lng": 80.2046276,
+    "ward_number": 65,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Korattur",
+    "name_ta": "கொரட்டூர்",
+    "type": "suburb",
+    "lat": 13.1115484,
+    "lng": 80.1846272,
+    "ward_number": 83,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Korukkupet",
+    "name_ta": "கோருக்குப்பெட்டை",
+    "type": "suburb",
+    "lat": 13.1215344,
+    "lng": 80.2837912,
+    "ward_number": 42,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Kothari Nagar",
+    "name_ta": "கோத்தாரி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0352116,
+    "lng": 80.1851019,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Kottivakkam",
+    "name_ta": "கொட்டிவாக்கம்",
+    "type": "suburb",
+    "lat": 12.9705053,
+    "lng": 80.2615033,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Kottur Gardens",
+    "type": "neighbourhood",
+    "lat": 13.0206311,
+    "lng": 80.2441277,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Kotturpuram",
+    "name_ta": "கோட்டூர்புரம்",
+    "type": "suburb",
+    "lat": 13.0193703,
+    "lng": 80.2435512,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Krishna Nagar, Periyar Road",
+    "type": "neighbourhood",
+    "lat": 13.015122,
+    "lng": 80.1721409,
+    "ward_number": 157,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Kuberan Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9574931,
+    "lng": 80.2062346,
+    "ward_number": 188,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Labour Colony",
+    "type": "neighbourhood",
+    "lat": 13.0154717,
+    "lng": 80.2094084,
+    "ward_number": 170,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Lakshmi Hayagriva Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9854291,
+    "lng": 80.212138,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Little Mount",
+    "name_ta": "சின்னமலை",
+    "type": "suburb",
+    "lat": 13.0141864,
+    "lng": 80.2266882,
+    "ward_number": 171,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Lloyds Colony",
+    "type": "neighbourhood",
+    "lat": 13.0490735,
+    "lng": 80.2715991,
+    "ward_number": 120,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Lock Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0665028,
+    "lng": 80.2815982,
+    "ward_number": 114,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Lotus Colony",
+    "type": "neighbourhood",
+    "lat": 13.0296417,
+    "lng": 80.2403771,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Madhavaram",
+    "name_ta": "மாதவரம்",
+    "type": "suburb",
+    "lat": 13.1429313,
+    "lng": 80.2325166,
+    "ward_number": 31,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Madhavaram Milk Colony",
+    "name_ta": "மாதவரம் பால் காலனி",
+    "type": "suburb",
+    "lat": 13.1554081,
+    "lng": 80.2425246,
+    "ward_number": 28,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Madipakkam",
+    "name_ta": "மடிப்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9611348,
+    "lng": 80.2001292,
+    "ward_number": 188,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Madura Kali Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9580319,
+    "lng": 80.1938321,
+    "ward_number": 187,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Maduravoyal",
+    "name_ta": "மதுரவாயல்",
+    "type": "suburb",
+    "lat": 13.0601732,
+    "lng": 80.1665988,
+    "ward_number": 147,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Mahalingapuram",
+    "type": "neighbourhood",
+    "lat": 13.0567826,
+    "lng": 80.2364037,
+    "ward_number": 110,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Mahaveer Colony",
+    "name_ta": "மஹாவீர் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0829169,
+    "lng": 80.2615578,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Majestic Colony",
+    "name_ta": "மெஜஸ்டிக் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0385477,
+    "lng": 80.1799846,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Malar Colony",
+    "type": "neighbourhood",
+    "lat": 13.0977956,
+    "lng": 80.1989321,
+    "ward_number": 95,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Manali",
+    "name_ta": "மணலி",
+    "type": "suburb",
+    "lat": 13.1672275,
+    "lng": 80.2598107,
+    "ward_number": 21,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "Manapakkam",
+    "name_ta": "மணப்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0147531,
+    "lng": 80.1744935,
+    "ward_number": 157,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Mandaveli",
+    "name_ta": "மந்தைவெளி",
+    "type": "suburb",
+    "lat": 13.0258445,
+    "lng": 80.2627877,
+    "ward_number": 126,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Mathur",
+    "name_ta": "மாத்தூர்",
+    "type": "suburb",
+    "lat": 13.1678641,
+    "lng": 80.2436918,
+    "ward_number": 19,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "Mattankuppam",
+    "name_ta": "மட்டன்குப்பம்",
+    "type": "neighbourhood",
+    "lat": 13.05672,
+    "lng": 80.2797427,
+    "ward_number": 116,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Meenambakkam",
+    "name_ta": "மீனம்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9866009,
+    "lng": 80.1726357,
+    "ward_number": 159,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Mehta Nagar",
+    "name_ta": "மேத்தா நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0703783,
+    "lng": 80.2268067,
+    "ward_number": 106,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Metukuppam",
+    "type": "neighbourhood",
+    "lat": 12.9365399,
+    "lng": 80.2374231,
+    "ward_number": 194,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "MGR Nagar",
+    "name_ta": "எம்.ஜி.ஆர் நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9795827,
+    "lng": 80.2494441,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Mogappair East",
+    "name_ta": "முகப்பேர் கிழக்கு",
+    "type": "suburb",
+    "lat": 13.0835142,
+    "lng": 80.1840779,
+    "ward_number": 93,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Moogambigai Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0372422,
+    "lng": 80.1851369,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Moolakothalam",
+    "type": "neighbourhood",
+    "lat": 13.1067345,
+    "lng": 80.2764807,
+    "ward_number": 53,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Moovarasampettai",
+    "name_ta": "மூவரசம்பேட்டை",
+    "type": "suburb",
+    "lat": 12.9693665,
+    "lng": 80.1833591,
+    "ward_number": 167,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "MRC Nagar",
+    "type": "suburb",
+    "lat": 13.0196693,
+    "lng": 80.2706525,
+    "ward_number": 173,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Mugalivakkam",
+    "type": "neighbourhood",
+    "lat": 13.019487,
+    "lng": 80.1609715,
+    "ward_number": 156,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Mylapore",
+    "name_ta": "மயிலாப்பூர்",
+    "type": "suburb",
+    "lat": 13.0316473,
+    "lng": 80.2700166,
+    "ward_number": 124,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Nagerkoyil Sudalaimuthu Krishnan Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0777508,
+    "lng": 80.2167134,
+    "ward_number": 100,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Nandambakkam",
+    "name_ta": "நந்தம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0166484,
+    "lng": 80.1911885,
+    "ward_number": 158,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Nandanam",
+    "name_ta": "நந்தனம்",
+    "type": "suburb",
+    "lat": 13.0286286,
+    "lng": 80.240256,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Nandanam Extension",
+    "type": "neighbourhood",
+    "lat": 13.0281859,
+    "lng": 80.2433142,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Nanganallur",
+    "name_ta": "நங்கநல்லூர்",
+    "type": "suburb",
+    "lat": 12.9801242,
+    "lng": 80.184902,
+    "ward_number": 167,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Nanganallur Co-op Society Colony",
+    "type": "neighbourhood",
+    "lat": 12.9879605,
+    "lng": 80.1905915,
+    "ward_number": 164,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Narasimha Nagar",
+    "type": "neighbourhood",
+    "lat": 13.1047765,
+    "lng": 80.2661886,
+    "ward_number": 72,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Narayanapuram",
+    "type": "suburb",
+    "lat": 12.9417967,
+    "lng": 80.2083837,
+    "ward_number": 189,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "NATCO Colony",
+    "type": "neighbourhood",
+    "lat": 12.9707301,
+    "lng": 80.2570084,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Natesan Colony",
+    "type": "neighbourhood",
+    "lat": 12.9730941,
+    "lng": 80.256686,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Nava Bharath Colony",
+    "name_ta": "நவ பரத் காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9900052,
+    "lng": 80.2666669,
+    "ward_number": 181,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "NCBS Colony",
+    "type": "neighbourhood",
+    "lat": 12.9854635,
+    "lng": 80.1896961,
+    "ward_number": 164,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Neelankarai",
+    "name_ta": "நீலாங்கரை",
+    "type": "suburb",
+    "lat": 12.9454955,
+    "lng": 80.2574692,
+    "ward_number": 192,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Nehru Nagar",
+    "name_ta": "நேரு நகர்",
+    "type": "neighbourhood",
+    "lat": 13.2159326,
+    "lng": 80.3187286,
+    "ward_number": 2,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Nehru Nagar Industrial Estate",
+    "name_ta": "நேரு நகர் தொழிற்பேட்டை",
+    "type": "neighbourhood",
+    "lat": 12.9742161,
+    "lng": 80.2475423,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Nerkundram",
+    "name_ta": "நெற்குன்றம்",
+    "type": "suburb",
+    "lat": 13.0688386,
+    "lng": 80.1838987,
+    "ward_number": 145,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Nesapakkam",
+    "name_ta": "நெசப்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0336193,
+    "lng": 80.1873092,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "New Colony",
+    "type": "neighbourhood",
+    "lat": 12.9827099,
+    "lng": 80.2322973,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "New Washermanpet",
+    "name_ta": "புதிய வண்ணாரப்பேட்டை",
+    "type": "suburb",
+    "lat": 13.1338663,
+    "lng": 80.2903592,
+    "ward_number": 40,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "NGO Colony",
+    "name_ta": "என்.ஜி.ஓ. காலனி",
+    "type": "neighbourhood",
+    "lat": 13.064553,
+    "lng": 80.2199644,
+    "ward_number": 108,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Nolambur",
+    "name_ta": "நொளம்பூர்",
+    "type": "suburb",
+    "lat": 13.0747182,
+    "lng": 80.1682206,
+    "ward_number": 143,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Nungambakkam",
+    "name_ta": "நுங்கம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0620626,
+    "lng": 80.240487,
+    "ward_number": 110,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Officers Colony",
+    "type": "neighbourhood",
+    "lat": 13.0703159,
+    "lng": 80.2282954,
+    "ward_number": 106,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Old Washermanpet",
+    "name_ta": "பழைய வண்ணாரப்பேட்டை",
+    "type": "neighbourhood",
+    "lat": 13.1122762,
+    "lng": 80.2893812,
+    "ward_number": 49,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Om Sakthi Nagar",
+    "name_ta": "ஓம் சக்தி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0380196,
+    "lng": 80.1867387,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Otteri",
+    "name_ta": "ஓட்டேரி",
+    "type": "suburb",
+    "lat": 13.0969576,
+    "lng": 80.2487215,
+    "ward_number": 74,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Padi",
+    "name_ta": "பாடி",
+    "type": "suburb",
+    "lat": 13.1035851,
+    "lng": 80.1920425,
+    "ward_number": 84,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Padmanabha Nagar",
+    "name_ta": "பத்மநாப நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0045512,
+    "lng": 80.2587292,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Palavakkam",
+    "name_ta": "பாலவாக்கம்",
+    "type": "suburb",
+    "lat": 12.95999,
+    "lng": 80.2560268,
+    "ward_number": 185,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Pallikaranai",
+    "name_ta": "பள்ளிக்கரணை",
+    "type": "suburb",
+    "lat": 12.9304748,
+    "lng": 80.2077692,
+    "ward_number": 190,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Parameswari Nagar",
+    "name_ta": "பரமேஸ்வரி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0027868,
+    "lng": 80.2581254,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Park Square colony",
+    "type": "neighbourhood",
+    "lat": 12.9656647,
+    "lng": 80.1934861,
+    "ward_number": 187,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Park Town",
+    "name_ta": "பூங்கா நகர",
+    "type": "suburb",
+    "lat": 13.0863491,
+    "lng": 80.2727321,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Pazhavanthangal",
+    "name_ta": "பழவந்தாங்கல்",
+    "type": "suburb",
+    "lat": 12.9883524,
+    "lng": 80.1891324,
+    "ward_number": 162,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Perambur",
+    "name_ta": "பெரம்பூர்",
+    "type": "suburb",
+    "lat": 13.1121242,
+    "lng": 80.245022,
+    "ward_number": 70,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Periamet",
+    "type": "neighbourhood",
+    "lat": 13.0844145,
+    "lng": 80.2692766,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Periyar Nagar",
+    "name_ta": "பெரியார் நகர்",
+    "type": "suburb",
+    "lat": 13.1151671,
+    "lng": 80.223666,
+    "ward_number": 66,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Perungudi",
+    "name_ta": "பெருங்குடி",
+    "type": "suburb",
+    "lat": 12.9710239,
+    "lng": 80.2418051,
+    "ward_number": 184,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Poes Garden",
+    "name_ta": "போயஸ் கார்டன்",
+    "type": "neighbourhood",
+    "lat": 13.0437065,
+    "lng": 80.253316,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Porur",
+    "name_ta": "போரூர்",
+    "type": "suburb",
+    "lat": 13.0320131,
+    "lng": 80.158304,
+    "ward_number": 153,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Postal Colony",
+    "name_ta": "தபால் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.036329,
+    "lng": 80.2195477,
+    "ward_number": 135,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "PTC Colony",
+    "type": "neighbourhood",
+    "lat": 12.9763834,
+    "lng": 80.2565187,
+    "ward_number": 182,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Pudupet",
+    "type": "neighbourhood",
+    "lat": 13.0712018,
+    "lng": 80.2669603,
+    "ward_number": 63,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Pulianthope",
+    "name_ta": "புளியந்தோப்பு",
+    "type": "suburb",
+    "lat": 13.1003849,
+    "lng": 80.2683122,
+    "ward_number": 72,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Purasawalkam",
+    "name_ta": "புரசைவாக்கம்",
+    "type": "suburb",
+    "lat": 13.0893275,
+    "lng": 80.2550331,
+    "ward_number": 78,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Pushpa Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0594569,
+    "lng": 80.2389972,
+    "ward_number": 110,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Puthagaram",
+    "name_ta": "புத்தகரம்",
+    "type": "suburb",
+    "lat": 13.1346231,
+    "lng": 80.1978478,
+    "ward_number": 24,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Puzhal",
+    "name_ta": "புழல்",
+    "type": "suburb",
+    "lat": 13.1636492,
+    "lng": 80.2038067,
+    "ward_number": 23,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Puzhuthivakkam",
+    "name_ta": "புழுதிவாக்கம்",
+    "type": "suburb",
+    "lat": 12.9691428,
+    "lng": 80.2062626,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "PVS Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9476068,
+    "lng": 80.242015,
+    "ward_number": 193,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Raj Bhavan",
+    "name_ta": "ராஜ் பவன்",
+    "type": "neighbourhood",
+    "lat": 13.0079401,
+    "lng": 80.2263985,
+    "ward_number": 174,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Raja Annamalai Puram",
+    "name_ta": "இராஜா அண்ணாமலைபுரம்",
+    "type": "suburb",
+    "lat": 13.0244783,
+    "lng": 80.253937,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Rajalakshmi Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9852883,
+    "lng": 80.2187428,
+    "ward_number": 178,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ram Nagar",
+    "name_ta": "ராம் நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9653558,
+    "lng": 80.2118131,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Ramakrishna Nagar",
+    "name_ta": "ராமகிருஷ்ணா நகர்",
+    "type": "neighbourhood",
+    "lat": 13.024366,
+    "lng": 80.261062,
+    "ward_number": 173,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ramalinga Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9675942,
+    "lng": 80.2058513,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Ramapuram",
+    "name_ta": "ராமாவரம்",
+    "type": "suburb",
+    "lat": 13.0298609,
+    "lng": 80.1780333,
+    "ward_number": 154,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Reserve Bank Staff Quarters",
+    "type": "quarter",
+    "lat": 13.0785501,
+    "lng": 80.2391628,
+    "ward_number": 103,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Royapettah",
+    "name_ta": "ராயப்பேட்டை",
+    "type": "suburb",
+    "lat": 13.0554718,
+    "lng": 80.2639706,
+    "ward_number": 115,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Royapuram",
+    "name_ta": "ராயபுரம்",
+    "type": "suburb",
+    "lat": 13.1146195,
+    "lng": 80.2940279,
+    "ward_number": 50,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "S and P Garden",
+    "type": "neighbourhood",
+    "lat": 13.0668681,
+    "lng": 80.1634939,
+    "ward_number": 143,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Sadasiva Nagar",
+    "name_ta": "சதாசிவ நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9651292,
+    "lng": 80.2028543,
+    "ward_number": 188,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Sai Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9516304,
+    "lng": 80.2344713,
+    "ward_number": 193,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Saidapet",
+    "name_ta": "சைதாப்பேட்டை",
+    "type": "suburb",
+    "lat": 13.020817,
+    "lng": 80.2239536,
+    "ward_number": 142,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Saidayankuppam",
+    "name_ta": "சைதையாங்குப்பம்",
+    "type": "suburb",
+    "lat": 13.1854785,
+    "lng": 80.2924308,
+    "ward_number": 16,
+    "zone_name": "MANALI",
+    "zone_no": "II"
+  },
+  {
+    "name": "Saligramam",
+    "name_ta": "சாலிகிராமம்",
+    "type": "suburb",
+    "lat": 13.0583406,
+    "lng": 80.1985327,
+    "ward_number": 127,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Sangam Colony",
+    "type": "neighbourhood",
+    "lat": 12.9673858,
+    "lng": 80.2558203,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Santhome",
+    "name_ta": "சாந்தோம்",
+    "type": "suburb",
+    "lat": 13.0298372,
+    "lng": 80.275738,
+    "ward_number": 125,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Sathya Garden",
+    "type": "neighbourhood",
+    "lat": 13.0455466,
+    "lng": 80.1982546,
+    "ward_number": 131,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "SBI Colony",
+    "name_ta": "எஸ்பிஐ காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0537733,
+    "lng": 80.1989368,
+    "ward_number": 129,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Secretariat Colony",
+    "type": "neighbourhood",
+    "lat": 13.0894501,
+    "lng": 80.2428196,
+    "ward_number": 74,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Seethammal Colony",
+    "type": "neighbourhood",
+    "lat": 13.0359586,
+    "lng": 80.2534418,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Seethammal Colony Ext",
+    "type": "neighbourhood",
+    "lat": 13.0344987,
+    "lng": 80.2474473,
+    "ward_number": 122,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Seethapathy Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9819509,
+    "lng": 80.2270333,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Senthamizh Nagar",
+    "name_ta": "செந்தமிழ் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0347636,
+    "lng": 80.1874367,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Seshadripuram",
+    "type": "neighbourhood",
+    "lat": 12.9798387,
+    "lng": 80.2306689,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Seva Nagar Velachery",
+    "type": "neighbourhood",
+    "lat": 12.9864108,
+    "lng": 80.2293212,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Shastri Nagar",
+    "name_ta": "சாஸ்திரி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9987729,
+    "lng": 80.2599116,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Sheela Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9650499,
+    "lng": 80.2020747,
+    "ward_number": 188,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Shenoy Nagar",
+    "name_ta": "ஷெனாய் நகர்",
+    "type": "suburb",
+    "lat": 13.0786669,
+    "lng": 80.2272547,
+    "ward_number": 102,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "SIDCO Industrial Estate",
+    "name_ta": "சிட்கோ தொழிற்பேட்டை",
+    "type": "suburb",
+    "lat": 13.01407,
+    "lng": 80.2091208,
+    "ward_number": 170,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Sivakami Nagar",
+    "type": "neighbourhood",
+    "lat": 13.1976526,
+    "lng": 80.3172985,
+    "ward_number": 3,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "Sony Nagar",
+    "name_ta": "சோனி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9865105,
+    "lng": 80.2279906,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Sowcarpet",
+    "name_ta": "சௌகார்பேட்டை",
+    "type": "neighbourhood",
+    "lat": 13.0884967,
+    "lng": 80.2783092,
+    "ward_number": 59,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Sri Laxmi Nagar",
+    "name_ta": "ஸ்ரீ லக்ஷ்மி நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0363489,
+    "lng": 80.1806501,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Sri Ragavendra Nagar",
+    "name_ta": "ஸ்ரீ ராகவேந்தரா நகர்",
+    "type": "neighbourhood",
+    "lat": 13.03673,
+    "lng": 80.186351,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Srinagar Colony",
+    "name_ta": "ஸ்ரீநகர் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0134666,
+    "lng": 80.2302782,
+    "ward_number": 171,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Srinivasa Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9503003,
+    "lng": 80.2469674,
+    "ward_number": 193,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Sriram Nagar",
+    "name_ta": "ஸ்ரீராம் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0035494,
+    "lng": 80.2443172,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Stanley Nagar",
+    "type": "neighbourhood",
+    "lat": 13.1092682,
+    "lng": 80.2721885,
+    "ward_number": 53,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Surapattu",
+    "name_ta": "சூரப்பட்டு",
+    "type": "suburb",
+    "lat": 13.1446934,
+    "lng": 80.1850249,
+    "ward_number": 24,
+    "zone_name": "MADHAVARAM",
+    "zone_no": "III"
+  },
+  {
+    "name": "Suresh Nagar",
+    "name_ta": "சுரேஷ் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0376269,
+    "lng": 80.1828189,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Swaminathan Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9713518,
+    "lng": 80.2543421,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "T Block",
+    "type": "neighbourhood",
+    "lat": 13.089406,
+    "lng": 80.2165159,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Tansi Nagar",
+    "name_ta": "டான்சி நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9774585,
+    "lng": 80.2234467,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Taramani",
+    "name_ta": "தரமணி",
+    "type": "suburb",
+    "lat": 12.9849067,
+    "lng": 80.2404069,
+    "ward_number": 180,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Teynampet",
+    "name_ta": "தேனாம்பேட்டை",
+    "type": "suburb",
+    "lat": 13.0443237,
+    "lng": 80.2498455,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Thillai Ganga Nagar",
+    "name_ta": "தில்லை கங்கா நகர்",
+    "type": "neighbourhood",
+    "lat": 12.989843,
+    "lng": 80.1936624,
+    "ward_number": 162,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Thiru Vi Ka Nagar",
+    "type": "suburb",
+    "lat": 13.1103367,
+    "lng": 80.2633882,
+    "ward_number": 45,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Thirumalai Nagar",
+    "name_ta": "திருமலை நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0367037,
+    "lng": 80.1829043,
+    "ward_number": 155,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Thiruvalluvar Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9626104,
+    "lng": 80.2474675,
+    "ward_number": 185,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Thiruvanmiyur",
+    "name_ta": "திருவான்மியூர்",
+    "type": "suburb",
+    "lat": 12.9858948,
+    "lng": 80.2644215,
+    "ward_number": 181,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Thiruvengada Nagar",
+    "name_ta": "திருவேங்கட நகர்",
+    "type": "suburb",
+    "lat": 13.1173939,
+    "lng": 80.1452698,
+    "ward_number": 81,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Thousand Lights",
+    "name_ta": "ஆயிரம் விளக்கு",
+    "type": "suburb",
+    "lat": 13.0587829,
+    "lng": 80.2557114,
+    "ward_number": 111,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Thuraipakkam",
+    "name_ta": "துறைப்பாக்கம்",
+    "type": "suburb",
+    "lat": 12.9385525,
+    "lng": 80.2372132,
+    "ward_number": 194,
+    "zone_name": "SHOLINGANALLUR",
+    "zone_no": "XV"
+  },
+  {
+    "name": "Tirumalai Nagar",
+    "name_ta": "திருமலை நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9718042,
+    "lng": 80.2455776,
+    "ward_number": 184,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Tiruvalluvar Nagar",
+    "name_ta": "திருவள்ளுவர் நகர்",
+    "type": "neighbourhood",
+    "lat": 13.0181474,
+    "lng": 80.2458186,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Tiruvottiyur",
+    "name_ta": "திருவொற்றியூர்",
+    "type": "suburb",
+    "lat": 13.1563873,
+    "lng": 80.3005279,
+    "ward_number": 11,
+    "zone_name": "THIRUVOTTIYUR",
+    "zone_no": "I"
+  },
+  {
+    "name": "TNagar",
+    "type": "suburb",
+    "lat": 13.034405,
+    "lng": 80.2301597,
+    "ward_number": 141,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "TNHB Colony",
+    "name_ta": "டீஎன்ஹெச்பி காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9914196,
+    "lng": 80.2120593,
+    "ward_number": 177,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Todhunter Nagar",
+    "type": "neighbourhood",
+    "lat": 13.0226153,
+    "lng": 80.2308086,
+    "ward_number": 171,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Tollgate",
+    "type": "neighbourhood",
+    "lat": 13.1429527,
+    "lng": 80.2955738,
+    "ward_number": 39,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Tondiarpet",
+    "name_ta": "தண்டையார்பேட்டை",
+    "type": "suburb",
+    "lat": 13.1277669,
+    "lng": 80.2895845,
+    "ward_number": 40,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "Triplicane",
+    "name_ta": "திருவல்லிக்கேணி",
+    "type": "suburb",
+    "lat": 13.0604285,
+    "lng": 80.2750704,
+    "ward_number": 114,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Trustpuram",
+    "name_ta": "டிரஸ்ட் புரம்",
+    "type": "neighbourhood",
+    "lat": 13.0555649,
+    "lng": 80.2233364,
+    "ward_number": 112,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Udhayam Nagar",
+    "name_ta": "உதயம் நகர்",
+    "type": "neighbourhood",
+    "lat": 12.9791677,
+    "lng": 80.2321701,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Ullagaram",
+    "name_ta": "உல்லகரம்",
+    "type": "suburb",
+    "lat": 12.9765868,
+    "lng": 80.1967196,
+    "ward_number": 168,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Union Carbide Colony",
+    "name_ta": "யூனியன் கார்பைட் காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9739802,
+    "lng": 80.1931481,
+    "ward_number": 169,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "United India Colony",
+    "name_ta": "யுனைடெட் இந்தியா காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0511219,
+    "lng": 80.2247578,
+    "ward_number": 134,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Urur Kuppam",
+    "type": "neighbourhood",
+    "lat": 13.0041761,
+    "lng": 80.2732889,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Valasaravakkam",
+    "name_ta": "வளசரவாக்கம்",
+    "type": "suburb",
+    "lat": 13.0410164,
+    "lng": 80.1721682,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Vallalar Nagar",
+    "name_ta": "வள்ளலார் நகர்",
+    "type": "suburb",
+    "lat": 13.1019255,
+    "lng": 80.2787773,
+    "ward_number": 54,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "Vaniya Teynampet",
+    "type": "neighbourhood",
+    "lat": 13.0389894,
+    "lng": 80.248111,
+    "ward_number": 123,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Varadapuram",
+    "type": "neighbourhood",
+    "lat": 13.0154212,
+    "lng": 80.2459988,
+    "ward_number": 172,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Veerappa Nagar",
+    "name_ta": "வீரப்பா நகர்",
+    "type": "neighbourhood",
+    "lat": 13.042342,
+    "lng": 80.1852505,
+    "ward_number": 152,
+    "zone_name": "VALASARAVAKKAM",
+    "zone_no": "XI"
+  },
+  {
+    "name": "Velachery",
+    "name_ta": "வேளச்சேரி",
+    "type": "suburb",
+    "lat": 12.9807243,
+    "lng": 80.2189104,
+    "ward_number": 178,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Velayudam Colony",
+    "type": "neighbourhood",
+    "lat": 13.0497555,
+    "lng": 80.202848,
+    "ward_number": 129,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Venkatapuram",
+    "name_ta": "வெங்கடபுரம்",
+    "type": "suburb",
+    "lat": 13.121015,
+    "lng": 80.1508292,
+    "ward_number": 81,
+    "zone_name": "AMBATTUR",
+    "zone_no": "VII"
+  },
+  {
+    "name": "Venkateshpuram",
+    "type": "neighbourhood",
+    "lat": 12.9689832,
+    "lng": 80.2523969,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Venkateshwara Nagar Colony",
+    "name_ta": "வெங்கடேஸ்வரா நகர் காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9769974,
+    "lng": 80.2446253,
+    "ward_number": 183,
+    "zone_name": "PERUNGUDI",
+    "zone_no": "XIV"
+  },
+  {
+    "name": "Venkateswara Nagar",
+    "name_ta": "வெங்கடேஸ்வரா நகர்",
+    "type": "neighbourhood",
+    "lat": 13.00328,
+    "lng": 80.2620566,
+    "ward_number": 176,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Venus Colony",
+    "name_ta": "வீனஸ் காலனி",
+    "type": "neighbourhood",
+    "lat": 13.0401069,
+    "lng": 80.2549202,
+    "ward_number": 118,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  },
+  {
+    "name": "Vepery",
+    "name_ta": "வேப்பேரி",
+    "type": "suburb",
+    "lat": 13.0842952,
+    "lng": 80.2622738,
+    "ward_number": 58,
+    "zone_name": "ROYAPURAM",
+    "zone_no": "V"
+  },
+  {
+    "name": "VGP Selva Nagar",
+    "type": "neighbourhood",
+    "lat": 12.9712216,
+    "lng": 80.2211034,
+    "ward_number": 179,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Vijaynagar",
+    "name_ta": "விஜயநகர்",
+    "type": "neighbourhood",
+    "lat": 12.9757425,
+    "lng": 80.2209882,
+    "ward_number": 178,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Vikram Sarabhai Industrial Estate",
+    "name_ta": "விக்ரம் சாராபாய் தொழிற்பேட்டை",
+    "type": "neighbourhood",
+    "lat": 12.9809554,
+    "lng": 80.2508748,
+    "ward_number": 180,
+    "zone_name": "ADYAR",
+    "zone_no": "XIII"
+  },
+  {
+    "name": "Villivakkam",
+    "name_ta": "வில்லிவாக்கம்",
+    "type": "suburb",
+    "lat": 13.1125875,
+    "lng": 80.2081378,
+    "ward_number": 65,
+    "zone_name": "THIRU-VI-KA NAGAR",
+    "zone_no": "VI"
+  },
+  {
+    "name": "Virugambakkam",
+    "name_ta": "விருகம்பாக்கம்",
+    "type": "suburb",
+    "lat": 13.0475434,
+    "lng": 80.1922181,
+    "ward_number": 128,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Voltas Colony",
+    "name_ta": "வோல்டாஸ் காலனி",
+    "type": "neighbourhood",
+    "lat": 12.9744987,
+    "lng": 80.1863675,
+    "ward_number": 167,
+    "zone_name": "ALANDUR",
+    "zone_no": "XII"
+  },
+  {
+    "name": "Vyasarpadi",
+    "name_ta": "வியாசர்பாடி",
+    "type": "suburb",
+    "lat": 13.1169726,
+    "lng": 80.2571242,
+    "ward_number": 45,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "W Block",
+    "type": "neighbourhood",
+    "lat": 13.0866698,
+    "lng": 80.2164999,
+    "ward_number": 101,
+    "zone_name": "ANNA NAGAR",
+    "zone_no": "VIII"
+  },
+  {
+    "name": "Washermanpet",
+    "name_ta": "வண்ணாரப்பேட்டை",
+    "type": "suburb",
+    "lat": 13.1136296,
+    "lng": 80.2814813,
+    "ward_number": 48,
+    "zone_name": "TONDIARPET",
+    "zone_no": "IV"
+  },
+  {
+    "name": "West Mambalam",
+    "name_ta": "மேற்கு மாம்பலம்",
+    "type": "suburb",
+    "lat": 13.0428296,
+    "lng": 80.2270184,
+    "ward_number": 135,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "West Saidapet",
+    "name_ta": "மேற்கு சைதாப்பேட்டை",
+    "type": "neighbourhood",
+    "lat": 13.0252576,
+    "lng": 80.2204237,
+    "ward_number": 140,
+    "zone_name": "KODAMBAKKAM",
+    "zone_no": "X"
+  },
+  {
+    "name": "Zam Bazaar",
+    "type": "neighbourhood",
+    "lat": 13.0592958,
+    "lng": 80.2710216,
+    "ward_number": 114,
+    "zone_name": "TEYNAMPET",
+    "zone_no": "IX"
+  }
+]

--- a/scripts/fetch-localities-osm.ts
+++ b/scripts/fetch-localities-osm.ts
@@ -1,0 +1,171 @@
+/**
+ * One-time script: Fetch Chennai neighborhoods/suburbs from OpenStreetMap via Overpass API.
+ * Maps each locality to its ward (via point-in-polygon) and zone (via ward-profiles).
+ * Saves result to public/data/chennai-localities.json
+ *
+ * Run: npx tsx scripts/fetch-localities-osm.ts
+ */
+
+import { writeFileSync, readFileSync } from "fs";
+import { join } from "path";
+import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
+import { point } from "@turf/helpers";
+
+// Greater Chennai Corporation bounding box: south, west, north, east
+const BBOX = "12.90,80.09,13.26,80.36";
+
+const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+
+const QUERY = `
+[out:json][timeout:90];
+(
+  node["place"~"^(suburb|neighbourhood|quarter)$"](${BBOX});
+  way["place"~"^(suburb|neighbourhood|quarter)$"](${BBOX});
+  relation["place"~"^(suburb|neighbourhood|quarter)$"](${BBOX});
+);
+out center tags;
+`.trim();
+
+interface OsmElement {
+  type: "node" | "way" | "relation";
+  id: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  tags?: Record<string, string>;
+}
+
+interface OsmResponse {
+  elements: OsmElement[];
+}
+
+interface WardProfile {
+  ward_number: number;
+  zone_no: string;
+  zone_name: string;
+  centroid: [number, number]; // [lng, lat]
+}
+
+interface WardFeature {
+  type: "Feature";
+  properties: { Ward_No?: number; ward_no?: number; [key: string]: unknown };
+  geometry: { type: string; coordinates: unknown };
+}
+
+export interface LocalityEntry {
+  name: string;
+  name_ta?: string;
+  type: "suburb" | "neighbourhood" | "quarter";
+  lat: number;
+  lng: number;
+  ward_number: number;
+  zone_name: string;
+  zone_no: string;
+}
+
+async function fetchLocalities(): Promise<void> {
+  console.log("Fetching Chennai localities from Overpass API...");
+  const res = await fetch(OVERPASS_URL, {
+    method: "POST",
+    body: new URLSearchParams({ data: QUERY }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  if (!res.ok) throw new Error(`Overpass API error: ${res.status}`);
+  const data: OsmResponse = await res.json();
+  console.log(`Received ${data.elements.length} raw OSM elements`);
+
+  // Load ward GeoJSON
+  const wardGeoPath = join(process.cwd(), "public/geojson/chennai-wards-2022.geojson");
+  const wardGeo = JSON.parse(readFileSync(wardGeoPath, "utf-8"));
+
+  // Load ward profiles for zone info
+  const profilesPath = join(process.cwd(), "public/data/ward-profiles.json");
+  const profiles: WardProfile[] = JSON.parse(readFileSync(profilesPath, "utf-8"));
+  const profileMap = new Map<number, WardProfile>(profiles.map((p) => [p.ward_number, p]));
+
+  // Helper: resolve lat/lng from OSM element
+  function getCoords(el: OsmElement): { lat: number; lng: number } | null {
+    if (el.type === "node" && el.lat != null && el.lon != null) {
+      return { lat: el.lat, lng: el.lon };
+    }
+    if ((el.type === "way" || el.type === "relation") && el.center) {
+      return { lat: el.center.lat, lng: el.center.lon };
+    }
+    return null;
+  }
+
+  // Helper: find ward number from lat/lng using point-in-polygon
+  function findWard(lat: number, lng: number): number | null {
+    const pt = point([lng, lat]);
+    for (const feature of wardGeo.features as WardFeature[]) {
+      try {
+        if (booleanPointInPolygon(pt, feature as Parameters<typeof booleanPointInPolygon>[1])) {
+          const wardNo =
+            feature.properties?.Ward_No ??
+            feature.properties?.ward_no ??
+            feature.properties?.WARD_NO;
+          return typeof wardNo === "number" ? wardNo : null;
+        }
+      } catch {
+        // skip malformed features
+      }
+    }
+    return null;
+  }
+
+  const seen = new Set<string>();
+  const localities: LocalityEntry[] = [];
+
+  for (const el of data.elements) {
+    const tags = el.tags || {};
+    const name = tags["name:en"] || tags["name"] || "";
+    if (!name) continue;
+
+    // Deduplicate by lowercase name
+    const key = name.toLowerCase().trim();
+    if (seen.has(key)) continue;
+
+    const coords = getCoords(el);
+    if (!coords) continue;
+
+    const wardNum = findWard(coords.lat, coords.lng);
+    if (!wardNum) continue; // outside GCC ward boundaries
+
+    const profile = profileMap.get(wardNum);
+    if (!profile) continue;
+
+    seen.add(key);
+    localities.push({
+      name: name.trim(),
+      name_ta: tags["name:ta"] || undefined,
+      type: (tags["place"] as LocalityEntry["type"]) || "suburb",
+      lat: coords.lat,
+      lng: coords.lng,
+      ward_number: wardNum,
+      zone_name: profile.zone_name,
+      zone_no: profile.zone_no,
+    });
+  }
+
+  // Sort by name
+  localities.sort((a, b) => a.name.localeCompare(b.name));
+
+  const outPath = join(process.cwd(), "public/data/chennai-localities.json");
+  writeFileSync(outPath, JSON.stringify(localities, null, 2));
+  console.log(`\nWrote ${localities.length} localities to public/data/chennai-localities.json`);
+
+  // Summary by zone
+  const byZone = new Map<string, number>();
+  for (const l of localities) {
+    byZone.set(l.zone_name, (byZone.get(l.zone_name) || 0) + 1);
+  }
+  console.log("\nLocalities per zone:");
+  for (const [zone, count] of [...byZone.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${zone}: ${count}`);
+  }
+}
+
+fetchLocalities().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/src/app/api/localities/route.ts
+++ b/src/app/api/localities/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import path from "path";
+
+export const revalidate = 86400; // cache for 24 hours
+
+export interface LocalityEntry {
+  name: string;
+  name_ta?: string;
+  type: "suburb" | "neighbourhood" | "quarter";
+  lat: number;
+  lng: number;
+  ward_number: number;
+  zone_name: string;
+  zone_no: string;
+}
+
+export async function GET() {
+  const localitiesPath = path.join(process.cwd(), "public/data/chennai-localities.json");
+  const raw = await readFile(localitiesPath, "utf-8");
+  const localities: LocalityEntry[] = JSON.parse(raw);
+  return NextResponse.json({ localities });
+}

--- a/src/components/map/ward-search.tsx
+++ b/src/components/map/ward-search.tsx
@@ -2,22 +2,36 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useLanguage } from "@/lib/i18n/context";
+import {
+  type WardEntry,
+  type LocalityEntry,
+  type ZoneEntry,
+  type SearchResult,
+  deriveZones,
+  searchAll,
+} from "@/lib/utils/ward-filter";
 
-interface WardEntry {
-  wardNumber: number;
-  wardName: string;
-  wardNameTa?: string;
-  zone: string;
-}
-
-interface WardSearchProps {
-  onSelect: (wardNumber: number) => void;
+export interface WardSearchProps {
+  /**
+   * Called when a ward, locality, or zone is selected.
+   * wardNumber: the ward to select and highlight.
+   * flyTo: optional precise coordinates to fly to (used for localities).
+   *        If omitted, the map should fly to the ward centroid.
+   */
+  onSelect: (wardNumber: number, flyTo?: { lat: number; lng: number }) => void;
   className?: string;
 }
+
+const SECTION_LABELS: Record<SearchResult["kind"], string> = {
+  locality: "Areas",
+  ward: "Wards",
+  zone: "Zones",
+};
 
 export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
   const { language } = useLanguage();
   const [wards, setWards] = useState<WardEntry[]>([]);
+  const [localities, setLocalities] = useState<LocalityEntry[]>([]);
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -29,9 +43,15 @@ export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
       .then((r) => r.json())
       .then((d) => setWards(d.wards || []))
       .catch(console.error);
+    fetch("/api/localities")
+      .then((r) => r.json())
+      .then((d) => setLocalities(d.localities || []))
+      .catch(console.error);
   }, []);
 
-  // Close dropdown on outside click
+  const zones = useMemo<ZoneEntry[]>(() => deriveZones(wards), [wards]);
+
+  // Close on outside click
   useEffect(() => {
     function handleClick(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -43,39 +63,39 @@ export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [query]);
 
-  const filtered = useMemo(() => {
-    if (!query.trim()) return [];
-    const q = query.toLowerCase().trim();
-    return wards
-      .filter((w) => {
-        const name = w.wardName.toLowerCase();
-        const nameTa = w.wardNameTa?.toLowerCase() || "";
-        const zone = w.zone.toLowerCase();
-        const num = String(w.wardNumber);
-        return name.includes(q) || nameTa.includes(q) || zone.includes(q) || num.startsWith(q);
-      })
-      .sort((a, b) => {
-        // Prioritize: exact ward number > ward name match > zone-only match
-        const aNum = String(a.wardNumber) === q ? 0 : String(a.wardNumber).startsWith(q) ? 1 : 9;
-        const bNum = String(b.wardNumber) === q ? 0 : String(b.wardNumber).startsWith(q) ? 1 : 9;
-        if (aNum !== bNum) return aNum - bNum;
-        const aName = a.wardName.toLowerCase().includes(q) ? 0 : 1;
-        const bName = b.wardName.toLowerCase().includes(q) ? 0 : 1;
-        if (aName !== bName) return aName - bName;
-        return a.wardNumber - b.wardNumber;
-      })
-      .slice(0, 8);
-  }, [query, wards]);
+  const results = useMemo<SearchResult[]>(
+    () => searchAll(localities, wards, zones, query),
+    [query, localities, wards, zones]
+  );
 
-  const handleSelect = (ward: WardEntry) => {
-    onSelect(ward.wardNumber);
+  // Group results by kind for section headers
+  const grouped = useMemo(() => {
+    const sections: { kind: SearchResult["kind"]; items: SearchResult[] }[] = [];
+    let current: SearchResult["kind"] | null = null;
+    for (const r of results) {
+      if (r.kind !== current) {
+        sections.push({ kind: r.kind, items: [r] });
+        current = r.kind;
+      } else {
+        sections[sections.length - 1].items.push(r);
+      }
+    }
+    return sections;
+  }, [results]);
+
+  const handleSelect = (result: SearchResult) => {
+    if (result.kind === "locality") {
+      onSelect(result.locality.ward_number, { lat: result.locality.lat, lng: result.locality.lng });
+    } else if (result.kind === "ward") {
+      onSelect(result.ward.wardNumber);
+    } else {
+      // Zone: select the first ward in that zone
+      const firstWard = wards.find((w) => w.zone === result.zone.zoneName);
+      if (firstWard) onSelect(firstWard.wardNumber);
+    }
     setQuery("");
     setOpen(false);
     setSearchOpen(false);
-  };
-
-  const displayName = (w: WardEntry) => {
-    return `Ward ${w.wardNumber} - ${w.zone}`;
   };
 
   return (
@@ -88,7 +108,7 @@ export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
             setTimeout(() => inputRef.current?.focus(), 100);
           }}
           className="w-9 h-9 rounded-full bg-white dark:bg-slate-800 shadow-lg border border-slate-200 dark:border-slate-700 flex items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
-          aria-label="Search wards"
+          aria-label="Search areas, wards, or zones"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -112,8 +132,8 @@ export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
                 setOpen(true);
               }}
               onFocus={() => query && setOpen(true)}
-              placeholder="Search ward, area, or zone..."
-              className="w-48 sm:w-56 px-2 py-2 text-sm bg-transparent outline-none text-slate-900 dark:text-slate-100 placeholder-slate-400"
+              placeholder="Search area, ward, or zone..."
+              className="w-52 sm:w-64 px-2 py-2 text-sm bg-transparent outline-none text-slate-900 dark:text-slate-100 placeholder-slate-400"
             />
             <button
               onClick={() => {
@@ -130,29 +150,91 @@ export function WardSearch({ onSelect, className = "" }: WardSearchProps) {
           </div>
 
           {/* Results dropdown */}
-          {open && filtered.length > 0 && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 max-h-64 overflow-y-auto z-10">
-              {filtered.map((w) => (
-                <button
-                  key={w.wardNumber}
-                  onClick={() => handleSelect(w)}
-                  className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors border-b border-slate-100 dark:border-slate-700 last:border-b-0"
-                >
-                  <div className="font-medium text-slate-900 dark:text-slate-100">
-                    {displayName(w)}
+          {open && results.length > 0 && (
+            <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 max-h-72 overflow-y-auto z-10">
+              {grouped.map((section) => (
+                <div key={section.kind}>
+                  {/* Section header */}
+                  <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
+                    {SECTION_LABELS[section.kind]}
                   </div>
-                </button>
+                  {section.items.map((result, i) => (
+                    <ResultRow
+                      key={`${result.kind}-${i}`}
+                      result={result}
+                      language={language}
+                      onClick={() => handleSelect(result)}
+                    />
+                  ))}
+                </div>
               ))}
             </div>
           )}
 
-          {open && query.trim() && filtered.length === 0 && (
+          {open && query.trim() && results.length === 0 && (
             <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 px-3 py-3 text-sm text-slate-500 dark:text-slate-400">
-              No wards found
+              No results for &ldquo;{query}&rdquo;
             </div>
           )}
         </div>
       )}
     </div>
   );
+}
+
+function ResultRow({
+  result,
+  language,
+  onClick,
+}: {
+  result: SearchResult;
+  language: string;
+  onClick: () => void;
+}) {
+  if (result.kind === "locality") {
+    const l = result.locality;
+    const displayName = language === "ta" && l.name_ta ? l.name_ta : l.name;
+    return (
+      <button
+        onClick={onClick}
+        className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex flex-col gap-0.5"
+      >
+        <span className="font-medium text-slate-900 dark:text-slate-100 leading-snug">{displayName}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500">
+          Ward {l.ward_number} · {toTitleCase(l.zone_name)}
+        </span>
+      </button>
+    );
+  }
+
+  if (result.kind === "ward") {
+    const w = result.ward;
+    return (
+      <button
+        onClick={onClick}
+        className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex items-baseline justify-between gap-2"
+      >
+        <span className="font-medium text-slate-900 dark:text-slate-100">Ward {w.wardNumber}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">{toTitleCase(w.zone)} zone</span>
+      </button>
+    );
+  }
+
+  // zone
+  const z = result.zone;
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex items-baseline justify-between gap-2"
+    >
+      <span className="font-medium text-slate-900 dark:text-slate-100">{toTitleCase(z.zoneName)}</span>
+      <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">{z.wardCount} wards</span>
+    </button>
+  );
+}
+
+function toTitleCase(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/src/components/my-ward/ward-selector.tsx
+++ b/src/components/my-ward/ward-selector.tsx
@@ -2,7 +2,15 @@
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useLanguage } from "@/lib/i18n/context";
-import { filterWards, type WardEntry } from "@/lib/utils/ward-filter";
+import {
+  filterWards,
+  type WardEntry,
+  type LocalityEntry,
+  type ZoneEntry,
+  type SearchResult,
+  deriveZones,
+  searchAll,
+} from "@/lib/utils/ward-filter";
 
 const RECENT_WARDS_KEY = "neer-vazhvu-recent-wards";
 const MAX_RECENT = 5;
@@ -26,14 +34,21 @@ function saveRecentWard(wardNumber: number): void {
   }
 }
 
+const SECTION_LABELS: Record<SearchResult["kind"], string> = {
+  locality: "Areas",
+  ward: "Wards",
+  zone: "Zones",
+};
+
 interface WardSelectorProps {
   onSelect: (wardNumber: number) => void;
   selectedWard: number | null;
 }
 
 export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
   const [wards, setWards] = useState<WardEntry[]>([]);
+  const [localities, setLocalities] = useState<LocalityEntry[]>([]);
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [recentWards, setRecentWards] = useState<number[]>(() => {
@@ -51,7 +66,13 @@ export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
       .then((r) => r.json())
       .then((d) => setWards(d.wards || []))
       .catch(console.error);
+    fetch("/api/localities")
+      .then((r) => r.json())
+      .then((d) => setLocalities(d.localities || []))
+      .catch(console.error);
   }, []);
+
+  const zones = useMemo<ZoneEntry[]>(() => deriveZones(wards), [wards]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -64,7 +85,25 @@ export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  const filtered = useMemo(() => filterWards(wards, query), [wards, query]);
+  const results = useMemo<SearchResult[]>(
+    () => searchAll(localities, wards, zones, query),
+    [query, localities, wards, zones]
+  );
+
+  // Group results by kind for section headers
+  const grouped = useMemo(() => {
+    const sections: { kind: SearchResult["kind"]; items: SearchResult[] }[] = [];
+    let current: SearchResult["kind"] | null = null;
+    for (const r of results) {
+      if (r.kind !== current) {
+        sections.push({ kind: r.kind, items: [r] });
+        current = r.kind;
+      } else {
+        sections[sections.length - 1].items.push(r);
+      }
+    }
+    return sections;
+  }, [results]);
 
   const handleSelect = useCallback(
     (wardNumber: number) => {
@@ -77,12 +116,57 @@ export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
     [onSelect],
   );
 
+  const handleResultSelect = useCallback(
+    (result: SearchResult) => {
+      if (result.kind === "locality") {
+        handleSelect(result.locality.ward_number);
+      } else if (result.kind === "ward") {
+        handleSelect(result.ward.wardNumber);
+      } else {
+        // Zone: navigate to first ward in that zone
+        const firstWard = wards.find((w) => w.zone === result.zone.zoneName);
+        if (firstWard) handleSelect(firstWard.wardNumber);
+      }
+    },
+    [handleSelect, wards]
+  );
+
   const wardLabel = useCallback(
     (wardNumber: number): string => {
       const w = wards.find((w) => w.wardNumber === wardNumber);
-      return w ? `Ward ${w.wardNumber} - ${w.zone}` : `Ward ${wardNumber}`;
+      return w ? `Ward ${w.wardNumber} - ${toTitleCase(w.zone)}` : `Ward ${wardNumber}`;
     },
     [wards],
+  );
+
+  const resultsDropdown = (
+    <>
+      {open && results.length > 0 && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 max-h-72 overflow-y-auto z-10">
+          {grouped.map((section) => (
+            <div key={section.kind}>
+              <div className="px-4 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
+                {SECTION_LABELS[section.kind]}
+              </div>
+              {section.items.map((result, i) => (
+                <ResultRow
+                  key={`${result.kind}-${i}`}
+                  result={result}
+                  language={language}
+                  onClick={() => handleResultSelect(result)}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {open && query.trim() && results.length === 0 && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 px-4 py-3 text-sm text-slate-500 dark:text-slate-400">
+          {t("my_ward.no_results")}
+        </div>
+      )}
+    </>
   );
 
   // If no ward is selected, show the full selector as the page hero
@@ -117,29 +201,7 @@ export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
             />
           </div>
 
-          {/* Results dropdown */}
-          {open && filtered.length > 0 && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 max-h-64 overflow-y-auto z-10">
-              {filtered.map((w) => (
-                <button
-                  key={w.wardNumber}
-                  onClick={() => handleSelect(w.wardNumber)}
-                  className="w-full text-left px-4 py-3 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors border-b border-slate-100 dark:border-slate-700 last:border-b-0"
-                >
-                  <span className="font-medium text-slate-900 dark:text-slate-100">
-                    Ward {w.wardNumber}
-                  </span>
-                  <span className="text-slate-500 dark:text-slate-400 ml-2">{w.zone}</span>
-                </button>
-              ))}
-            </div>
-          )}
-
-          {open && query.trim() && filtered.length === 0 && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 px-4 py-3 text-sm text-slate-500 dark:text-slate-400">
-              {t("my_ward.no_results")}
-            </div>
-          )}
+          {resultsDropdown}
         </div>
 
         {/* Recent wards */}
@@ -182,20 +244,86 @@ export function WardSelector({ onSelect, selectedWard }: WardSelectorProps) {
         </div>
       </div>
 
-      {open && filtered.length > 0 && (
-        <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 max-h-64 overflow-y-auto z-10 max-w-xs">
-          {filtered.map((w) => (
-            <button
-              key={w.wardNumber}
-              onClick={() => handleSelect(w.wardNumber)}
-              className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors border-b border-slate-100 dark:border-slate-700 last:border-b-0"
-            >
-              <span className="font-medium text-slate-900 dark:text-slate-100">Ward {w.wardNumber}</span>
-              <span className="text-slate-500 dark:text-slate-400 ml-2">{w.zone}</span>
-            </button>
+      {/* Compact dropdown uses same grouped results */}
+      {open && results.length > 0 && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 max-h-72 overflow-y-auto z-10 max-w-xs">
+          {grouped.map((section) => (
+            <div key={section.kind}>
+              <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
+                {SECTION_LABELS[section.kind]}
+              </div>
+              {section.items.map((result, i) => (
+                <ResultRow
+                  key={`${result.kind}-${i}`}
+                  result={result}
+                  language={language}
+                  onClick={() => handleResultSelect(result)}
+                  compact
+                />
+              ))}
+            </div>
           ))}
         </div>
       )}
     </div>
   );
+}
+
+function ResultRow({
+  result,
+  language,
+  onClick,
+  compact = false,
+}: {
+  result: SearchResult;
+  language: string;
+  onClick: () => void;
+  compact?: boolean;
+}) {
+  const px = compact ? "px-3 py-2" : "px-4 py-3";
+
+  if (result.kind === "locality") {
+    const l = result.locality;
+    const displayName = language === "ta" && l.name_ta ? l.name_ta : l.name;
+    return (
+      <button
+        onClick={onClick}
+        className={`w-full text-left ${px} text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex flex-col gap-0.5`}
+      >
+        <span className="font-medium text-slate-900 dark:text-slate-100 leading-snug">{displayName}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500">
+          Ward {l.ward_number} · {toTitleCase(l.zone_name)}
+        </span>
+      </button>
+    );
+  }
+
+  if (result.kind === "ward") {
+    const w = result.ward;
+    return (
+      <button
+        onClick={onClick}
+        className={`w-full text-left ${px} text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex items-baseline justify-between gap-2`}
+      >
+        <span className="font-medium text-slate-900 dark:text-slate-100">Ward {w.wardNumber}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">{toTitleCase(w.zone)} zone</span>
+      </button>
+    );
+  }
+
+  // zone
+  const z = result.zone;
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full text-left ${px} text-sm hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors flex items-baseline justify-between gap-2`}
+    >
+      <span className="font-medium text-slate-900 dark:text-slate-100">{toTitleCase(z.zoneName)}</span>
+      <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">{z.wardCount} wards</span>
+    </button>
+  );
+}
+
+function toTitleCase(s: string): string {
+  return s.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/src/lib/utils/ward-filter.ts
+++ b/src/lib/utils/ward-filter.ts
@@ -5,6 +5,30 @@ export interface WardEntry {
   zone: string;
 }
 
+export interface LocalityEntry {
+  name: string;
+  name_ta?: string;
+  type: "suburb" | "neighbourhood" | "quarter";
+  lat: number;
+  lng: number;
+  ward_number: number;
+  zone_name: string;
+  zone_no: string;
+}
+
+export interface ZoneEntry {
+  zoneName: string;
+  zoneNo: string;
+  wardCount: number;
+}
+
+export type SearchResultKind = "locality" | "ward" | "zone";
+
+export type SearchResult =
+  | { kind: "locality"; locality: LocalityEntry }
+  | { kind: "ward"; ward: WardEntry }
+  | { kind: "zone"; zone: ZoneEntry };
+
 /**
  * Filter and sort wards by query string.
  * Prioritizes: exact ward number > ward number prefix > name match > zone-only match.
@@ -30,4 +54,93 @@ export function filterWards(wards: WardEntry[], query: string, limit = 8): WardE
       return a.wardNumber - b.wardNumber;
     })
     .slice(0, limit);
+}
+
+/**
+ * Filter localities by query string.
+ * Prioritizes: name starts with query > name contains query > Tamil name match.
+ */
+export function filterLocalities(
+  localities: LocalityEntry[],
+  query: string,
+  limit = 5
+): LocalityEntry[] {
+  if (!query.trim()) return [];
+  const q = query.toLowerCase().trim();
+  return localities
+    .filter((l) => {
+      const name = l.name.toLowerCase();
+      const nameTa = l.name_ta?.toLowerCase() || "";
+      const zone = l.zone_name.toLowerCase();
+      return name.includes(q) || nameTa.includes(q) || zone.includes(q);
+    })
+    .sort((a, b) => {
+      const aName = a.name.toLowerCase();
+      const bName = b.name.toLowerCase();
+      // Exact match first
+      if (aName === q && bName !== q) return -1;
+      if (bName === q && aName !== q) return 1;
+      // Starts-with next
+      const aStarts = aName.startsWith(q) ? 0 : 1;
+      const bStarts = bName.startsWith(q) ? 0 : 1;
+      if (aStarts !== bStarts) return aStarts - bStarts;
+      return aName.localeCompare(bName);
+    })
+    .slice(0, limit);
+}
+
+/**
+ * Derive unique zones from a list of wards.
+ */
+export function deriveZones(wards: WardEntry[]): ZoneEntry[] {
+  const zoneMap = new Map<string, ZoneEntry>();
+  for (const w of wards) {
+    const existing = zoneMap.get(w.zone);
+    if (existing) {
+      existing.wardCount++;
+    } else {
+      zoneMap.set(w.zone, { zoneName: w.zone, zoneNo: "", wardCount: 1 });
+    }
+  }
+  return [...zoneMap.values()].sort((a, b) => a.zoneName.localeCompare(b.zoneName));
+}
+
+/**
+ * Filter zones by query string.
+ */
+export function filterZones(zones: ZoneEntry[], query: string, limit = 3): ZoneEntry[] {
+  if (!query.trim()) return [];
+  const q = query.toLowerCase().trim();
+  return zones
+    .filter((z) => z.zoneName.toLowerCase().includes(q))
+    .sort((a, b) => {
+      const aStarts = a.zoneName.toLowerCase().startsWith(q) ? 0 : 1;
+      const bStarts = b.zoneName.toLowerCase().startsWith(q) ? 0 : 1;
+      if (aStarts !== bStarts) return aStarts - bStarts;
+      return a.zoneName.localeCompare(b.zoneName);
+    })
+    .slice(0, limit);
+}
+
+/**
+ * Combined search across localities, wards, and zones.
+ * Returns grouped results in order: localities, wards, zones.
+ */
+export function searchAll(
+  localities: LocalityEntry[],
+  wards: WardEntry[],
+  zones: ZoneEntry[],
+  query: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const l of filterLocalities(localities, query, 4)) {
+    results.push({ kind: "locality", locality: l });
+  }
+  for (const w of filterWards(wards, query, 3)) {
+    results.push({ kind: "ward", ward: w });
+  }
+  for (const z of filterZones(zones, query, 2)) {
+    results.push({ kind: "zone", zone: z });
+  }
+  return results;
 }


### PR DESCRIPTION
## Problem

Searching by ward number or zone name isn't natural - most users know they live in *Anna Nagar* or *Adyar*, not *Ward 101* or *Zone VIII*. Both the map search and the My Ward picker had no way to accept colloquial area names.

## What this does

Adds 500 Chennai neighbourhoods and suburbs (sourced from OpenStreetMap) to all search surfaces, each correctly mapped to its GCC ward and zone. Users can now type a familiar area name and see it alongside the matching wards and zones in a single grouped dropdown.

**Hierarchy established:** Locality → Ward → Zone

**Search result grouping:**
```
Areas
  Anna Nagar          Ward 101 · Anna Nagar
  Anna Nagar East     Ward 102 · Anna Nagar

Wards
  Ward 101            Anna Nagar zone

Zones
  Anna Nagar          41 wards
```

## Changes

| File | What changed |
|------|-------------|
| `scripts/fetch-localities-osm.ts` | One-time script: queries Overpass API for all `place=suburb/neighbourhood` nodes in Chennai's bounding box, resolves each to a ward via point-in-polygon, outputs static JSON. Re-run with `npx tsx scripts/fetch-localities-osm.ts` to refresh OSM data. |
| `public/data/chennai-localities.json` | 500 localities with name, Tamil name where available, lat/lng centroid, ward number, zone name, zone number |
| `src/app/api/localities/route.ts` | New API route serving locality data (24 h cache) |
| `src/lib/utils/ward-filter.ts` | New types (`LocalityEntry`, `ZoneEntry`, `SearchResult`) and utilities (`filterLocalities`, `filterZones`, `searchAll`). Existing `filterWards` API is unchanged - `ward-multi-selector` is unaffected. |
| `src/components/map/ward-search.tsx` | Grouped dropdown on all map pages (Flood Risk, Water Bodies, Groundwater, Rivers). Locality rows use a two-line layout so long names never truncate. `onSelect` gains an optional `flyTo` param for locality-level map precision. |
| `src/components/my-ward/ward-selector.tsx` | Same grouped search in both the hero state (first-time ward picker) and the compact inline state (change ward). Recent wards behaviour is preserved. |

## Test plan

- [x] Search "Anna Nagar" - see Anna Nagar, Anna Nagar East, Anna Nagar West as separate locality results with correct ward/zone labels
- [x] Search "101" - ward result appears as before
- [x] Search "Adyar" - zone result appears alongside locality results
- [x] Select a locality in My Ward hero - lands on the correct ward data page
- [x] Select a locality in compact My Ward selector - switches to correct ward
- [x] Recent wards still appear and work after selecting via locality
- [x] Long locality names (e.g. "Annai Sathya Nagar Nesapakkam") display without truncation