### PR TITLE
Auto-publish satellite evidence frames and extend manual job timeout

### DIFF
--- a/.github/workflows/gee-phase1.yml
+++ b/.github/workflows/gee-phase1.yml
@@ -149,7 +149,7 @@ jobs:
   manual-phase1:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 150
     defaults:
       run:
         working-directory: neer-vazhvu-api

--- a/neer-vazhvu-api/app/gee/evidence.py
+++ b/neer-vazhvu-api/app/gee/evidence.py
@@ -67,7 +67,7 @@ class WaterBodySatelliteEvidenceRow:
     cloud_note: str | None = None
     geometry_version: str | None = None
     is_same_scene_as_overlay: bool = False
-    is_reviewed: bool = False
+    is_reviewed: bool = True
     notes: str | None = None
 
 
@@ -636,7 +636,7 @@ def _preserve_existing_review_state(
         )
         .in_("gee_target_id", target_ids)
         .in_("reference_date", ref_dates)
-        .eq("is_reviewed", True)
+        .eq("is_reviewed", False)
         .execute()
     )
 
@@ -662,7 +662,8 @@ def _preserve_existing_review_state(
         if not same_selection:
             continue
 
-        row.is_reviewed = True
+        # Preserve your rejection - if same scene was marked bad, keep it hidden
+        row.is_reviewed = False
         if row.notes is None and existing.get("notes") is not None:
             row.notes = str(existing.get("notes"))
 


### PR DESCRIPTION
## Summary

- **Auto-publish evidence frames:** `is_reviewed` now defaults to `True` so newly downloaded Sentinel-2 thumbnails appear in the evidence viewer immediately, without a manual Supabase update step. You can set `is_reviewed = false` on any frame that looks bad (clouds, wrong mask, etc.) to hide it.
- **Preserve rejections across re-runs:** `_preserve_existing_review_state` now carries forward `is_reviewed = False` (rejections) instead of approvals. If the pipeline re-runs and picks the same scene you previously rejected, it stays hidden. A different scene for the same reference date starts fresh as visible.
- **Bump manual job timeout:** `manual-phase1` workflow timeout raised from 90 to 150 minutes to safely cover a full 150-body 24-month backfill dispatch.

## Post-merge steps

1. Run this once in the Supabase SQL editor to surface the existing 12 flagship evidence frames (currently hidden under the old default):
   ```sql
   UPDATE water_body_satellite_evidence SET is_reviewed = true WHERE is_reviewed = false;
   ```
2. Trigger the summary backfill via GitHub Actions → "GEE Phase 1" → Run workflow:
   - `task`: `backfill-water-body-summaries`
   - `months_back`: `24`
   - `target_cohort`: `all`

## Test plan

- [ ] Merge and trigger a `build-satellite-evidence` dispatch for a single target (`--limit 1`) - confirm the new frame appears in the evidence viewer without a manual DB update
- [ ] Set `is_reviewed = false` on that frame in Supabase, re-run the evidence builder for the same target - confirm it stays hidden
- [ ] Trigger the summary backfill and confirm the history chart populates for a non-flagship body