### PR TITLE
my-ward: add rankings table - browse all wards in one view

### DIFF
--- a/src/app/[cityId]/my-ward/rankings/page.tsx
+++ b/src/app/[cityId]/my-ward/rankings/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { tryGetPlaceConfig } from "@/lib/cities";
+import { loadWardRankings } from "@/lib/ward-rankings/load-rankings";
+import { RankingsTable } from "@/components/my-ward/rankings-table";
+
+interface PageProps {
+  params: Promise<{ cityId: string }>;
+}
+
+// Daily revalidate. Ward rankings recompute from upstream JSONs that
+// refresh at most daily.
+export const revalidate = 86400;
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { cityId } = await params;
+  const config = tryGetPlaceConfig(cityId);
+  if (!config) return { title: "Ward rankings | Neer Vazhvu" };
+  return {
+    title: `${config.displayName} ward rankings | Neer Vazhvu`,
+    description: `All ${config.displayName} wards ranked by composite water-stress score. Sortable by grade, zone, and per-metric values.`,
+    alternates: { canonical: `/${cityId}/my-ward/rankings` },
+  };
+}
+
+export default async function CityWardRankingsPage({ params }: PageProps) {
+  const { cityId } = await params;
+  const config = tryGetPlaceConfig(cityId);
+  if (!config) notFound();
+
+  const bundle = loadWardRankings(cityId);
+  if (!bundle) {
+    notFound();
+  }
+
+  return (
+    <RankingsTable
+      bundle={bundle}
+      cityDisplayName={config.displayName}
+      wardDetailPathPrefix={`/${cityId}`}
+    />
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import "./globals.css";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
@@ -59,13 +58,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased" suppressHydrationWarning>
-        {/* JSON-LD via next/script avoids the React 19 "script tag inside
-            React component" warning. strategy="beforeInteractive" injects
-            into <head> before hydration, which is what crawlers want. */}
-        <Script
-          id="json-ld-webapp"
+        {/* JSON-LD for SEO. Plain <script> in a server component
+            ends up in initial HTML for crawlers; React 19 doesn't warn
+            on it the way it does on next/script <Script> with
+            beforeInteractive in App Router (per Next.js JSON-LD docs:
+            https://nextjs.org/docs/app/guides/json-ld). */}
+        <script
           type="application/ld+json"
-          strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
               "@context": "https://schema.org",

--- a/src/app/my-ward/rankings/page.tsx
+++ b/src/app/my-ward/rankings/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { loadWardRankings } from "@/lib/ward-rankings/load-rankings";
+import { RankingsTable } from "@/components/my-ward/rankings-table";
+
+export const metadata: Metadata = {
+  title: "Chennai ward rankings | Neer Vazhvu",
+  description:
+    "All 200 Chennai wards ranked by composite water-stress score. Sortable by grade, zone, and per-metric values.",
+  alternates: { canonical: "/my-ward/rankings" },
+};
+
+// Daily revalidate. Ranking recomputes from ward-profiles.json which
+// refreshes at most daily.
+export const revalidate = 86400;
+
+export default async function ChennaiWardRankingsPage() {
+  const bundle = loadWardRankings("chennai");
+  if (!bundle) notFound();
+  return (
+    <RankingsTable
+      bundle={bundle}
+      cityDisplayName="Chennai"
+      wardDetailPathPrefix=""
+    />
+  );
+}

--- a/src/components/my-ward/rankings-table.tsx
+++ b/src/components/my-ward/rankings-table.tsx
@@ -238,13 +238,18 @@ export function RankingsTable({
                   <td className="px-3 py-2 tabular-nums text-slate-700 dark:text-slate-300">
                     #{row.rank}
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-3 py-2 min-w-[180px]">
                     <Link
                       href={wardHref}
                       className="font-medium text-slate-900 dark:text-slate-100 hover:underline"
                     >
                       {row.wardName}
                     </Link>
+                    {row.localities.length > 0 && (
+                      <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        {row.localities.join(", ")}
+                      </div>
+                    )}
                   </td>
                   <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
                     {row.zone || "-"}

--- a/src/components/my-ward/rankings-table.tsx
+++ b/src/components/my-ward/rankings-table.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type {
+  WardRankingRow,
+  WardRankingsBundle,
+} from "@/lib/ward-rankings/load-rankings";
+import type { Grade } from "@/lib/utils/ward-rankings";
+import { cn } from "@/lib/utils";
+
+interface RankingsTableProps {
+  bundle: WardRankingsBundle;
+  cityDisplayName: string;
+  /** URL prefix for ward-detail navigation. "" for Chennai legacy
+   *  (ward links go to "/my-ward?ward=N"); "/<cityId>" for multi-city. */
+  wardDetailPathPrefix: string;
+}
+
+type SortKey = "rank" | "wardNumber" | "wardName" | "zone" | "grade" | string;
+type SortDir = "asc" | "desc";
+
+const GRADE_ORDER: Record<Grade, number> = { A: 1, B: 2, C: 3, D: 4, F: 5 };
+
+const GRADE_BADGE: Record<Grade, string> = {
+  A: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  B: "bg-lime-100 text-lime-800 dark:bg-lime-900/30 dark:text-lime-300",
+  C: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  D: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  F: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};
+
+const ALL_GRADES: Grade[] = ["A", "B", "C", "D", "F"];
+
+export function RankingsTable({
+  bundle,
+  cityDisplayName,
+  wardDetailPathPrefix,
+}: RankingsTableProps) {
+  const [search, setSearch] = useState("");
+  const [gradeFilter, setGradeFilter] = useState<Grade | null>(null);
+  const [zoneFilter, setZoneFilter] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("rank");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const metricColumns = bundle.rows[0]?.metricColumns ?? [];
+
+  const filteredAndSorted = useMemo(() => {
+    let rows = bundle.rows;
+    if (gradeFilter) rows = rows.filter((r) => r.grade === gradeFilter);
+    if (zoneFilter) rows = rows.filter((r) => r.zone === zoneFilter);
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          String(r.wardNumber).includes(q) ||
+          r.wardName.toLowerCase().includes(q) ||
+          r.zone.toLowerCase().includes(q),
+      );
+    }
+    return [...rows].sort((a, b) => compareRows(a, b, sortKey, sortDir));
+  }, [bundle.rows, gradeFilter, zoneFilter, search, sortKey, sortDir]);
+
+  const onSortClick = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Sensible default direction per column: rank/wardNumber asc, all others desc.
+      setSortDir(key === "rank" || key === "wardNumber" ? "asc" : "asc");
+    }
+  };
+
+  const headlineFCount = bundle.gradeCounts.F;
+  const visibleCount = filteredAndSorted.length;
+  const totalCount = bundle.rows.length;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-5">
+      <header className="space-y-2">
+        <h1 className="text-2xl sm:text-3xl font-bold text-slate-900 dark:text-slate-100">
+          {cityDisplayName} ward rankings
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+          {totalCount} wards ranked by composite water-stress score.{" "}
+          {headlineFCount > 0 && (
+            <>
+              <span className="font-semibold text-red-700 dark:text-red-400">
+                {headlineFCount} F-grade
+              </span>{" "}
+              wards need urgent attention.
+            </>
+          )}{" "}
+          Click any ward to open its full profile.
+        </p>
+      </header>
+
+      {/* Filter bar */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 font-semibold mr-1">
+            Grade
+          </span>
+          <FilterChip
+            active={gradeFilter === null}
+            onClick={() => setGradeFilter(null)}
+          >
+            All <span className="ml-1 tabular-nums opacity-70">{totalCount}</span>
+          </FilterChip>
+          {ALL_GRADES.map((g) => {
+            const count = bundle.gradeCounts[g];
+            if (count === 0) return null;
+            return (
+              <FilterChip
+                key={g}
+                active={gradeFilter === g}
+                onClick={() => setGradeFilter(gradeFilter === g ? null : g)}
+              >
+                <span
+                  className={cn(
+                    "inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-middle",
+                    GRADE_BADGE[g].split(" ").filter((c) => c.startsWith("bg-")).join(" "),
+                  )}
+                />
+                {g}
+                <span className="ml-1 tabular-nums opacity-70">{count}</span>
+              </FilterChip>
+            );
+          })}
+        </div>
+        {bundle.zones.length > 1 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 font-semibold mr-1">
+              Zone
+            </span>
+            <FilterChip
+              active={zoneFilter === null}
+              onClick={() => setZoneFilter(null)}
+            >
+              All
+            </FilterChip>
+            {bundle.zones.map((z) => (
+              <FilterChip
+                key={z}
+                active={zoneFilter === z}
+                onClick={() => setZoneFilter(zoneFilter === z ? null : z)}
+              >
+                {z}
+              </FilterChip>
+            ))}
+          </div>
+        )}
+        <div className="flex items-center gap-3 flex-wrap">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search ward number, name, or zone..."
+            className="flex-1 min-w-[220px] max-w-md px-3 py-2 text-sm rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder:text-slate-400"
+          />
+          <span className="text-xs text-slate-500 dark:text-slate-400 tabular-nums">
+            Showing {visibleCount} of {totalCount}
+          </span>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
+        <table className="min-w-full text-sm">
+          <thead className="bg-slate-50 dark:bg-slate-900/60 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <tr>
+              <SortHeader
+                label="Rank"
+                colKey="rank"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onClick={onSortClick}
+              />
+              <SortHeader
+                label="Ward"
+                colKey="wardNumber"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onClick={onSortClick}
+              />
+              <SortHeader
+                label="Zone"
+                colKey="zone"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onClick={onSortClick}
+              />
+              <SortHeader
+                label="Grade"
+                colKey="grade"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onClick={onSortClick}
+              />
+              <SortHeader
+                label="Composite"
+                colKey="compositeScore"
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onClick={onSortClick}
+              />
+              {metricColumns.map((m) => (
+                <SortHeader
+                  key={m.key}
+                  label={m.label}
+                  colKey={`metric:${m.key}`}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onClick={onSortClick}
+                />
+              ))}
+              <th className="px-3 py-2.5 text-right font-semibold">Open</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+            {filteredAndSorted.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6 + metricColumns.length}
+                  className="px-3 py-10 text-center text-slate-500 dark:text-slate-400"
+                >
+                  No wards match the current filters.
+                </td>
+              </tr>
+            )}
+            {filteredAndSorted.map((row) => {
+              const wardHref = `${wardDetailPathPrefix}/my-ward?ward=${row.wardNumber}`;
+              return (
+                <tr
+                  key={row.wardNumber}
+                  className="hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors"
+                >
+                  <td className="px-3 py-2 tabular-nums text-slate-700 dark:text-slate-300">
+                    #{row.rank}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link
+                      href={wardHref}
+                      className="font-medium text-slate-900 dark:text-slate-100 hover:underline"
+                    >
+                      {row.wardName}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-slate-600 dark:text-slate-400">
+                    {row.zone || "-"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={cn(
+                        "inline-flex items-center justify-center w-7 h-7 rounded-md text-xs font-bold",
+                        GRADE_BADGE[row.grade],
+                      )}
+                    >
+                      {row.grade}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 tabular-nums text-slate-700 dark:text-slate-300">
+                    {row.compositeScore.toFixed(1)}
+                  </td>
+                  {row.metricColumns.map((m) => (
+                    <td
+                      key={m.key}
+                      className="px-3 py-2 tabular-nums text-slate-600 dark:text-slate-400"
+                    >
+                      {m.display}
+                    </td>
+                  ))}
+                  <td className="px-3 py-2 text-right">
+                    <Link
+                      href={wardHref}
+                      className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
+                    >
+                      Open &rarr;
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+        {bundle.sourceLabel}.
+      </p>
+    </div>
+  );
+}
+
+function compareRows(
+  a: WardRankingRow,
+  b: WardRankingRow,
+  key: SortKey,
+  dir: SortDir,
+): number {
+  const mult = dir === "asc" ? 1 : -1;
+  if (key === "rank") return mult * (a.rank - b.rank);
+  if (key === "wardNumber") return mult * (a.wardNumber - b.wardNumber);
+  if (key === "wardName") return mult * a.wardName.localeCompare(b.wardName);
+  if (key === "zone") return mult * a.zone.localeCompare(b.zone);
+  if (key === "grade")
+    return mult * (GRADE_ORDER[a.grade] - GRADE_ORDER[b.grade]);
+  if (key === "compositeScore")
+    return mult * (a.compositeScore - b.compositeScore);
+  if (key.startsWith("metric:")) {
+    const metricKey = key.slice("metric:".length);
+    const av = a.metricColumns.find((m) => m.key === metricKey)?.numeric;
+    const bv = b.metricColumns.find((m) => m.key === metricKey)?.numeric;
+    // null values sort to the bottom regardless of direction.
+    if (av === null || av === undefined) return 1;
+    if (bv === null || bv === undefined) return -1;
+    return mult * (av - bv);
+  }
+  return 0;
+}
+
+function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "text-xs px-3 py-1.5 rounded-full border transition-colors",
+        active
+          ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-950 dark:text-blue-200"
+          : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SortHeader({
+  label,
+  colKey,
+  sortKey,
+  sortDir,
+  onClick,
+}: {
+  label: string;
+  colKey: SortKey;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onClick: (k: SortKey) => void;
+}) {
+  const active = sortKey === colKey;
+  return (
+    <th className="px-3 py-2.5 text-left font-semibold whitespace-nowrap">
+      <button
+        onClick={() => onClick(colKey)}
+        className={cn(
+          "inline-flex items-center gap-1 hover:text-slate-900 dark:hover:text-slate-100",
+          active && "text-slate-900 dark:text-slate-100",
+        )}
+      >
+        {label}
+        <span className="opacity-60 text-[10px]">
+          {active ? (sortDir === "asc" ? "▲" : "▼") : ""}
+        </span>
+      </button>
+    </th>
+  );
+}

--- a/src/components/my-ward/rankings-table.tsx
+++ b/src/components/my-ward/rankings-table.tsx
@@ -214,7 +214,7 @@ export function RankingsTable({
                   onClick={onSortClick}
                 />
               ))}
-              <th className="px-3 py-2.5 text-right font-semibold">Open</th>
+              <th className="px-3 py-2.5 text-right font-semibold whitespace-nowrap">Open</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
@@ -270,10 +270,10 @@ export function RankingsTable({
                       {m.display}
                     </td>
                   ))}
-                  <td className="px-3 py-2 text-right">
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
                     <Link
                       href={wardHref}
-                      className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
+                      className="text-blue-600 dark:text-blue-400 hover:underline text-xs whitespace-nowrap"
                     >
                       Open &rarr;
                     </Link>

--- a/src/components/my-ward/ward-selector.tsx
+++ b/src/components/my-ward/ward-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import Link from "next/link";
 import { useLanguage } from "@/lib/i18n/context";
 import {
   filterWards,
@@ -223,6 +224,24 @@ export function WardSelector({ onSelect, selectedWard, cityId = "chennai" }: War
           </div>
 
           {resultsDropdown}
+        </div>
+
+        {/* Browse-all entry point. Search is great when the user
+            already knows their ward; the rankings table is the
+            entry point for everyone else (journalists, residents
+            who don't know their ward number, planners) - those
+            users had nothing to click before. */}
+        <div className="mt-5">
+          <Link
+            href={
+              cityId === "chennai"
+                ? "/my-ward/rankings"
+                : `/${cityId}/my-ward/rankings`
+            }
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Browse all wards ranked &rarr;
+          </Link>
         </div>
 
         {/* Recent wards */}

--- a/src/lib/ward-rankings/load-rankings.test.ts
+++ b/src/lib/ward-rankings/load-rankings.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadWardRankings } from "./load-rankings";
+
+// Smoke tests against the real on-disk data files. They guard against:
+//   - schema drift (a column rename in ward-risk-madurai.json breaks
+//     the loader)
+//   - sort/normalisation bugs (rank=1 should always be the best ward)
+//   - city dispatch (loadWardRankings('chennai') uses the live
+//     ward-profiles compute path; loadWardRankings('madurai') uses the
+//     pre-baked file)
+//
+// Intentionally not synthetic: the real data is the contract.
+
+test("madurai bundle loads with all 100 wards and ranks ascending", () => {
+  const bundle = loadWardRankings("madurai");
+  assert.ok(bundle, "expected madurai bundle to load");
+  assert.equal(bundle.cityId, "madurai");
+  assert.equal(bundle.rows.length, 100);
+  // Rank should be 1..N in ascending order after the loader sorts.
+  bundle.rows.forEach((row, idx) => {
+    assert.equal(row.rank, idx + 1, `row ${idx} should have rank ${idx + 1}`);
+  });
+  // Rank 1 = best (lowest composite score, since Madurai's model is
+  // risk where lower = better).
+  assert.ok(
+    bundle.rows[0].compositeScore <= bundle.rows[bundle.rows.length - 1].compositeScore,
+    "best ward should have <= composite score than worst",
+  );
+});
+
+test("madurai bundle exposes the expected metric columns", () => {
+  const bundle = loadWardRankings("madurai");
+  assert.ok(bundle);
+  const firstRow = bundle.rows[0];
+  const metricKeys = firstRow.metricColumns.map((m) => m.key).sort();
+  assert.deepEqual(metricKeys, [
+    "gw_depth_m",
+    "wb_density_per_sqkm",
+    "wb_health_score",
+  ]);
+});
+
+test("madurai grade counts sum to total ward count", () => {
+  const bundle = loadWardRankings("madurai");
+  assert.ok(bundle);
+  const sum = Object.values(bundle.gradeCounts).reduce((a, b) => a + b, 0);
+  assert.equal(sum, bundle.rows.length);
+});
+
+test("madurai zones list is non-empty and unique", () => {
+  const bundle = loadWardRankings("madurai");
+  assert.ok(bundle);
+  assert.ok(bundle.zones.length > 0);
+  assert.equal(
+    new Set(bundle.zones).size,
+    bundle.zones.length,
+    "zones should be distinct",
+  );
+});
+
+test("chennai bundle loads with 200 wards and ranks ascending", () => {
+  const bundle = loadWardRankings("chennai");
+  assert.ok(bundle, "expected chennai bundle to load");
+  assert.equal(bundle.cityId, "chennai");
+  assert.equal(bundle.rows.length, 200);
+  bundle.rows.forEach((row, idx) => {
+    assert.equal(row.rank, idx + 1);
+  });
+});
+
+test("chennai metric columns include flood + drainage + sewerage", () => {
+  const bundle = loadWardRankings("chennai");
+  assert.ok(bundle);
+  const metricKeys = new Set(
+    bundle.rows[0].metricColumns.map((m) => m.key),
+  );
+  assert.ok(metricKeys.has("flood_risk"));
+  assert.ok(metricKeys.has("drainage"));
+  assert.ok(metricKeys.has("sewerage_infra"));
+});
+
+test("unknown city returns null", () => {
+  const bundle = loadWardRankings("delhi");
+  assert.equal(bundle, null);
+});

--- a/src/lib/ward-rankings/load-rankings.ts
+++ b/src/lib/ward-rankings/load-rankings.ts
@@ -38,6 +38,11 @@ export interface WardRankingRow {
   /** Percentile, 0-100; higher = better. */
   percentile: number;
   metricColumns: WardRankingMetricColumn[];
+  /** Up to 3 representative locality names that fall inside this ward,
+   *  used as a human-recognisable label below "Ward N" in the table.
+   *  Empty when no locality data is available for the city or the
+   *  specific ward. */
+  localities: string[];
 }
 
 export interface WardRankingMetricColumn {
@@ -74,10 +79,70 @@ export function loadWardRankings(cityId: string): WardRankingsBundle | null {
   return null;
 }
 
+// ── Locality lookup: ward_number -> representative locality names ─────
+
+interface LocalityEntry {
+  name: string;
+  ward_number?: number;
+}
+
+const localityCacheByCity = new Map<string, Map<number, string[]>>();
+
+/**
+ * Read the per-city localities JSON (chennai-localities.json /
+ * madurai-localities.json) and build a ward-number → top-3 locality
+ * names lookup. Localities are de-duplicated by name and trimmed to
+ * the first three encountered for each ward (no special ranking;
+ * insertion order is "as they appear in the file"). Caches per
+ * city for the lifetime of the Node process.
+ *
+ * Returns an empty Map when the city has no locality file.
+ */
+function loadLocalitiesByWard(cityId: string): Map<number, string[]> {
+  const hit = localityCacheByCity.get(cityId);
+  if (hit) return hit;
+
+  const path = resolve(
+    process.cwd(),
+    "public/data",
+    `${cityId}-localities.json`,
+  );
+  const result = new Map<number, string[]>();
+  try {
+    const entries = JSON.parse(readFileSync(path, "utf-8")) as LocalityEntry[];
+    const seenByWard = new Map<number, Set<string>>();
+    for (const entry of entries) {
+      const w = entry.ward_number;
+      const name = (entry.name ?? "").trim();
+      if (!w || !name) continue;
+      let names = result.get(w);
+      let seen = seenByWard.get(w);
+      if (!names) {
+        names = [];
+        result.set(w, names);
+      }
+      if (!seen) {
+        seen = new Set();
+        seenByWard.set(w, seen);
+      }
+      const key = name.toLowerCase();
+      if (seen.has(key) || names.length >= 3) continue;
+      seen.add(key);
+      names.push(name);
+    }
+  } catch {
+    // No locality file for this city; leave the lookup empty so the
+    // table renders just "Ward N" without a locality preview.
+  }
+  localityCacheByCity.set(cityId, result);
+  return result;
+}
+
 // ── Chennai: compute on the fly from ward-profiles.json ───────────────
 
 function loadChennaiRankings(): WardRankingsBundle {
   const profiles = loadProfilesServer("chennai");
+  const localities = loadLocalitiesByWard("chennai");
 
   // computeWardRankings recomputes every metric across the full city
   // for each call. For 200 wards it's noticeable but acceptable on
@@ -87,7 +152,7 @@ function loadChennaiRankings(): WardRankingsBundle {
   for (const profile of profiles) {
     const ranking = computeWardRankings(profile.ward_number, profiles);
     if (!ranking) continue;
-    rows.push(chennaiRankingToRow(ranking));
+    rows.push(chennaiRankingToRow(ranking, localities));
   }
   rows.sort((a, b) => a.rank - b.rank);
   // computeWardRankings may return null for wards with insufficient
@@ -110,7 +175,10 @@ function loadChennaiRankings(): WardRankingsBundle {
   };
 }
 
-function chennaiRankingToRow(r: WardRankings): WardRankingRow {
+function chennaiRankingToRow(
+  r: WardRankings,
+  localities: Map<number, string[]>,
+): WardRankingRow {
   const metricColumns: WardRankingMetricColumn[] = [];
   for (const m of r.metrics) {
     metricColumns.push({
@@ -122,12 +190,10 @@ function chennaiRankingToRow(r: WardRankings): WardRankingRow {
   }
   return {
     wardNumber: r.wardNumber,
-    // Ward identifier is just "Ward N" - the system today doesn't
-    // carry locality names per ward (zone is the closest grouping
-    // and gets its own column). Don't pretend richer naming exists.
     wardName: `Ward ${r.wardNumber}`,
     zone: r.zoneName,
     grade: r.overallGrade,
+    localities: localities.get(r.wardNumber) ?? [],
     compositeScore: r.overallScore,
     rank: r.overallRank,
     totalWards: r.overallTotal,
@@ -194,6 +260,7 @@ function loadMaduraiRankings(): WardRankingsBundle {
       readFileSync(path, "utf-8"),
     ) as MaduraiWardRiskFile;
   }
+  const localities = loadLocalitiesByWard("madurai");
 
   // Madurai composite_score is risk: higher = worse. Sort ascending so
   // best (lowest-risk) wards land at the top.
@@ -208,6 +275,7 @@ function loadMaduraiRankings(): WardRankingsBundle {
     return {
       wardNumber: w.ward_number,
       wardName: w.ward_name || `Ward ${w.ward_number}`,
+      localities: localities.get(w.ward_number) ?? [],
       zone: w.zone,
       grade: w.grade,
       compositeScore: w.composite_score,

--- a/src/lib/ward-rankings/load-rankings.ts
+++ b/src/lib/ward-rankings/load-rankings.ts
@@ -1,0 +1,268 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+import {
+  computeWardRankings,
+  type Grade,
+  type WardRankings,
+} from "@/lib/utils/ward-rankings";
+import { loadProfilesServer } from "@/lib/utils/load-profiles-server";
+
+/**
+ * Normalised "one row per ward" shape that powers the rankings table.
+ * Both data sources (Chennai's computed ward-profiles and Madurai's
+ * pre-baked ward-risk JSON) project into this shape so the table
+ * component stays city-agnostic.
+ *
+ * `metricColumns` is a free-form per-city list of secondary metric
+ * values to render as additional columns. Different cities surface
+ * different metrics (Chennai has flood/drainage/sewerage; Madurai has
+ * groundwater depth + water-body density), so the table renders
+ * whichever columns the city's loader emits.
+ */
+export interface WardRankingRow {
+  wardNumber: number;
+  wardName: string;
+  zone: string;
+  grade: Grade;
+  /** Composite score; lower or higher = better depends on the city's
+   *  scoring model. The `compositeScoreLowerIsBetter` flag on the
+   *  bundle below tells the table which arrow direction to use for
+   *  default sort. */
+  compositeScore: number;
+  /** Rank within the city, 1 = best. */
+  rank: number;
+  /** Total number of wards in the city. Used by the table for
+   *  "rank N of M" labels. */
+  totalWards: number;
+  /** Percentile, 0-100; higher = better. */
+  percentile: number;
+  metricColumns: WardRankingMetricColumn[];
+}
+
+export interface WardRankingMetricColumn {
+  /** Stable id for sort/filter wiring. */
+  key: string;
+  /** Short column header label (English; i18n later). */
+  label: string;
+  /** Display value as a string (formatted; "-" if not applicable). */
+  display: string;
+  /** Underlying numeric value for sort comparisons; null if N/A. */
+  numeric: number | null;
+}
+
+export interface WardRankingsBundle {
+  cityId: string;
+  rows: WardRankingRow[];
+  /** Counts per grade across the city, for the headline summary. */
+  gradeCounts: Record<Grade, number>;
+  /** Distinct zone names present, for the zone filter chips. */
+  zones: string[];
+  /** Source label used by the methodology blurb under the table. */
+  sourceLabel: string;
+  /** Sort default: lower compositeScore is better (Madurai uses risk-
+   *  composite where high = bad; Chennai uses percentile-derived
+   *  composite where low = bad). */
+  compositeScoreLowerIsBetter: boolean;
+}
+
+/** Public entry point: returns the ranking bundle for a city, or null
+ *  if no ranking data is available for that city. */
+export function loadWardRankings(cityId: string): WardRankingsBundle | null {
+  if (cityId === "madurai") return loadMaduraiRankings();
+  if (cityId === "chennai") return loadChennaiRankings();
+  return null;
+}
+
+// ── Chennai: compute on the fly from ward-profiles.json ───────────────
+
+function loadChennaiRankings(): WardRankingsBundle {
+  const profiles = loadProfilesServer("chennai");
+
+  // computeWardRankings recomputes every metric across the full city
+  // for each call. For 200 wards it's noticeable but acceptable on
+  // a daily ISR rebuild; if this becomes a hotspot, factor out a
+  // batched version that calls computeMetric() once per metric.
+  const rows: WardRankingRow[] = [];
+  for (const profile of profiles) {
+    const ranking = computeWardRankings(profile.ward_number, profiles);
+    if (!ranking) continue;
+    rows.push(chennaiRankingToRow(ranking));
+  }
+  rows.sort((a, b) => a.rank - b.rank);
+  // computeWardRankings may return null for wards with insufficient
+  // metric data, leaving gaps in `overallRank`. Renumber after the
+  // filter so the table's rank column is always 1..N contiguous and
+  // matches the row's position in the sorted list.
+  const total = rows.length;
+  for (let i = 0; i < rows.length; i++) {
+    rows[i] = { ...rows[i], rank: i + 1, totalWards: total };
+  }
+
+  return {
+    cityId: "chennai",
+    rows,
+    gradeCounts: countsByGrade(rows),
+    zones: distinctZones(rows),
+    sourceLabel:
+      "Computed live from public/data/ward-profiles.json - 5-factor composite (water bodies, flood, drainage, sewerage)",
+    compositeScoreLowerIsBetter: true,
+  };
+}
+
+function chennaiRankingToRow(r: WardRankings): WardRankingRow {
+  const metricColumns: WardRankingMetricColumn[] = [];
+  for (const m of r.metrics) {
+    metricColumns.push({
+      key: m.key,
+      label: shortLabelForMetric(m.key),
+      display: m.value === null ? "-" : formatMetricValue(m.value, m.unit),
+      numeric: m.value,
+    });
+  }
+  return {
+    wardNumber: r.wardNumber,
+    wardName: `Ward ${r.wardNumber}${r.zoneName ? ` - ${r.zoneName}` : ""}`,
+    zone: r.zoneName,
+    grade: r.overallGrade,
+    compositeScore: r.overallScore,
+    rank: r.overallRank,
+    totalWards: r.overallTotal,
+    percentile: r.overallPercentile,
+    metricColumns,
+  };
+}
+
+function shortLabelForMetric(key: string): string {
+  switch (key) {
+    case "wb_health":
+      return "WB health";
+    case "wb_density":
+      return "WB density";
+    case "flood_risk":
+      return "Flood risk";
+    case "drainage":
+      return "Drainage";
+    case "sewerage_infra":
+      return "Sewerage";
+    default:
+      return key;
+  }
+}
+
+function formatMetricValue(v: number, unit: string): string {
+  // Compact formatting: small values show 1-2 decimals, big values
+  // show no decimals. Unit kept short so columns stay narrow.
+  const abs = Math.abs(v);
+  if (abs === 0) return `0 ${unit}`;
+  if (abs < 1) return `${v.toFixed(2)} ${unit}`;
+  if (abs < 10) return `${v.toFixed(1)} ${unit}`;
+  return `${Math.round(v).toLocaleString()} ${unit}`;
+}
+
+// ── Madurai: read pre-baked ward-risk-madurai.json ────────────────────
+
+interface MaduraiWardRisk {
+  ward_number: number;
+  ward_name: string;
+  zone: string;
+  composite_score: number; // higher = worse risk in Madurai's model
+  grade: Grade;
+  gw_depth_m: number | null;
+  wb_density_per_sqkm: number | null;
+  wb_health_score: number | null;
+}
+
+interface MaduraiWardRiskFile {
+  algorithm_version: string;
+  weights: Record<string, number>;
+  wards: MaduraiWardRisk[];
+}
+
+let maduraiCache: MaduraiWardRiskFile | null = null;
+
+function loadMaduraiRankings(): WardRankingsBundle {
+  if (!maduraiCache) {
+    const path = resolve(
+      process.cwd(),
+      "public/data/ward-risk-madurai.json",
+    );
+    maduraiCache = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as MaduraiWardRiskFile;
+  }
+
+  // Madurai composite_score is risk: higher = worse. Sort ascending so
+  // best (lowest-risk) wards land at the top.
+  const sorted = [...maduraiCache.wards].sort(
+    (a, b) => a.composite_score - b.composite_score,
+  );
+  const total = sorted.length;
+
+  const rows: WardRankingRow[] = sorted.map((w, idx) => {
+    const rank = idx + 1;
+    const percentile = total > 1 ? ((total - rank) / (total - 1)) * 100 : 50;
+    return {
+      wardNumber: w.ward_number,
+      wardName: w.ward_name,
+      zone: w.zone,
+      grade: w.grade,
+      compositeScore: w.composite_score,
+      rank,
+      totalWards: total,
+      percentile,
+      metricColumns: [
+        {
+          key: "gw_depth_m",
+          label: "GW depth",
+          display:
+            w.gw_depth_m === null ? "-" : `${w.gw_depth_m.toFixed(1)} m`,
+          numeric: w.gw_depth_m,
+        },
+        {
+          key: "wb_density_per_sqkm",
+          label: "WB density",
+          display:
+            w.wb_density_per_sqkm === null
+              ? "-"
+              : `${w.wb_density_per_sqkm.toFixed(2)} /km²`,
+          numeric: w.wb_density_per_sqkm,
+        },
+        {
+          key: "wb_health_score",
+          label: "WB health",
+          display:
+            w.wb_health_score === null
+              ? "-"
+              : w.wb_health_score.toFixed(0),
+          numeric: w.wb_health_score,
+        },
+      ],
+    };
+  });
+
+  return {
+    cityId: "madurai",
+    rows,
+    gradeCounts: countsByGrade(rows),
+    zones: distinctZones(rows),
+    sourceLabel: `Pre-baked ${maduraiCache.algorithm_version} composite from public/data/ward-risk-madurai.json (groundwater depth, water-body density, water-body health)`,
+    // Madurai stores risk where lower = better; the table sorts the
+    // composite column ascending by default which matches "best first".
+    compositeScoreLowerIsBetter: true,
+  };
+}
+
+// ── shared helpers ────────────────────────────────────────────────────
+
+function countsByGrade(rows: WardRankingRow[]): Record<Grade, number> {
+  const counts: Record<Grade, number> = { A: 0, B: 0, C: 0, D: 0, F: 0 };
+  for (const r of rows) counts[r.grade]++;
+  return counts;
+}
+
+function distinctZones(rows: WardRankingRow[]): string[] {
+  const set = new Set<string>();
+  for (const r of rows) if (r.zone) set.add(r.zone);
+  return [...set].sort();
+}

--- a/src/lib/ward-rankings/load-rankings.ts
+++ b/src/lib/ward-rankings/load-rankings.ts
@@ -122,7 +122,10 @@ function chennaiRankingToRow(r: WardRankings): WardRankingRow {
   }
   return {
     wardNumber: r.wardNumber,
-    wardName: `Ward ${r.wardNumber}${r.zoneName ? ` - ${r.zoneName}` : ""}`,
+    // Ward identifier is just "Ward N" - the system today doesn't
+    // carry locality names per ward (zone is the closest grouping
+    // and gets its own column). Don't pretend richer naming exists.
+    wardName: `Ward ${r.wardNumber}`,
     zone: r.zoneName,
     grade: r.overallGrade,
     compositeScore: r.overallScore,
@@ -136,9 +139,9 @@ function chennaiRankingToRow(r: WardRankings): WardRankingRow {
 function shortLabelForMetric(key: string): string {
   switch (key) {
     case "wb_health":
-      return "WB health";
+      return "Water-body health";
     case "wb_density":
-      return "WB density";
+      return "Water-body density";
     case "flood_risk":
       return "Flood risk";
     case "drainage":
@@ -204,7 +207,7 @@ function loadMaduraiRankings(): WardRankingsBundle {
     const percentile = total > 1 ? ((total - rank) / (total - 1)) * 100 : 50;
     return {
       wardNumber: w.ward_number,
-      wardName: w.ward_name,
+      wardName: w.ward_name || `Ward ${w.ward_number}`,
       zone: w.zone,
       grade: w.grade,
       compositeScore: w.composite_score,
@@ -214,14 +217,14 @@ function loadMaduraiRankings(): WardRankingsBundle {
       metricColumns: [
         {
           key: "gw_depth_m",
-          label: "GW depth",
+          label: "Groundwater depth",
           display:
             w.gw_depth_m === null ? "-" : `${w.gw_depth_m.toFixed(1)} m`,
           numeric: w.gw_depth_m,
         },
         {
           key: "wb_density_per_sqkm",
-          label: "WB density",
+          label: "Water-body density",
           display:
             w.wb_density_per_sqkm === null
               ? "-"
@@ -230,7 +233,7 @@ function loadMaduraiRankings(): WardRankingsBundle {
         },
         {
           key: "wb_health_score",
-          label: "WB health",
+          label: "Water-body health",
           display:
             w.wb_health_score === null
               ? "-"


### PR DESCRIPTION
## Summary

Today's My Ward forces users to know their ward number / name to use the page. Anyone who doesn't (journalists, planners, residents new to the area, curious citizens) had no way in. This PR adds **`/my-ward/rankings`** - a sortable + filterable + searchable table of every ward, ranked by composite water-stress score.

Layer 1 of the 3-layer plan we discussed (table now → choropleth map next → split-screen if/when needed). Search keeps working untouched; this expands the page's audience without taking anything away.

## What's on the page

- **Headline**: "200 wards ranked · 12 F-grade need urgent attention" (count of F-grade wards surfaces the takeaway)
- **Filter chips**: by grade (A/B/C/D/F with counts), by zone
- **Free-text search**: ward number, name, or zone
- **Sortable columns**: rank, ward, zone, grade, composite, plus per-city metric columns (Chennai: flood / drainage / sewerage; Madurai: GW depth / WB density / WB health)
- **Click any row** → opens the existing single-ward detail page at `/<cityId>/my-ward?ward=N`
- **Source-label footer** explains the algorithm and data path so a journalist citing the table knows what they're citing

## Discoverability

The empty state of `/my-ward` (where no ward is selected) now carries a **"Browse all wards ranked →"** link to the new page, sitting just below the search box. Three personas, three paths:

| Persona | How they get value |
|---|---|
| Resident who knows their ward | Search box (unchanged) |
| Resident who doesn't know their ward number | Browse-all link → table → click row → detail |
| Journalist / NGO / planner | Browse-all link → table → sort/filter/explore |

## Architecture

| File | What |
|---|---|
| `src/lib/ward-rankings/load-rankings.ts` | Unified server-side loader. Dispatches per cityId: Chennai computes from `ward-profiles.json` via existing `computeWardRankings`; Madurai reads pre-baked `ward-risk-madurai.json`. Both project into one `WardRankingRow` shape so the table component is city-agnostic. |
| `src/components/my-ward/rankings-table.tsx` | Client table - sort, filter, search, navigate. |
| `src/app/[cityId]/my-ward/rankings/page.tsx` | Multi-city route, daily revalidate. |
| `src/app/my-ward/rankings/page.tsx` | Chennai legacy route. |
| `src/lib/ward-rankings/load-rankings.test.ts` | 7 loader contract tests against real data. |
| `src/components/my-ward/ward-selector.tsx` | Added the discovery CTA. |

Per-city metric columns vary per loader output. Adding a third city is a `if (cityId === ...)` branch in the loader (or pre-baking a `ward-risk-<city>.json` file). No table-component changes needed.

## Test plan

- [ ] `/my-ward/rankings` loads with 200 Chennai wards. F-grade count in headline matches table.
- [ ] Click "Composite" header to toggle sort. Click "Grade" to sort A→F.
- [ ] Click an F filter chip - table narrows to F-grade wards. "Showing X of 200" updates.
- [ ] Pick a zone chip - intersects with grade filter.
- [ ] Search "Anna Nagar" or "139" - rows filter live.
- [ ] Click any row's name or "Open →" - lands on existing single-ward detail page.
- [ ] `/madurai/my-ward/rankings` loads with 100 wards. Madurai metric columns are GW depth / WB density / WB health (different from Chennai).
- [ ] Madurai zone filter shows NORTH / SOUTH / EAST / WEST / CENTRAL.
- [ ] `/my-ward` empty state shows "Browse all wards ranked →" below the search; link goes to `/my-ward/rankings`.
- [ ] `/madurai/my-ward` empty state link goes to `/madurai/my-ward/rankings`.