### PR TITLE
fix: skip incomplete reservoir days in days-left estimate

### DIFF
--- a/neer-vazhvu-api/app/etl/constants.py
+++ b/neer-vazhvu-api/app/etl/constants.py
@@ -43,6 +43,9 @@ RESERVOIR_CAPACITY: dict[str, float] = {
     "kannankottai": 1574.0,
 }
 
+EXPECTED_RESERVOIR_COUNT = len(RESERVOIR_CAPACITY)
+"""All reservoirs must report on a date for it to be usable in days-left math."""
+
 # Maps various CMWSSB page names to canonical reservoir names
 RESERVOIR_NAME_MAP: dict[str, str] = {
     "poondi": "poondi",

--- a/neer-vazhvu-api/app/etl/pipeline.py
+++ b/neer-vazhvu-api/app/etl/pipeline.py
@@ -16,6 +16,7 @@ from app.etl.constants import (
     CUSEC_DAY_TO_MCFT,
     DEFAULT_CONSUMPTION_MLD,
     DEFAULT_DESALINATION_MLD,
+    EXPECTED_RESERVOIR_COUNT,
     MLD_TO_MCFT,
 )
 from app.etl.estimate import compute_days_left
@@ -252,28 +253,56 @@ async def _step_compute_estimate() -> dict:
     today = ist_today().isoformat()
 
     # 1. Get latest reservoir data
+    lookback_days = 10
     res = (
         supabase.table("reservoir_daily")
         .select("reservoir, current_storage_mcft, capacity_mcft, inflow_cusecs, date")
         .order("date", desc=True)
-        .limit(12)
+        .limit(EXPECTED_RESERVOIR_COUNT * lookback_days)
         .execute()
     )
 
     if not res.data:
         raise ValueError("No reservoir data available for estimate computation")
 
-    most_recent_date = res.data[0]["date"]
-    today_reservoirs = [r for r in res.data if r["date"] == most_recent_date]
+    by_date: dict[str, list[dict]] = {}
+    for row in res.data:
+        by_date.setdefault(row["date"], []).append(row)
 
+    # Walk dates newest-first; skip any date missing reservoirs (scrape lag),
+    # since a partial day understates storage and makes days-left misleadingly low.
+    complete_date = None
+    skipped: list[tuple[str, set[str]]] = []
+    for date in sorted(by_date.keys(), reverse=True):
+        reservoirs_seen = {r["reservoir"] for r in by_date[date]}
+        if len(reservoirs_seen) >= EXPECTED_RESERVOIR_COUNT:
+            complete_date = date
+            break
+        skipped.append((date, reservoirs_seen))
+
+    if complete_date is None:
+        details = "; ".join(f"{d} had {sorted(seen)}" for d, seen in skipped[:5])
+        raise ValueError(
+            f"No complete reservoir set in the last {lookback_days} days "
+            f"(expected {EXPECTED_RESERVOIR_COUNT}). {details}"
+        )
+
+    if skipped:
+        logger.warning(
+            "compute_estimate: falling back to %s, skipped incomplete: %s",
+            complete_date,
+            [(d, sorted(seen)) for d, seen in skipped],
+        )
+
+    today_reservoirs = by_date[complete_date]
     total_storage = sum(r["current_storage_mcft"] or 0 for r in today_reservoirs)
     total_capacity = sum(r["capacity_mcft"] or 0 for r in today_reservoirs)
 
-    # 2. Compute 7-day rolling average inflow
+    # 2. Compute 7-day rolling average inflow (complete days only)
     seven_days_ago = (ist_today() - timedelta(days=7)).isoformat()
     recent_res = (
         supabase.table("reservoir_daily")
-        .select("date, inflow_cusecs")
+        .select("date, reservoir, inflow_cusecs")
         .gte("date", seven_days_ago)
         .not_.is_("inflow_cusecs", "null")
         .execute()
@@ -281,13 +310,18 @@ async def _step_compute_estimate() -> dict:
 
     recent_avg_inflow_mcft_per_day = 0.0
     if recent_res.data:
-        by_date: dict[str, float] = {}
+        per_date: dict[str, dict[str, float]] = {}
         for row in recent_res.data:
             d = row["date"]
-            by_date[d] = by_date.get(d, 0) + (row["inflow_cusecs"] or 0)
-        daily_totals = list(by_date.values())
-        avg_cusecs = sum(daily_totals) / len(daily_totals)
-        recent_avg_inflow_mcft_per_day = avg_cusecs * CUSEC_DAY_TO_MCFT
+            per_date.setdefault(d, {})[row["reservoir"]] = row["inflow_cusecs"] or 0
+        complete_days = [
+            sum(rows.values())
+            for rows in per_date.values()
+            if len(rows) >= EXPECTED_RESERVOIR_COUNT
+        ]
+        if complete_days:
+            avg_cusecs = sum(complete_days) / len(complete_days)
+            recent_avg_inflow_mcft_per_day = avg_cusecs * CUSEC_DAY_TO_MCFT
 
     # 3. Get seasonal average inflow
     current_month = ist_today().month


### PR DESCRIPTION
## Summary
Closes #92.

Fixes the days-left calculation in `_step_compute_estimate` so that a partial scrape day (one or more reservoirs missing) no longer produces a misleadingly low number.

## What changed
- Walk dates newest-first and pick the most recent date where all `EXPECTED_RESERVOIR_COUNT` (6) reservoirs reported. Skipped incomplete dates are logged.
- Apply the same completeness gate to the 7-day rolling inflow average so a partial day doesn't drag it down.
- Bump the lookback from 12 rows to `6 * 10` so there's headroom to fall back through several partial days.
- Raise a clear `ValueError` (with the partial-date details) if no complete day exists in the window, so the daily run fails loudly rather than silently publishing.

## Test plan
- [x] Trigger pipeline run on a day where the latest `reservoir_daily` row set is complete - confirm `days_left_*` matches prior values (no behaviour change in the happy path).
- [x] Manually delete one reservoir's row for today, re-run `_step_compute_estimate`, confirm it falls back to yesterday's complete row set and logs a warning.
- [x] Wipe / null out reservoir data in the lookback window, confirm step raises with the diagnostic message instead of silently writing a low estimate.