### PR TITLE
cascade: hover hit-test scales with tank area

### DIFF
--- a/src/components/cascade/cascade-map-layer.tsx
+++ b/src/components/cascade/cascade-map-layer.tsx
@@ -20,11 +20,20 @@ const EDGE_COLOR = "#0ea5e9";
 // "this tank drains into the river" terminations.
 const RIVER_OUTLET_COLOR = "#f59e0b";
 
-// Hover hit-test radius in screen pixels. The cascade map already
-// shares hover space with water-body polygon tooltips and lost-tank
-// circle tooltips, so this should be tight enough that a hover OVER a
-// polygon doesn't accidentally surface a faraway cascade node.
-const NODE_HIT_RADIUS_PX = 14;
+// Hover hit-test thresholds, in METRES on the ground (not screen
+// pixels). Each tank's hit area is the larger of:
+//   - MIN_NODE_HIT_RADIUS_M (so small tanks are still grabbable when
+//     the cursor is anywhere near their centroid even when zoomed in)
+//   - the tank's area-equivalent radius (sqrt(area_ha * 10000 / pi))
+//     plus EXTRA_HIT_PADDING_M (so hovering near the visible polygon
+//     edge of a large tank like Vandiyur Lake still triggers the
+//     tooltip - earlier the fixed 14-pixel-around-centroid threshold
+//     missed the edges of any polygon larger than a small pond).
+//
+// Working in metres rather than pixels means hit areas scale naturally
+// with tank size and don't depend on the current zoom level math.
+const MIN_NODE_HIT_RADIUS_M = 60;
+const EXTRA_HIT_PADDING_M = 30;
 
 interface NodeIndexEntry {
   lat: number;
@@ -228,16 +237,29 @@ export default function CascadeMapLayer({ cityId }: CascadeMapLayerProps) {
         if (nodes.length === 0) return;
         const rect = container.getBoundingClientRect();
         const cursorPoint = L.point(clientX - rect.left, clientY - rect.top);
+        const cursorLatLng = map.containerPointToLatLng(cursorPoint);
 
+        // Pick the tank whose hit radius the cursor is inside, with the
+        // smallest cursor-to-centroid distance breaking ties (so when
+        // hit areas overlap, the tank you're nearer to wins). Working
+        // in metres lets the hit area scale with the polygon size:
+        // hovering anywhere within Vandiyur Lake's footprint (~850 m
+        // from centroid) triggers it; small tanks still fall back to
+        // the 60 m floor.
         let bestEntry: NodeIndexEntry | null = null;
-        let bestDistSq = NODE_HIT_RADIUS_PX * NODE_HIT_RADIUS_PX;
+        let bestDistM = Number.POSITIVE_INFINITY;
         for (const entry of nodes) {
-          const p = map.latLngToContainerPoint([entry.lat, entry.lng]);
-          const dx = p.x - cursorPoint.x;
-          const dy = p.y - cursorPoint.y;
-          const distSq = dx * dx + dy * dy;
-          if (distSq < bestDistSq) {
-            bestDistSq = distSq;
+          const distM = cursorLatLng.distanceTo([entry.lat, entry.lng]);
+          const tankRadiusM =
+            entry.areaHa > 0
+              ? Math.sqrt((entry.areaHa * 10000) / Math.PI)
+              : 0;
+          const hitRadiusM = Math.max(
+            MIN_NODE_HIT_RADIUS_M,
+            tankRadiusM + EXTRA_HIT_PADDING_M,
+          );
+          if (distM < hitRadiusM && distM < bestDistM) {
+            bestDistM = distM;
             bestEntry = entry;
           }
         }


### PR DESCRIPTION
## Summary

User reported that the cascade hover tooltip only fires near the centroid for large water bodies. Hovering near the **visible polygon edge** of Vandiyur Lake (228 ha) missed entirely.

Cause: hit-test was a fixed **14 screen pixels** around each tank's centroid - far smaller than the actual visible footprint of any tank larger than a small pond.

## Fix

Replace pixel-based hit-test with a **metres-based** one that scales with each tank's area:

- For each tank: compute area-equivalent circle radius (`sqrt(area_ha * 10000 / π)`). 200 ha → ~800 m. 1 ha → ~56 m.
- Hit if cursor is within `max(60 m floor, tankRadius + 30 m padding)` of the tank's centroid, measured as actual ground distance via Leaflet's `latLng.distanceTo`.
- Tie-break (when multiple hit areas overlap): pick the tank with smallest cursor-to-centroid distance.

Working in metres rather than pixels means hit areas scale naturally with tank size and don't depend on zoom level math. Hovering anywhere within the inscribed circle of a polygon triggers - matching the visible footprint for compact polygons (lakes, reservoirs) and falling back gracefully for elongated ones.

## Test plan

- [x] `/madurai/water-bodies` with cascade on → hover **anywhere on Vandiyur Lake** (the big polygon NE of city centre): tooltip should fire even when cursor is near the polygon edge.
- [x] Hover Madakulam Kanmai (124 ha): tooltip fires across its visible footprint.
- [x] Hover a small 2-3 ha tank: tooltip still fires when cursor is near the centroid (60 m floor).
- [x] Hover empty area between tanks: no tooltip (no false positives).
- [x] Same on `/water-bodies` (Chennai legacy) for tanks like Chembarambakkam (2,000 ha) - hover anywhere within visible footprint should trigger.

## Local CI

Pre-push: full CI command set ran green locally (ruff check + ruff format --check + pytest, npm lint + data:check + build + npm test).