### PR TITLE
i18n: city-aware language architecture for pan-India scale

### DIFF
--- a/src/components/layout/language-toggle.tsx
+++ b/src/components/layout/language-toggle.tsx
@@ -1,29 +1,110 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n/context";
+import { LANGUAGE_LABELS, type LanguageCode } from "@/lib/i18n/translations";
 
+/**
+ * Language switcher. UX adapts to how many languages the current city
+ * offers (driven by `availableLanguages` in the LanguageContext, which
+ * itself derives from the URL's city config):
+ *
+ *   - 1 language (English-only city): button hidden entirely.
+ *   - 2 languages: simple cycle button (the historical TN UX).
+ *   - 3+ languages: button-with-popover listing all options.
+ *
+ * Each button shows the script glyph for the *next* language to switch
+ * to (when a 2-lang cycle), or the current language's glyph (when a
+ * popover - so the popover is "what am I in" + "what could I switch
+ * to").
+ */
 export function LanguageToggle() {
-  const { language, setLanguage, t } = useLanguage();
+  const { language, availableLanguages, setLanguage, t } = useLanguage();
   const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
 
   if (!mounted) {
     return <div className="w-9 h-9" />;
   }
 
-  const isTamil = language === "ta";
+  if (availableLanguages.length <= 1) {
+    return null;
+  }
 
+  if (availableLanguages.length === 2) {
+    const other = availableLanguages.find((l) => l !== language) ?? "en";
+    const otherLabel = LANGUAGE_LABELS[other];
+    return (
+      <button
+        onClick={() => setLanguage(other)}
+        className="px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
+        aria-label={`Switch to ${otherLabel.english}`}
+        title={`Switch to ${otherLabel.native}`}
+      >
+        {otherLabel.toggle}
+      </button>
+    );
+  }
+
+  // 3+ languages: popover.
+  const currentLabel = LANGUAGE_LABELS[language];
   return (
-    <button
-      onClick={() => setLanguage(isTamil ? "en" : "ta")}
-      className="px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
-      aria-label={isTamil ? t("lang.switch_to_english") : t("lang.view_in_tamil")}
-      title={isTamil ? t("lang.switch_to_english") : t("lang.switch_to_tamil")}
-    >
-      {isTamil ? "EN" : "த"}
-    </button>
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={t("lang.choose_language") || `Choose language - currently ${currentLabel.english}`}
+        aria-expanded={open}
+        className="px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
+      >
+        {currentLabel.toggle}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-10 z-50 min-w-[160px] rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg py-1">
+          {availableLanguages.map((code: LanguageCode) => {
+            const label = LANGUAGE_LABELS[code];
+            const isActive = code === language;
+            return (
+              <button
+                key={code}
+                onClick={() => {
+                  setLanguage(code);
+                  setOpen(false);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between gap-3 ${
+                  isActive
+                    ? "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100"
+                    : "text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
+                }`}
+              >
+                <span>{label.native}</span>
+                <span className="text-xs text-slate-400">{label.english}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/lib/cities/chennai.ts
+++ b/src/lib/cities/chennai.ts
@@ -4,6 +4,7 @@ export const CHENNAI: CityConfig = {
   placeKind: 'city',
   cityId: 'chennai',
   displayName: 'Chennai',
+  displayNameLocalized: { ta: 'சென்னை' },
   stateCode: 'TN',
   timezone: 'Asia/Kolkata',
   center: { lat: 13.0827, lng: 80.2707 },
@@ -21,6 +22,7 @@ export const CHENNAI: CityConfig = {
   },
   defaultConsumptionMld: 830,
   defaultDesalinationMld: 190,
+  availableLanguages: ['en', 'ta'],
   // Cascade reconstruction available (755 nodes / 573 edges across 7
   // cascade depths from the same HydroSHEDS pipeline that built
   // Madurai's). Chennai's max depth is shorter because the delta is

--- a/src/lib/cities/madurai.ts
+++ b/src/lib/cities/madurai.ts
@@ -4,6 +4,7 @@ export const MADURAI: CityConfig = {
   placeKind: 'city',
   cityId: 'madurai',
   displayName: 'Madurai',
+  displayNameLocalized: { ta: 'மதுரை' },
   stateCode: 'TN',
   timezone: 'Asia/Kolkata',
   center: { lat: 9.9252, lng: 78.1198 },
@@ -21,6 +22,7 @@ export const MADURAI: CityConfig = {
   },
   defaultConsumptionMld: 135,
   defaultDesalinationMld: null,
+  availableLanguages: ['en', 'ta'],
   // Madurai's tracked dams are irrigation-primary (Vaigai is shared
   // across Madurai/Theni/Sivagangai/Ramanathapuram for fields,
   // Mullaperiyar is Kerala-side basin storage). Chennai's days-left

--- a/src/lib/cities/types.ts
+++ b/src/lib/cities/types.ts
@@ -1,3 +1,5 @@
+import type { LanguageCode } from '@/lib/i18n/translations';
+
 export type WaterSourceType =
   | 'reservoir'
   | 'cauvery_stage'
@@ -117,6 +119,10 @@ export interface UrbanSupplyConfig {
 export interface BasePlaceConfig {
   cityId: string;
   displayName: string;
+  /** Localized display name in the city's primary regional language
+   *  (e.g. Tamil for TN cities). Used wherever copy renders the city
+   *  name in that language. Falls back to `displayName` when omitted. */
+  displayNameLocalized?: Partial<Record<LanguageCode, string>>;
   stateCode: string;
   timezone: string;
   center: Coordinates;
@@ -150,6 +156,24 @@ export interface BasePlaceConfig {
   /** Public, audited urban supply numbers for the allocation hero.
    *  Required when heroMode === 'allocation'; ignored otherwise. */
   urbanSupply?: UrbanSupplyConfig;
+
+  /**
+   * Languages this city's UI offers, in display order. First entry is
+   * the default. 'en' MUST appear (accessibility floor + translation
+   * fallback).
+   *
+   * For Tamil Nadu cities use ['en', 'ta']; future Karnataka cities
+   * use ['en', 'kn']; Maharashtra ['en', 'mr']; Delhi ['en', 'hi']; etc.
+   *
+   * Cities can ship before any city-language strings are translated -
+   * unmatched keys fall back to English at runtime via `t()` in
+   * `src/lib/i18n/context.tsx`. Translating `src/lib/i18n/translations.ts`
+   * to a new language is independent content work.
+   *
+   * Defaults to ['en', 'ta'] when omitted (preserves current behaviour
+   * for any in-flight city configs that haven't been updated yet).
+   */
+  availableLanguages?: readonly LanguageCode[];
 
   /** Whether the cascade reconstruction overlay is available for this
    *  place. When true, /<city>/water-bodies surfaces a "Show cascade

--- a/src/lib/i18n/available-languages.test.ts
+++ b/src/lib/i18n/available-languages.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveAvailableLanguagesForPath } from "./available-languages";
+
+test("root path resolves to Chennai's available languages (legacy)", () => {
+  const langs = resolveAvailableLanguagesForPath("/");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("legacy unscoped path resolves to Chennai's languages", () => {
+  const langs = resolveAvailableLanguagesForPath("/water-bodies");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("madurai-scoped path resolves to Madurai's languages", () => {
+  const langs = resolveAvailableLanguagesForPath("/madurai/water-bodies");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("explicit chennai-scoped path resolves to Chennai's languages", () => {
+  const langs = resolveAvailableLanguagesForPath("/chennai/about");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("unknown city slug falls back to Chennai (legacy default)", () => {
+  // Future-proofs the resolver: if a city is added without
+  // availableLanguages, we don't crash; we use the Chennai default.
+  const langs = resolveAvailableLanguagesForPath("/some-future-place/page");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("path with trailing slash and query is parsed correctly", () => {
+  const langs = resolveAvailableLanguagesForPath("/madurai/");
+  assert.deepEqual([...langs], ["en", "ta"]);
+});
+
+test("returns at least 'en' even if config lookup fails", () => {
+  const langs = resolveAvailableLanguagesForPath("");
+  assert.ok(langs.length >= 1);
+  assert.ok(langs.includes("en"));
+});

--- a/src/lib/i18n/available-languages.ts
+++ b/src/lib/i18n/available-languages.ts
@@ -1,0 +1,37 @@
+import { tryGetPlaceConfig } from "@/lib/cities";
+import type { LanguageCode } from "./translations";
+
+/**
+ * Map a URL pathname to the language set the UI should offer there.
+ *
+ * Routing today:
+ *   - "/" and legacy unscoped routes ("/water-bodies", "/about", etc.)
+ *     belong to Chennai (the historical default city).
+ *   - "/<cityId>/..." belongs to that city.
+ *
+ * Resolver:
+ *   1. Take the first non-empty path segment.
+ *   2. If it matches a known city config, return that city's
+ *      `availableLanguages`.
+ *   3. Otherwise treat the request as Chennai-scoped (legacy routes).
+ *
+ * Always returns a list with at least 'en' so the toggle and the
+ * fallback `t()` lookup always have something usable.
+ */
+export function resolveAvailableLanguagesForPath(
+  pathname: string,
+): readonly LanguageCode[] {
+  const firstSegment = pathname.split("/").filter(Boolean)[0] ?? "";
+  const cityFromSegment = tryGetPlaceConfig(firstSegment);
+  if (cityFromSegment?.availableLanguages?.length) {
+    return cityFromSegment.availableLanguages;
+  }
+
+  // Legacy unscoped routes are Chennai-implicit.
+  const chennai = tryGetPlaceConfig("chennai");
+  if (chennai?.availableLanguages?.length) {
+    return chennai.availableLanguages;
+  }
+
+  return ["en"];
+}

--- a/src/lib/i18n/context.tsx
+++ b/src/lib/i18n/context.tsx
@@ -1,52 +1,96 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
-import { translations } from "./translations";
-import type { Language } from "./translations";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import { translations, isLanguageCode } from "./translations";
+import type { Language, LanguageCode } from "./translations";
+import { resolveAvailableLanguagesForPath } from "./available-languages";
 
 interface LanguageContextValue {
   language: Language;
+  /**
+   * Languages available in the current city's UI, in display order.
+   * Always includes 'en'. Derived from `usePathname()` so the toggle
+   * automatically reflects the city the user is on.
+   */
+  availableLanguages: readonly LanguageCode[];
   setLanguage: (lang: Language) => void;
   t: (key: string) => string;
 }
 
+const STORAGE_KEY = "neer-vazhvu-lang";
+
 const LanguageContext = createContext<LanguageContextValue>({
   language: "en",
+  availableLanguages: ["en"],
   setLanguage: () => {},
   t: (key) => translations[key]?.en ?? key,
 });
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [language, setLanguageState] = useState<Language>("en");
+  const pathname = usePathname();
+  // Stored preference - what the user picked (or null until hydrated).
+  // The displayed `language` is derived from this and the city's
+  // available list, so a stored 'ta' visiting /bangalore renders en
+  // without writing back to localStorage.
+  const [storedLanguage, setStoredLanguage] = useState<Language>("en");
   const [mounted, setMounted] = useState(false);
 
-  // Read persisted preference after mount to avoid hydration mismatch
+  // Available languages for this URL - resolved synchronously so SSR
+  // and initial render agree.
+  const availableLanguages = useMemo(
+    () => resolveAvailableLanguagesForPath(pathname ?? "/"),
+    [pathname],
+  );
+
+  // Effective language: stored preference if it's offered here, else
+  // the city's first available (always 'en' or the city's primary).
+  // Derived during render - no setState-in-effect cascade.
+  const language: Language = availableLanguages.includes(storedLanguage)
+    ? storedLanguage
+    : availableLanguages[0];
+
+  // Read persisted preference once after mount.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
-    const stored = localStorage.getItem("neer-vazhvu-lang") as Language;
-    if (stored === "en" || stored === "ta") {
-      setLanguageState(stored);
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (isLanguageCode(stored)) {
+      setStoredLanguage(stored);
     }
   }, []);
 
-  // Persist + update <html lang> whenever language changes
+  // Persist + update <html lang> when the user explicitly chooses.
+  // Effective `language` is the source of truth for what the page is
+  // rendering in - that's what we mark on <html>. localStorage tracks
+  // the user's explicit preference (storedLanguage) so it survives
+  // the temporary fallback when visiting a city that doesn't offer it.
   useEffect(() => {
     if (!mounted) return;
-    localStorage.setItem("neer-vazhvu-lang", language);
-    document.documentElement.lang = language === "ta" ? "ta" : "en";
+    localStorage.setItem(STORAGE_KEY, storedLanguage);
+  }, [storedLanguage, mounted]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    document.documentElement.lang = language;
   }, [language, mounted]);
 
   function setLanguage(lang: Language) {
-    setLanguageState(lang);
+    // Defensive: reject preferences not offered by the current city.
+    if (!availableLanguages.includes(lang)) return;
+    setStoredLanguage(lang);
   }
 
   function t(key: string): string {
-    return translations[key]?.[language] ?? translations[key]?.en ?? key;
+    const entry = translations[key];
+    if (!entry) return key;
+    return entry[language] ?? entry.en;
   }
 
   return (
-    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+    <LanguageContext.Provider
+      value={{ language, availableLanguages, setLanguage, t }}
+    >
       {children}
     </LanguageContext.Provider>
   );

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -1,6 +1,71 @@
-export type Language = "en" | "ta";
+/**
+ * The set of language codes the platform is architected to support
+ * across India. Adding a city in a new state means: extend this union
+ * (if the language is not yet present), add a `LANGUAGE_LABELS` entry,
+ * and set `availableLanguages: ['en', '<code>']` on that city's config.
+ *
+ * Translation entries are partial (see `TranslationEntry`): every
+ * entry MUST have an `en` value (accessibility floor + fallback), but
+ * other-language values are optional. A city can ship before all
+ * strings are translated; missing strings render in English.
+ */
+export type LanguageCode =
+  | "en"
+  | "ta" // Tamil (TN cities)
+  | "kn" // Kannada (Karnataka)
+  | "mr" // Marathi (Maharashtra)
+  | "hi" // Hindi (Delhi, MP, UP, etc.)
+  | "te" // Telugu (Andhra, Telangana)
+  | "ml" // Malayalam (Kerala)
+  | "bn"; // Bengali (West Bengal)
 
-export const translations: Record<string, { en: string; ta: string }> = {
+/** Back-compat alias - many imports still use `Language`. */
+export type Language = LanguageCode;
+
+/** Per-language display metadata: native script name, English name, and a
+ *  one-or-two-character glyph for the toggle button. */
+export const LANGUAGE_LABELS: Record<
+  LanguageCode,
+  { native: string; english: string; toggle: string }
+> = {
+  en: { native: "English", english: "English", toggle: "EN" },
+  ta: { native: "தமிழ்", english: "Tamil", toggle: "த" },
+  kn: { native: "ಕನ್ನಡ", english: "Kannada", toggle: "ಕ" },
+  mr: { native: "मराठी", english: "Marathi", toggle: "म" },
+  hi: { native: "हिन्दी", english: "Hindi", toggle: "हि" },
+  te: { native: "తెలుగు", english: "Telugu", toggle: "తె" },
+  ml: { native: "മലയാളം", english: "Malayalam", toggle: "മ" },
+  bn: { native: "বাংলা", english: "Bengali", toggle: "ব" },
+};
+
+/** All language codes the platform recognises. Useful for runtime
+ *  validation of stored localStorage preferences. */
+export const ALL_LANGUAGES: readonly LanguageCode[] = [
+  "en",
+  "ta",
+  "kn",
+  "mr",
+  "hi",
+  "te",
+  "ml",
+  "bn",
+] as const;
+
+export function isLanguageCode(value: unknown): value is LanguageCode {
+  return typeof value === "string" && (ALL_LANGUAGES as readonly string[]).includes(value);
+}
+
+/**
+ * Shape of a single translation entry. English is required - it is both
+ * the accessibility floor and the fallback whenever a key is missing in
+ * the requested language. Other languages are optional, so e.g. Karnataka
+ * cities can ship before any string is translated to Kannada.
+ */
+export type TranslationEntry = { en: string } & Partial<
+  Record<Exclude<LanguageCode, "en">, string>
+>;
+
+export const translations: Record<string, TranslationEntry> = {
   // ── Common ────────────────────────────────────────────────────────────────
   "common.loading_map":     { en: "Loading map...", ta: "வரைபடம் ஏற்றப்படுகிறது..." },
   "common.close":           { en: "Close", ta: "மூடு" },
@@ -1421,11 +1486,11 @@ export const translations: Record<string, { en: string; ta: string }> = {
   "uplift.factor_wb_health":          { en: "Water body health", ta: "நீர்நிலை ஆரோக்கியம்" },
   "uplift.factor_wb_density":         { en: "Water body density", ta: "நீர்நிலை அடர்த்தி" },
 
-  // ── Chennai Water Facts page ──────────────────────────────────────────────
-  "facts.page_title":       { en: "Chennai Water Facts", ta: "சென்னை நீர் உண்மைகள்" },
+  // ── Water Facts page (city name interpolated via {city}) ─────────────────
+  "facts.page_title":       { en: "{city} Water Facts", ta: "{city} நீர் உண்மைகள்" },
   "facts.page_intro":       {
-    en: "Chennai's water state in quotable numbers. Every fact has a source, a date, and a methodology link. Organised by freshness: today's live data, this year's government releases, historical milestones, and structural infrastructure.",
-    ta: "சென்னையின் நீர் நிலை மேற்கோள் எண்களில். ஒவ்வொரு உண்மைக்கும் ஒரு மூலம், தேதி மற்றும் முறைமை இணைப்பு உள்ளது. புதுமையின் அடிப்படையில் ஒழுங்கமைக்கப்பட்டது: இன்றைய நேரடித் தரவு, இந்த ஆண்டின் அரசாங்க வெளியீடுகள், வரலாற்று மைல்கற்கள், மற்றும் கட்டமைப்பு உள்கட்டமைப்பு.",
+    en: "{city}'s water state in quotable numbers. Every fact has a source, a date, and a methodology link. Organised by freshness: today's live data, this year's government releases, historical milestones, and structural infrastructure.",
+    ta: "{city}யின் நீர் நிலை மேற்கோள் எண்களில். ஒவ்வொரு உண்மைக்கும் ஒரு மூலம், தேதி மற்றும் முறைமை இணைப்பு உள்ளது. புதுமையின் அடிப்படையில் ஒழுங்கமைக்கப்பட்டது: இன்றைய நேரடித் தரவு, இந்த ஆண்டின் அரசாங்க வெளியீடுகள், வரலாற்று மைல்கற்கள், மற்றும் கட்டமைப்பு உள்கட்டமைப்பு.",
   },
   "facts.last_updated":     { en: "Last updated", ta: "கடைசியாக புதுப்பிக்கப்பட்டது" },
   "facts.as_of":            { en: "As of", ta: "அன்று" },


### PR DESCRIPTION
## Summary

- **Lays the i18n foundation for Bangalore, Mumbai, Delhi, and other non-TN cities** without yet adding any of them. The hardcoded en/ta toggle becomes a per-city language list resolved from the URL.
- **Architecture commitment**: `LanguageProvider` is now city-aware via `usePathname()`. Each city's UI offers exactly the languages declared in its config (`availableLanguages: ['en', 'ta']` for TN, `['en', 'kn']` for future Karnataka cities, etc.). The Tamil-preferring user visiting /bangalore sees Kannada/English there but Tamil returns when they're back on /madurai.
- **TranslationEntry is now partial**: every key still requires English (accessibility floor + fallback), other languages are optional. Cities can onboard before any string is translated to their language; missing keys render in English at runtime.
- **No content translation in this PR.** This is just the architecture - adding a Karnataka city later is `availableLanguages: ['en', 'kn']` plus content work; nothing else changes.

## What's NOT in this PR (deferred)

- Any actual Kannada / Marathi / Hindi / Telugu / Malayalam / Bengali strings (content work; per-language module split deferred until file size demands)
- Brand / domain decisions (waits for partnership conversations to stress-test names)
- The cities themselves (Bangalore / Mumbai / Delhi onboarding lands as separate PRs)

## Files

| File | What |
|---|---|
| `src/lib/i18n/translations.ts` | `LanguageCode` union extended; `LANGUAGE_LABELS`, `ALL_LANGUAGES`, `isLanguageCode`, `TranslationEntry` (`{ en } & Partial<others>`) |
| `src/lib/i18n/context.tsx` | LanguageProvider derives `availableLanguages` from URL, derives effective `language` during render (no setState cascade), persists explicit user preference even when current city doesn't honour it |
| `src/lib/i18n/available-languages.ts` | New pure helper: pathname → city config → languages |
| `src/lib/i18n/available-languages.test.ts` | 7 cases: root, legacy paths, /madurai, /chennai explicit, unknown city, trailing slash, en-floor invariant |
| `src/lib/cities/types.ts` | `availableLanguages?: readonly LanguageCode[]` and `displayNameLocalized?: Partial<Record<LanguageCode, string>>` on PlaceConfig |
| `src/lib/cities/chennai.ts`, `madurai.ts` | Set `availableLanguages: ['en', 'ta']` and `displayNameLocalized: { ta: 'சென்னை' / 'மதுரை' }` |
| `src/components/layout/language-toggle.tsx` | UX adapts to language count: 1 → hide; 2 → cycle button; 3+ → button-with-popover. Click-outside / Escape close |

## Test plan

- [ ] `/` and `/water-bodies` (Chennai legacy) still show the EN/த toggle. No visual change.
- [ ] `/madurai/water-bodies` still shows EN/த toggle. No visual change.
- [ ] DevTools localStorage: setting `neer-vazhvu-lang = 'kn'` while on `/madurai/water-bodies` does NOT render in Kannada (Madurai doesn't offer it); user sees English. Switching back to a TN city honours their explicit `ta` if previously set.
- [ ] Backend pytest still passes (no Python changes; just a smoke check).
- [ ] `npm run build` produces all routes without errors.

## How a future city onboards

```ts
// src/lib/cities/bangalore.ts (future)
export const BANGALORE: CityConfig = {
  ...
  availableLanguages: ['en', 'kn'],
  displayNameLocalized: { kn: 'ಬೆಂಗಳೂರು' },
  ...
};
```

The toggle picks up the new languages automatically. Adding strings to `translations.ts` for Kannada is independent content work that can happen incrementally - keys without a `kn` value render in English until they're translated.