### PR TITLE
cascade: suppress polygon hover tooltips when overlay is on

### DIFF
--- a/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
+++ b/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
@@ -234,6 +234,7 @@ export default function WaterBodiesMapClient({
             riversGeoJsonUrl={`/geojson/${cityId}-rivers.geojson`}
             mapCenter={mapCenter}
             mapZoom={mapZoom}
+            suppressLayerTooltips={hasCascadeOverlay && showCascade}
           >
             {hasCascadeOverlay && showCascade && (
               <CascadeMapLayer cityId={cityId} />

--- a/src/app/water-bodies/page.tsx
+++ b/src/app/water-bodies/page.tsx
@@ -416,6 +416,7 @@ function WaterBodiesPageContent() {
               onSelectLost={setSelected}
               focusCenter={focusCenter}
               hiddenCategories={hiddenCategories}
+              suppressLayerTooltips={hasCascadeOverlay && showCascade}
             >
               {hasCascadeOverlay && showCascade && <CascadeMapLayer cityId="chennai" />}
             </UnifiedMap>

--- a/src/components/water-bodies/unified-map.tsx
+++ b/src/components/water-bodies/unified-map.tsx
@@ -44,6 +44,14 @@ interface UnifiedMapProps {
    *  MapContainer. Used to plug in opt-in overlays (e.g. cascade
    *  reconstruction) without coupling them into UnifiedMap itself. */
   children?: ReactNode;
+  /**
+   * When true, suppress hover tooltips on the current/lost/census/
+   * orphan-scored layers. The cascade overlay surfaces its own
+   * hover tooltip; having both fire at once produces a confusing
+   * dual-tooltip stack. Toggling this puts the map into
+   * "cascade mode" cleanly.
+   */
+  suppressLayerTooltips?: boolean;
 }
 
 /** Flies the map to a given center when it changes */
@@ -99,6 +107,7 @@ export function UnifiedMap({
   mapCenter = DEFAULT_MAP_CENTER,
   mapZoom = 11,
   children,
+  suppressLayerTooltips = false,
 }: UnifiedMapProps) {
   const { t, language } = useLanguage();
   const tiles = useMapTiles();
@@ -362,7 +371,11 @@ export function UnifiedMap({
       return props.name || riverInfo?.name || t("wb_panel.unnamed");
     })();
 
-    if (viewMode === "restoration") {
+    if (suppressLayerTooltips) {
+      // Skip tooltip binding entirely; the cascade overlay's hover tooltip
+      // owns the hover surface in this mode. Click-to-select still works
+      // because we still install the click handler below.
+    } else if (viewMode === "restoration") {
       const scored = scoreLookupByOsmId.get(props.osm_id);
       if (scored) {
         const levelLabel = t(`lr.${scored.priority_level}`);
@@ -431,10 +444,12 @@ export function UnifiedMap({
         ? t("wb_panel.severely_reduced")
         : t("wb_panel.partially_encroached");
 
-    layer.bindTooltip(
-      `<strong>${name}</strong><br/><span style="font-size:11px;color:#64748b">${statusLabel} · ${t("wb_map.was_area")} ${props.historical_area_ha} ha</span>`,
-      { sticky: true }
-    );
+    if (!suppressLayerTooltips) {
+      layer.bindTooltip(
+        `<strong>${name}</strong><br/><span style="font-size:11px;color:#64748b">${statusLabel} · ${t("wb_map.was_area")} ${props.historical_area_ha} ha</span>`,
+        { sticky: true }
+      );
+    }
 
     layer.on({
       click: (e) => {
@@ -494,7 +509,7 @@ export function UnifiedMap({
       {currentGeoJSON && (
         <GeoJSON
           ref={(layer) => { currentLayerRef.current = layer; }}
-          key={`current-${viewMode}-${language}-${censusMatchByOsmId.size}-${tiles.url}`}
+          key={`current-${viewMode}-${language}-${censusMatchByOsmId.size}-${tiles.url}-${suppressLayerTooltips}`}
           data={currentGeoJSON}
           style={currentStyle}
           onEachFeature={onEachCurrent}
@@ -510,7 +525,7 @@ export function UnifiedMap({
         <Pane name="lost-bodies-pane" style={{ zIndex: 540, pointerEvents: "auto" }}>
           <GeoJSON
             ref={(layer) => { lostLayerRef.current = layer; }}
-            key={`lost-${language}-${tiles.url}`}
+            key={`lost-${language}-${tiles.url}-${suppressLayerTooltips}`}
             data={lostGeoJSON}
             pointToLayer={pointToLayer}
             style={lostStyle}
@@ -552,14 +567,16 @@ export function UnifiedMap({
                       },
                     }}
                   >
-                    <Tooltip sticky>
-                      <strong>{name}</strong>
-                      <br />
-                      <span style={{ fontSize: "11px", color: "#64748b" }}>
-                        {type}
-                        {wb.ownership ? ` · ${wb.ownership}` : ""}
-                      </span>
-                    </Tooltip>
+                    {!suppressLayerTooltips && (
+                      <Tooltip sticky>
+                        <strong>{name}</strong>
+                        <br />
+                        <span style={{ fontSize: "11px", color: "#64748b" }}>
+                          {type}
+                          {wb.ownership ? ` · ${wb.ownership}` : ""}
+                        </span>
+                      </Tooltip>
+                    )}
                   </Circle>
                 );
               })}
@@ -596,17 +613,19 @@ export function UnifiedMap({
                       },
                     }}
                   >
-                    <Tooltip sticky>
-                      <strong>{name}</strong>
-                      {scored && (
-                        <>
-                          <br />
-                          <span style={{ fontSize: "11px", color: "#64748b" }}>
-                            {t("lr.priority_score")}: {scored.priority_score} · {t(`lr.${scored.priority_level}`)}
-                          </span>
-                        </>
-                      )}
-                    </Tooltip>
+                    {!suppressLayerTooltips && (
+                      <Tooltip sticky>
+                        <strong>{name}</strong>
+                        {scored && (
+                          <>
+                            <br />
+                            <span style={{ fontSize: "11px", color: "#64748b" }}>
+                              {t("lr.priority_score")}: {scored.priority_score} · {t(`lr.${scored.priority_level}`)}
+                            </span>
+                          </>
+                        )}
+                      </Tooltip>
+                    )}
                   </Circle>
                 );
               })}
@@ -653,13 +672,15 @@ export function UnifiedMap({
                     },
                   }}
                 >
-                  <Tooltip sticky>
-                    <strong>{name}</strong>
-                    <br />
-                    <span style={{ fontSize: "11px", color: "#64748b" }}>
-                      {t("lr.priority_score")}: {wb.priority_score} · {t(`lr.${wb.priority_level}`)}
-                    </span>
-                  </Tooltip>
+                  {!suppressLayerTooltips && (
+                    <Tooltip sticky>
+                      <strong>{name}</strong>
+                      <br />
+                      <span style={{ fontSize: "11px", color: "#64748b" }}>
+                        {t("lr.priority_score")}: {wb.priority_score} · {t(`lr.${wb.priority_level}`)}
+                      </span>
+                    </Tooltip>
+                  )}
                 </Circle>
               );
             })}


### PR DESCRIPTION
## Summary

When the cascade overlay was active, hovering a tank surfaced **two tooltips at once** - the existing polygon/circle-bound tooltip (water body name, area, census info) plus the cascade overlay's own hover tooltip (cascade depth, in/out degrees, drains-to-river). Reads as noise.

This PR makes the cascade overlay own the hover surface exclusively while it's on. Polygon/circle tooltips return automatically when the overlay is off.

## Change

New `suppressLayerTooltips?: boolean` prop on `UnifiedMap`. When `true`:
- `onEachCurrent` and `onEachLost` skip their `bindTooltip(...)` calls
- The three react-leaflet `<Tooltip>` children (unmatched-census in water-bodies mode, in restoration mode, and orphan-scored circles) render conditionally

The two consuming pages (`/<city>/water-bodies/water-bodies-map-client.tsx` and the legacy `/water-bodies/page.tsx`) wire the prop as `hasCascadeOverlay && showCascade`. So the suppression flips automatically with the cascade toggle - no extra UI state.

GeoJSON `key` includes `suppressLayerTooltips` so the layer remounts on toggle and `bindTooltip` runs (or doesn't) under the new flag.

Click-to-select still works in both modes; only hover surfaces change.

## Test plan

- [ ] `/madurai/water-bodies` with cascade off: hover a tank polygon → existing tooltip with name/area/census info shows. No regression.
- [ ] Toggle cascade on. Hover the same tank → only the cascade tooltip (cascade depth · X in · Y out · Z ha) appears. The polygon tooltip is gone.
- [ ] Click the polygon → BottomSheet still opens with the water body details panel. Click is unchanged.
- [ ] Same on `/water-bodies` (Chennai legacy).
- [ ] Toggle cascade off again → polygon tooltips return.

## Local CI

Pre-push: ran the full CI command set locally (ruff check + ruff format --check + pytest, npm lint + data:check + build + npm test) - all green.