### PR TITLE
analytics: add Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@turf/helpers": "^7.3.4",
         "@turf/length": "^7.3.4",
         "@turf/simplify": "^7.3.4",
+        "@vercel/analytics": "^2.0.1",
         "cheerio": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5550,6 +5551,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@turf/helpers": "^7.3.4",
     "@turf/length": "^7.3.4",
     "@turf/simplify": "^7.3.4",
+    "@vercel/analytics": "^2.0.1",
     "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
@@ -105,6 +106,7 @@ export default function RootLayout({
             </div>
           </ThemeProvider>
         </LanguageProvider>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Mounts `<Analytics />` from `@vercel/analytics/next` in the root layout for anonymous page-view tracking.
- Adds `@vercel/analytics` dependency.
- Cookieless / no PII; Vercel free Hobby tier gives 2,500 events/month, ample for current traffic.

## Follow-up (not in this PR)
- Privacy disclosure page (`/privacy` or footer line) - tracked separately.
- After Vercel dashboard side: enable Web Analytics on the project in the Vercel UI before the events start flowing.

## Test plan
- [ ] Vercel preview deploy builds cleanly.
- [ ] Enable Web Analytics in the Vercel dashboard for this project.
- [ ] Visit a preview URL; confirm a page-view event appears in the Vercel Analytics tab within ~30s.
- [ ] Sanity-check no console errors on the live site after merge.