### PR TITLE
bangalore: full Chennai-parity ward analytical profiles (369 GBA wards)

### DIFF
--- a/public/data/bangalore-ward-profiles.json
+++ b/public/data/bangalore-ward-profiles.json
@@ -3,14 +3,14 @@
     "ward_number": 1,
     "ward_id_local": 25,
     "ward_name": "Vinayaka Layout",
-    "ward_name_kn": "\u0cb5\u0cbf\u0ca8\u0cbe\u0caf\u0c95 \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ವಿನಾಯಕ ಲೇಔಟ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 11,
     "ro_division": "RO- Rajarajeswari Nagara",
@@ -27,20 +27,69 @@
       77.511128,
       12.966616
     ],
-    "area_sq_km": 2.5708
+    "area_sq_km": 2.5708,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.741947
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 66,
+      "pumping_main_length_km": 5.807908,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 2,
     "ward_id_local": 2,
     "ward_name": "Aerocity",
-    "ward_name_kn": "\u0c8f\u0cb0\u0ccb\u0cb8\u0cbf\u0c9f\u0cbf",
+    "ward_name_kn": "ಏರೋಸಿಟಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -57,20 +106,80 @@
       77.624894,
       13.107594
     ],
-    "area_sq_km": 10.2404
+    "area_sq_km": 10.2404,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": 54,
+      "top_bodies": [
+        {
+          "name": "Yelahanka Lake",
+          "score": 54,
+          "level": "moderate"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 7.762303
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 4.502977,
+      "total_stp_capacity_mld": 15
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 13.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 1.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 3,
     "ward_id_local": 3,
     "ward_name": "Chowdeshwari ward",
-    "ward_name_kn": "\u0c9a\u0ccc\u0ca1\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಚೌಡೇಶ್ವರಿ ವಾರ್ಡ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -87,20 +196,71 @@
       77.579267,
       13.122537
     ],
-    "area_sq_km": 6.4186
+    "area_sq_km": 6.4186,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 3.381593
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 2.044793,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 4,
     "ward_id_local": 58,
     "ward_name": "Nagashettyhalli",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0cb6\u0cc6\u0c9f\u0ccd\u0c9f\u0cbf\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ನಾಗಶೆಟ್ಟಿಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 4,
     "ro_division": "RO- Hebbal",
@@ -117,20 +277,71 @@
       77.57345,
       13.039949
     ],
-    "area_sq_km": 0.9537
+    "area_sq_km": 0.9537,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.547617
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 2.157365,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 5,
     "ward_id_local": 21,
     "ward_name": "Kogilu",
-    "ward_name_kn": "\u0c95\u0ccb\u0c97\u0cbf\u0cb2\u0cc1",
+    "ward_name_kn": "ಕೋಗಿಲು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -147,20 +358,71 @@
       77.6279,
       13.107911
     ],
-    "area_sq_km": 11.84
+    "area_sq_km": 11.84,
+    "water_bodies": {
+      "current_count": 5,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 5.48233
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 4.317637,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 15.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 6,
     "ward_id_local": 46,
     "ward_name": "Yamalur",
-    "ward_name_kn": "\u0caf\u0cae\u0cb2\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಯಮಲೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -177,20 +439,77 @@
       77.66974,
       12.941119
     ],
-    "area_sq_km": 7.0417
+    "area_sq_km": 7.0417,
+    "water_bodies": {
+      "current_count": 6,
+      "census_records": 0,
+      "restoration_critical": 1,
+      "restoration_high": 0,
+      "avg_restoration_score": 100,
+      "top_bodies": [
+        {
+          "name": "Bellandur Lake",
+          "score": 100,
+          "level": "critical"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 9.772256
+    },
+    "sewerage": {
+      "stp_count": 5,
+      "sps_count": 0,
+      "pumping_main_count": 55,
+      "pumping_main_length_km": 9.66042,
+      "total_stp_capacity_mld": 428
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 2
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 7,
     "ward_id_local": 24,
     "ward_name": "Agaram",
-    "ward_name_kn": "\u0c85\u0c97\u0cb0\u0c82",
+    "ward_name_kn": "ಅಗರಂ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -207,20 +526,68 @@
       77.639565,
       12.945102
     ],
-    "area_sq_km": 11.0223
+    "area_sq_km": 11.0223,
+    "water_bodies": {
+      "current_count": 9,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 6.521988
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 61,
+      "pumping_main_length_km": 12.139838,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 8,
     "ward_id_local": 72,
     "ward_name": "Dasarahalli",
-    "ward_name_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ದಾಸರಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -237,20 +604,66 @@
       77.516613,
       13.046151
     ],
-    "area_sq_km": 0.7408
+    "area_sq_km": 0.7408,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.16783
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 1.775022,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 11.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 9,
     "ward_id_local": 16,
     "ward_name": "Kotthur",
-    "ward_name_kn": "\u0c95\u0cca\u0ca4\u0ccd\u0ca4\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಕೊತ್ತೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -267,20 +680,68 @@
       77.677801,
       13.00698
     ],
-    "area_sq_km": 1.233
+    "area_sq_km": 1.233,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.737238
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 46,
+      "pumping_main_length_km": 2.113011,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 10,
     "ward_id_local": 69,
     "ward_name": "Bagalagunte",
-    "ward_name_kn": "\u0cac\u0cbe\u0c97\u0cb2\u0c97\u0cc1\u0c82\u0c9f\u0cc6",
+    "ward_name_kn": "ಬಾಗಲಗುಂಟೆ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -297,20 +758,69 @@
       77.499916,
       13.062787
     ],
-    "area_sq_km": 2.5107
+    "area_sq_km": 2.5107,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 3.558108
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 3.69534,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 9.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 11,
     "ward_id_local": 68,
     "ward_name": "Mallasandra",
-    "ward_name_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಮಲ್ಲಸಂದ್ರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -327,20 +837,66 @@
       77.515199,
       13.05589
     ],
-    "area_sq_km": 1.1874
+    "area_sq_km": 1.1874,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.095165
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 6,
+      "pumping_main_length_km": 1.476013,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 12,
     "ward_id_local": 70,
     "ward_name": "Manjunatha Nagar",
-    "ward_name_kn": "\u0cae\u0c82\u0c9c\u0cc1\u0ca8\u0cbe\u0ca5 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಮಂಜುನಾಥ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -357,20 +913,66 @@
       77.499785,
       13.052319
     ],
-    "area_sq_km": 1.488
+    "area_sq_km": 1.488,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.740402
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 3.420984,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 13,
     "ward_id_local": 60,
     "ward_name": "Jalahalli",
-    "ward_name_kn": "\u0c9c\u0cbe\u0cb2\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಜಾಲಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 8,
     "ro_division": "RO- Jalahalli",
@@ -387,20 +989,71 @@
       77.53656,
       13.048337
     ],
-    "area_sq_km": 1.9756
+    "area_sq_km": 1.9756,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.149699
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 37,
+      "pumping_main_length_km": 3.618332,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 14,
     "ward_id_local": 14,
     "ward_name": "K.R Pura",
-    "ward_name_kn": "\u0c95\u0cc6 \u0c86\u0cb0\u0ccd \u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕೆ ಆರ್ ಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -417,20 +1070,68 @@
       77.696913,
       13.010739
     ],
-    "area_sq_km": 0.8852
+    "area_sq_km": 0.8852,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 2.462928
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 72,
+      "pumping_main_length_km": 2.704048,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 15,
     "ward_id_local": 36,
     "ward_name": "Beguru",
-    "ward_name_kn": "\u0cac\u0cc7\u0c97\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಬೇಗೂರು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -447,20 +1148,73 @@
       77.6245,
       12.874441
     ],
-    "area_sq_km": 2.8852
+    "area_sq_km": 2.8852,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.764707
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 1.315895,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 16,
     "ward_id_local": 41,
     "ward_name": "V.V Puram",
-    "ward_name_kn": "\u0cb5\u0cbf.\u0cb5\u0cbf. \u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ವಿ.ವಿ. ಪುರಂ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -477,20 +1231,73 @@
       77.577344,
       12.950458
     ],
-    "area_sq_km": 1.0759
+    "area_sq_km": 1.0759,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.041102
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 48,
+      "pumping_main_length_km": 3.517315,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 1.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 17,
     "ward_id_local": 15,
     "ward_name": "Ramamurthy Nagara",
-    "ward_name_kn": "\u0cb0\u0cbe\u0cae\u0cae\u0cc2\u0cb0\u0ccd\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -507,20 +1314,70 @@
       77.679027,
       13.014064
     ],
-    "area_sq_km": 0.8008
+    "area_sq_km": 0.8008,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.86903
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 107,
+      "pumping_main_length_km": 5.286842,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 18,
     "ward_id_local": 7,
     "ward_name": "Byrasandra",
-    "ward_name_kn": "\u0cac\u0cc8\u0cb0\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಬೈರಸಂದ್ರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -537,20 +1394,74 @@
       77.585413,
       12.92946
     ],
-    "area_sq_km": 1.1415
+    "area_sq_km": 1.1415,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.097401
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 47,
+      "pumping_main_length_km": 3.378351,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 19,
     "ward_id_local": 8,
     "ward_name": "Tilak Nagara",
-    "ward_name_kn": "\u0ca4\u0cbf\u0cb2\u0c95 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ತಿಲಕ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -567,20 +1478,73 @@
       77.591036,
       12.927737
     ],
-    "area_sq_km": 1.0063
+    "area_sq_km": 1.0063,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.848549
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.547289,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 20,
     "ward_id_local": 34,
     "ward_name": "Subbayanapalya",
-    "ward_name_kn": "\u0cb8\u0cc1\u0cac\u0ccd\u0cac\u0caf\u0ccd\u0caf\u0ca8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಸುಬ್ಬಯ್ಯನಪಾಳ್ಯ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -597,20 +1561,68 @@
       77.639073,
       13.008242
     ],
-    "area_sq_km": 0.4783
+    "area_sq_km": 0.4783,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.277457
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 39,
+      "pumping_main_length_km": 3.448861,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 21,
     "ward_id_local": 2,
     "ward_name": "Kadirenahalli",
-    "ward_name_kn": "\u0c95\u0ca6\u0cbf\u0cb0\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕದಿರೇನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -627,20 +1639,71 @@
       77.561197,
       12.917019
     ],
-    "area_sq_km": 0.6519
+    "area_sq_km": 0.6519,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.730484
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 3.235194,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 22,
     "ward_id_local": 20,
     "ward_name": "Kengeri Kote ward",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0c97\u0cc7\u0cb0\u0cbf \u0c95\u0ccb\u0c9f\u0cc6 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕೆಂಗೇರಿ ಕೋಟೆ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -657,20 +1720,68 @@
       77.487246,
       12.895796
     ],
-    "area_sq_km": 15.2038
+    "area_sq_km": 15.2038,
+    "water_bodies": {
+      "current_count": 11,
+      "census_records": 4,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 11.307211
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 85,
+      "pumping_main_length_km": 8.677683,
+      "total_stp_capacity_mld": 60
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 23,
     "ward_id_local": 63,
     "ward_name": "J.P PARK",
-    "ward_name_kn": "\u0c9c\u0cc6\u0caa\u0cbf \u0caa\u0cbe\u0cb0\u0ccd\u0c95\u0ccd",
+    "ward_name_kn": "ಜೆಪಿ ಪಾರ್ಕ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 8,
     "ro_division": "RO- Jalahalli",
@@ -687,20 +1798,71 @@
       77.55125,
       13.0317
     ],
-    "area_sq_km": 0.8318
+    "area_sq_km": 0.8318,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.088666
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 3.92082,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 24,
     "ward_id_local": 51,
     "ward_name": "Old Guddadahalli",
-    "ward_name_kn": "\u0cb9\u0cb3\u0cc6 \u0c97\u0cc1\u0ca1\u0ccd\u0ca1\u0ca6\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹಳೆ ಗುಡ್ಡದಹಳ್ಳಿ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -717,20 +1879,71 @@
       77.547357,
       12.962531
     ],
-    "area_sq_km": 0.2113
+    "area_sq_km": 0.2113,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.396359
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 1.919215,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 25,
     "ward_id_local": 39,
     "ward_name": "Gottigere",
-    "ward_name_kn": "\u0c97\u0cca\u0c9f\u0ccd\u0c9f\u0cbf\u0c97\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಗೊಟ್ಟಿಗೆರೆ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -747,20 +1960,71 @@
       77.581614,
       12.848393
     ],
-    "area_sq_km": 2.0552
+    "area_sq_km": 2.0552,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.047733
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 26,
     "ward_id_local": 4,
     "ward_name": "Babusab Palya",
-    "ward_name_kn": "\u0cac\u0cbe\u0cac\u0cc1\u0cb8\u0cbe\u0cac\u0ccd \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಬಾಬುಸಾಬ್ ಪಾಳ್ಯ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -777,20 +2041,66 @@
       77.654481,
       13.024641
     ],
-    "area_sq_km": 1.8312
+    "area_sq_km": 1.8312,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.921261
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 1.413614,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 27,
     "ward_id_local": 4,
     "ward_name": "Banashankari Temple Ward",
-    "ward_name_kn": "\u0cac\u0ca8\u0cb6\u0c82\u0c95\u0cb0\u0cbf \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಬನಶಂಕರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -807,20 +2117,71 @@
       77.571418,
       12.911924
     ],
-    "area_sq_km": 0.3948
+    "area_sq_km": 0.3948,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.647142,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 28,
     "ward_id_local": 71,
     "ward_name": "Nele Maheshwaramma Temple Ward",
-    "ward_name_kn": "\u0ca8\u0cc6\u0cb2\u0cc6 \u0cae\u0cb9\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cae\u0ccd\u0cae \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ನೆಲೆ ಮಹೇಶ್ವರಮ್ಮ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -837,20 +2198,68 @@
       77.510793,
       13.048105
     ],
-    "area_sq_km": 0.5892
+    "area_sq_km": 0.5892,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.7332
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 39,
+      "pumping_main_length_km": 1.954379,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 29,
     "ward_id_local": 45,
     "ward_name": "Konanakunte",
-    "ward_name_kn": "\u0c95\u0ccb\u0ca3\u0ca8\u0c95\u0cc1\u0c82\u0c9f\u0cc6",
+    "ward_name_kn": "ಕೋಣನಕುಂಟೆ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -867,20 +2276,71 @@
       77.565367,
       12.881092
     ],
-    "area_sq_km": 1.6428
+    "area_sq_km": 1.6428,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 1.197822
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 1.912078,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 30,
     "ward_id_local": 13,
     "ward_name": "Marenahalli South",
-    "ward_name_kn": "\u0cae\u0cbe\u0cb0\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "ward_name_kn": "ಮಾರೇನಹಳ್ಳಿ ದಕ್ಷಿಣ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 10,
     "ro_division": "RO- JP Nagar",
@@ -897,20 +2357,73 @@
       77.589602,
       12.914313
     ],
-    "area_sq_km": 0.7565
+    "area_sq_km": 0.7565,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.996748
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 22,
+      "pumping_main_length_km": 2.535516,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 31,
     "ward_id_local": 44,
     "ward_name": "Harinagar",
-    "ward_name_kn": "\u0cb9\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಹರಿನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -927,20 +2440,71 @@
       77.572409,
       12.875058
     ],
-    "area_sq_km": 1.7695
+    "area_sq_km": 1.7695,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.527702
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 1.289412,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 0.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 32,
     "ward_id_local": 2,
     "ward_name": "Horamavu",
-    "ward_name_kn": "\u0cb9\u0cca\u0cb0\u0cae\u0cbe\u0cb5\u0cc1",
+    "ward_name_kn": "ಹೊರಮಾವು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -957,20 +2521,66 @@
       77.659302,
       13.045678
     ],
-    "area_sq_km": 7.8093
+    "area_sq_km": 7.8093,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 9,
+      "total_length_km": 11.270117
+    },
+    "sewerage": {
+      "stp_count": 5,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 2.137957,
+      "total_stp_capacity_mld": 100
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 17.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 33,
     "ward_id_local": 50,
     "ward_name": "Dinnur",
-    "ward_name_kn": "\u0ca6\u0cbf\u0ca3\u0ccd\u0ca3\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ದಿಣ್ಣೂರು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -987,20 +2597,73 @@
       77.598342,
       13.026189
     ],
-    "area_sq_km": 0.508
+    "area_sq_km": 0.508,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.346339
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 2.695281,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 34,
     "ward_id_local": 66,
     "ward_name": "Kammagondanahalli",
-    "ward_name_kn": "\u0c95\u0cae\u0ccd\u0cae\u0c97\u0cca\u0c82\u0ca1\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕಮ್ಮಗೊಂಡನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -1017,20 +2680,66 @@
       77.529317,
       13.068136
     ],
-    "area_sq_km": 1.3874
+    "area_sq_km": 1.3874,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 2.241992
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 6.363027,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 9.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 35,
     "ward_id_local": 10,
     "ward_name": "Abdul Kalam Nagar",
-    "ward_name_kn": "\u0c85\u0cac\u0ccd\u0ca6\u0cc1\u0cb2\u0ccd \u0c95\u0cb2\u0cbe\u0c82 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅಬ್ದುಲ್ ಕಲಾಂ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -1047,20 +2756,73 @@
       77.600662,
       12.922697
     ],
-    "area_sq_km": 0.4083
+    "area_sq_km": 0.4083,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.728688
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 24,
+      "pumping_main_length_km": 2.541393,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 36,
     "ward_id_local": 11,
     "ward_name": "Krishnanagar",
-    "ward_name_kn": "\u0c95\u0cc3\u0cb7\u0ccd\u0ca3\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕೃಷ್ಣನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -1077,20 +2839,68 @@
       77.711917,
       13.008081
     ],
-    "area_sq_km": 1.2273
+    "area_sq_km": 1.2273,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.182556
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 42,
+      "pumping_main_length_km": 1.87243,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 37,
     "ward_id_local": 43,
     "ward_name": "Bheereshwara Nagar",
-    "ward_name_kn": "\u0cad\u0cc0\u0cb0\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಭೀರೇಶ್ವರ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -1107,20 +2917,73 @@
       77.57344,
       12.888868
     ],
-    "area_sq_km": 0.8315
+    "area_sq_km": 0.8315,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.39566
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 2.514849,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 38,
     "ward_id_local": 42,
     "ward_name": "RBI Layout",
-    "ward_name_kn": "\u0c86\u0cb0\u0ccd\u200c\u0cac\u0cbf\u0c90 \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಆರ್‌ಬಿಐ ಲೇಔಟ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -1137,20 +3000,73 @@
       77.582704,
       12.886253
     ],
-    "area_sq_km": 2.0143
+    "area_sq_km": 2.0143,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 4.1551,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 39,
     "ward_id_local": 1,
     "ward_name": "K Narayanapura",
-    "ward_name_kn": "\u0c95\u0cc6 \u0ca8\u0cbe\u0cb0\u0cbe\u0caf\u0ca3\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕೆ ನಾರಾಯಣಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -1167,20 +3083,66 @@
       77.644367,
       13.063971
     ],
-    "area_sq_km": 4.7598
+    "area_sq_km": 4.7598,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 11,
+      "total_length_km": 6.403515
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 3,
+      "pumping_main_length_km": 0.858884,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 18
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 40,
     "ward_id_local": 39,
     "ward_name": "Hagaduru",
-    "ward_name_kn": "\u0cb9\u0c97\u0ca6\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಹಗದೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -1197,20 +3159,66 @@
       77.762021,
       12.96323
     ],
-    "area_sq_km": 5.7876
+    "area_sq_km": 5.7876,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 22,
+      "total_length_km": 11.169715
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 1.91199,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 41,
     "ward_id_local": 13,
     "ward_name": "Krishnaiahnapalya",
-    "ward_name_kn": "\u0c95\u0cc3\u0cb7\u0ccd\u0ca3\u0caf\u0ccd\u0caf\u0ca8 \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಕೃಷ್ಣಯ್ಯನ ಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -1227,20 +3235,68 @@
       77.655388,
       12.993468
     ],
-    "area_sq_km": 1.185
+    "area_sq_km": 1.185,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.135482
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 5.578534,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 42,
     "ward_id_local": 1,
     "ward_name": "Padmanabhanagara",
-    "ward_name_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪದ್ಮನಾಭನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -1257,20 +3313,71 @@
       77.556003,
       12.915495
     ],
-    "area_sq_km": 0.8955
+    "area_sq_km": 0.8955,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.141894
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 3.483726,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 43,
     "ward_id_local": 6,
     "ward_name": "Gowdanapalya",
-    "ward_name_kn": "\u0c97\u0ccc\u0ca1\u0ca8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಗೌಡನಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -1287,20 +3394,71 @@
       77.5575,
       12.907995
     ],
-    "area_sq_km": 0.9087
+    "area_sq_km": 0.9087,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.18669
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 3.916401,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 44,
     "ward_id_local": 63,
     "ward_name": "Okalipuram",
-    "ward_name_kn": "\u0c93\u0c95\u0cb3\u0cbf\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ಓಕಳಿಪುರಂ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -1317,20 +3475,73 @@
       77.564401,
       12.985047
     ],
-    "area_sq_km": 0.4237
+    "area_sq_km": 0.4237,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.993206
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 1.922584,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 45,
     "ward_id_local": 5,
     "ward_name": "Kane Muneshwara Ward",
-    "ward_name_kn": "\u0c95\u0cbe\u0ca8\u0cc6 \u0cae\u0cc1\u0ca8\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕಾನೆ ಮುನೇಶ್ವರ ವಾರ್ಡ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -1347,20 +3558,73 @@
       77.561482,
       12.903581
     ],
-    "area_sq_km": 1.1313
+    "area_sq_km": 1.1313,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.372797
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 4.858279,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 4.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 46,
     "ward_id_local": 9,
     "ward_name": "Hoysala Nagara Central",
-    "ward_name_kn": "\u0cb9\u0cca\u0caf\u0ccd\u0cb8\u0cb3 \u0ca8\u0c97\u0cb0 \u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಹೊಯ್ಸಳ ನಗರ ಕೇಂದ್ರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -1377,20 +3641,73 @@
       77.631179,
       12.982369
     ],
-    "area_sq_km": 1.9677
+    "area_sq_km": 1.9677,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.790388
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 51,
+      "pumping_main_length_km": 4.836424,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 47,
     "ward_id_local": 52,
     "ward_name": "Talagattapura",
-    "ward_name_kn": "\u0ca4\u0cb2\u0c98\u0c9f\u0ccd\u0c9f\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ತಲಘಟ್ಟಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1407,20 +3724,73 @@
       77.52753,
       12.867517
     ],
-    "area_sq_km": 18.0352
+    "area_sq_km": 18.0352,
+    "water_bodies": {
+      "current_count": 9,
+      "census_records": 7,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "vulnerable_unnamed": 4
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 8.150797
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 5,
+      "pumping_main_length_km": 0.278232,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 0.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 48,
     "ward_id_local": 45,
     "ward_name": "Marathahalli",
-    "ward_name_kn": "\u0cae\u0cbe\u0cb0\u0ca4\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಮಾರತಹಳ್ಳಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -1437,20 +3807,73 @@
       77.696478,
       12.952811
     ],
-    "area_sq_km": 0.9977
+    "area_sq_km": 0.9977,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.598105
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 35,
+      "pumping_main_length_km": 4.171652,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 1.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 49,
     "ward_id_local": 50,
     "ward_name": "Sarvabhouma Nagar",
-    "ward_name_kn": "\u0cb8\u0cbe\u0cb0\u0ccd\u0cb5\u0cad\u0ccc\u0cae \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸಾರ್ವಭೌಮ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1467,20 +3890,73 @@
       77.547059,
       12.912583
     ],
-    "area_sq_km": 1.0152
+    "area_sq_km": 1.0152,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 24,
+      "pumping_main_length_km": 1.636985,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 50,
     "ward_id_local": 53,
     "ward_name": "Rayapuram",
-    "ward_name_kn": "\u0cb0\u0cbe\u0caf\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ರಾಯಪುರಂ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -1497,20 +3973,71 @@
       77.555046,
       12.966304
     ],
-    "area_sq_km": 0.2094
+    "area_sq_km": 0.2094,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 0.855098,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 51,
     "ward_id_local": 40,
     "ward_name": "Anjanapura",
-    "ward_name_kn": "\u0c85\u0c82\u0c9c\u0ca8\u0cbe\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಅಂಜನಾಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1527,20 +4054,71 @@
       77.559771,
       12.861797
     ],
-    "area_sq_km": 12.1434
+    "area_sq_km": 12.1434,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 18,
+      "total_length_km": 15.809084
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 34,
+      "pumping_main_length_km": 7.382714,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 52,
     "ward_id_local": 59,
     "ward_name": "Vijaya Bank Layout",
-    "ward_name_kn": "\u0cb5\u0cbf\u0c9c\u0caf \u0cac\u0ccd\u0caf\u0cbe\u0c82\u0c95\u0ccd \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ವಿಜಯ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -1557,20 +4135,71 @@
       77.608902,
       12.881826
     ],
-    "area_sq_km": 4.2265
+    "area_sq_km": 4.2265,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 6.085509
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 228,
+      "pumping_main_length_km": 9.259486,
+      "total_stp_capacity_mld": 10
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 0.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 53,
     "ward_id_local": 41,
     "ward_name": "Periyar Nagar",
-    "ward_name_kn": "\u0caa\u0cc6\u0cb0\u0cbf\u0caf\u0cbe\u0cb0\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪೆರಿಯಾರ್ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -1587,20 +4216,71 @@
       77.612294,
       13.01288
     ],
-    "area_sq_km": 0.2475
+    "area_sq_km": 0.2475,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 1.406429
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 1.95068,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 54,
     "ward_id_local": 25,
     "ward_name": "L.B Shastri Nagar",
-    "ward_name_kn": "\u0c8e\u0cb2\u0ccd.\u0cac\u0cbf.\u0cb6\u0cbe\u0cb8\u0ccd\u0ca4\u0ccd\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಎಲ್.ಬಿ.ಶಾಸ್ತ್ರಿ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -1617,20 +4297,71 @@
       77.671325,
       12.965875
     ],
-    "area_sq_km": 0.4197
+    "area_sq_km": 0.4197,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.596592
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 1.053805,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 55,
     "ward_id_local": 52,
     "ward_name": "Padarayanapura",
-    "ward_name_kn": "\u0caa\u0cbe\u0ca6\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಪಾದರಾಯನಪುರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -1647,20 +4378,74 @@
       77.551136,
       12.964577
     ],
-    "area_sq_km": 0.2317
+    "area_sq_km": 0.2317,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 2,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 1.185026,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 56,
     "ward_id_local": 59,
     "ward_name": "Geddalahalli",
-    "ward_name_kn": "\u0c97\u0cc6\u0ca6\u0ccd\u0ca6\u0cb2\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಗೆದ್ದಲಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 4,
     "ro_division": "RO- Hebbal",
@@ -1677,20 +4462,74 @@
       77.570127,
       13.037212
     ],
-    "area_sq_km": 1.4548
+    "area_sq_km": 1.4548,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 3.263292
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 34,
+      "pumping_main_length_km": 3.625755,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 0.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 57,
     "ward_id_local": 51,
     "ward_name": "Subramanyapura",
-    "ward_name_kn": "\u0cb8\u0cc1\u0cac\u0ccd\u0cb0\u0cb9\u0ccd\u0cae\u0ca3\u0ccd\u0caf\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1707,20 +4546,71 @@
       77.533045,
       12.898237
     ],
-    "area_sq_km": 7.6925
+    "area_sq_km": 7.6925,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 4,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 7.609985
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 124,
+      "pumping_main_length_km": 11.141251,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 58,
     "ward_id_local": 35,
     "ward_name": "Goraguntepalya",
-    "ward_name_kn": "\u0c97\u0ccb\u0cb0\u0c97\u0cc1\u0c82\u0c9f\u0cc6\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಗೋರಗುಂಟೆಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -1737,20 +4627,73 @@
       77.541128,
       13.026571
     ],
-    "area_sq_km": 2.1106
+    "area_sq_km": 2.1106,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 3.760996,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.6
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 59,
     "ward_id_local": 28,
     "ward_name": "Kottegepalya",
-    "ward_name_kn": "\u0c95\u0cca\u0c9f\u0ccd\u0c9f\u0cbf\u0c97\u0cc6\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಕೊಟ್ಟಿಗೆಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -1767,20 +4710,69 @@
       77.516166,
       12.98661
     ],
-    "area_sq_km": 2.3918
+    "area_sq_km": 2.3918,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 3.335356
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 148,
+      "pumping_main_length_km": 10.057222,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 60,
     "ward_id_local": 62,
     "ward_name": "Brundavana Nagara",
-    "ward_name_kn": "\u0cac\u0cc3\u0c82\u0ca6\u0cbe\u0cb5\u0ca8 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಬೃಂದಾವನ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 8,
     "ro_division": "RO- Jalahalli",
@@ -1797,20 +4789,75 @@
       77.556136,
       13.032437
     ],
-    "area_sq_km": 0.67
+    "area_sq_km": 0.67,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.488334
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 2.87082,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 61,
     "ward_id_local": 5,
     "ward_name": "Yelahanka Satellite Town",
-    "ward_name_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95 \u0cb8\u0ccd\u0caf\u0cbe\u0c9f\u0cb2\u0cc8\u0c9f\u0ccd\u200c \u0c9f\u0ccc\u0ca8\u0ccd\u200c",
+    "ward_name_kn": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್‌ ಟೌನ್‌",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -1827,20 +4874,73 @@
       77.580011,
       13.097885
     ],
-    "area_sq_km": 2.9019
+    "area_sq_km": 2.9019,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.049929
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 3.708313,
+      "total_stp_capacity_mld": 10
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 11
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 62,
     "ward_id_local": 22,
     "ward_name": "Bangarappa Nagara",
-    "ward_name_kn": "\u0cac\u0c82\u0c97\u0cbe\u0cb0\u0caa\u0ccd\u0caa \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಬಂಗಾರಪ್ಪ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 11,
     "ro_division": "RO- Rajarajeswari Nagara",
@@ -1857,20 +4957,74 @@
       77.526097,
       12.920451
     ],
-    "area_sq_km": 6.7481
+    "area_sq_km": 6.7481,
+    "water_bodies": {
+      "current_count": 20,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 22,
+      "total_length_km": 12.313499
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 169,
+      "pumping_main_length_km": 16.586117,
+      "total_stp_capacity_mld": 330
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 63,
     "ward_id_local": 49,
     "ward_name": "Uttarahalli",
-    "ward_name_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಉತ್ತರಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1887,20 +5041,73 @@
       77.547626,
       12.898556
     ],
-    "area_sq_km": 2.1496
+    "area_sq_km": 2.1496,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 3.166386
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 54,
+      "pumping_main_length_km": 7.377031,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 64,
     "ward_id_local": 46,
     "ward_name": "Yelachenahalli",
-    "ward_name_kn": "\u0caf\u0cc6\u0cb2\u0c9a\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಯೆಲಚೇನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -1917,20 +5124,73 @@
       77.568727,
       12.899852
     ],
-    "area_sq_km": 0.9206
+    "area_sq_km": 0.9206,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.043812
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 2.168714,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 65,
     "ward_id_local": 37,
     "ward_name": "Yelenahalli",
-    "ward_name_kn": "\u0caf\u0cc6\u0cb2\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಯೆಲೇನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -1947,20 +5207,73 @@
       77.605731,
       12.864334
     ],
-    "area_sq_km": 5.0296
+    "area_sq_km": 5.0296,
+    "water_bodies": {
+      "current_count": 5,
+      "census_records": 5,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 4.196307
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 22,
+      "pumping_main_length_km": 3.465445,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 66,
     "ward_id_local": 64,
     "ward_name": "Yeshwanthpura",
-    "ward_name_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಯಶವಂತಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 8,
     "ro_division": "RO- Jalahalli",
@@ -1977,20 +5290,71 @@
       77.554611,
       13.023544
     ],
-    "area_sq_km": 0.3495
+    "area_sq_km": 0.3495,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.297494
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.073893,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 67,
     "ward_id_local": 11,
     "ward_name": "Old Baiyappanahalli",
-    "ward_name_kn": "\u0cb9\u0cb3\u0cc6 \u0cac\u0cc8\u0caf\u0caa\u0ccd\u0caa\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹಳೆ ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -2007,20 +5371,66 @@
       77.643145,
       12.991338
     ],
-    "area_sq_km": 0.5475
+    "area_sq_km": 0.5475,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 2.082881
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 0.955567,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 68,
     "ward_id_local": 17,
     "ward_name": "Kaggadasapura",
-    "ward_name_kn": "\u0c95\u0c97\u0ccd\u0c97\u0ca6\u0cbe\u0cb8\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕಗ್ಗದಾಸಪುರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -2037,20 +5447,66 @@
       77.672848,
       12.982301
     ],
-    "area_sq_km": 1.1511
+    "area_sq_km": 1.1511,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.341889
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 42,
+      "pumping_main_length_km": 3.093398,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 69,
     "ward_id_local": 41,
     "ward_name": "Kothanur",
-    "ward_name_kn": "\u0c95\u0cca\u0ca4\u0ccd\u0ca4\u0ca8\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಕೊತ್ತನೂರು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -2067,20 +5523,71 @@
       77.579398,
       12.869183
     ],
-    "area_sq_km": 3.4447
+    "area_sq_km": 3.4447,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.999521
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 4.990577,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 0.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 70,
     "ward_id_local": 57,
     "ward_name": "Bhoopasandra",
-    "ward_name_kn": "\u0cad\u0cc2\u0caa\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಭೂಪಸಂದ್ರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 4,
     "ro_division": "RO- Hebbal",
@@ -2097,20 +5604,73 @@
       77.582304,
       13.036538
     ],
-    "area_sq_km": 2.636
+    "area_sq_km": 2.636,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 2.99838
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 37,
+      "pumping_main_length_km": 4.332897,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 71,
     "ward_id_local": 38,
     "ward_name": "Doddakammanahalli",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1\u0c95\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ದೊಡ್ಡಕಮ್ಮನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -2127,20 +5687,73 @@
       77.594537,
       12.850168
     ],
-    "area_sq_km": 4.8748
+    "area_sq_km": 4.8748,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 4,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 3.037269
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 1,
+      "pumping_main_length_km": 0.133725,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 72,
     "ward_id_local": 28,
     "ward_name": "Byrathi",
-    "ward_name_kn": "\u0cac\u0cc8\u0cb0\u0ca4\u0cbf",
+    "ward_name_kn": "ಬೈರತಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -2157,20 +5770,66 @@
       77.687875,
       13.027882
     ],
-    "area_sq_km": 5.7323
+    "area_sq_km": 5.7323,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 21,
+      "total_length_km": 8.468006
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 0.316069,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 17.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 73,
     "ward_id_local": 19,
     "ward_name": "K.S. Nissar Ahmed Ward",
-    "ward_name_kn": "\u0c95\u0cc6. \u0c8e\u0cb8\u0ccd. \u0ca8\u0cbf\u0cb8\u0cbe\u0cb0\u0ccd \u0c85\u0cb9\u0cae\u0ca6\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕೆ. ಎಸ್. ನಿಸಾರ್ ಅಹಮದ್ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -2187,20 +5846,69 @@
       77.669007,
       12.997998
     ],
-    "area_sq_km": 0.8358
+    "area_sq_km": 0.8358,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 1.77172
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 2.557847,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 74,
     "ward_id_local": 15,
     "ward_name": "Shakambarinagara",
-    "ward_name_kn": "\u0cb6\u0cbe\u0c95\u0c82\u0cad\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಾಕಂಭರಿನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 10,
     "ro_division": "RO- JP Nagar",
@@ -2217,20 +5925,73 @@
       77.583951,
       12.910987
     ],
-    "area_sq_km": 1.7224
+    "area_sq_km": 1.7224,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.598049
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 36,
+      "pumping_main_length_km": 3.090211,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 75,
     "ward_id_local": 56,
     "ward_name": "Hebbal",
-    "ward_name_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "ward_name_kn": "ಹೆಬ್ಬಾಳ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 4,
     "ro_division": "RO- Hebbal",
@@ -2247,20 +6008,74 @@
       77.592339,
       13.035332
     ],
-    "area_sq_km": 1.0935
+    "area_sq_km": 1.0935,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.594177
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 21,
+      "pumping_main_length_km": 1.45709,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 76,
     "ward_id_local": 52,
     "ward_name": "Vishwanatha Nagenahalli",
-    "ward_name_kn": "\u0cb5\u0cbf\u0cb6\u0ccd\u0cb5\u0ca8\u0cbe\u0ca5 \u0ca8\u0cbe\u0c97\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ವಿಶ್ವನಾಥ ನಾಗೇನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -2277,20 +6092,71 @@
       77.603731,
       13.037661
     ],
-    "area_sq_km": 0.9669
+    "area_sq_km": 0.9669,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.734136
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 47,
+      "pumping_main_length_km": 5.955053,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 13
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 77,
     "ward_id_local": 4,
     "ward_name": "Sampangirama Nagar",
-    "ward_name_kn": "\u0cb8\u0c82\u0caa\u0c82\u0c97\u0cbf\u0cb0\u0cbe\u0cae \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸಂಪಂಗಿರಾಮ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -2307,20 +6173,74 @@
       77.587318,
       12.979116
     ],
-    "area_sq_km": 4.6677
+    "area_sq_km": 4.6677,
+    "water_bodies": {
+      "current_count": 6,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.295704
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 97,
+      "pumping_main_length_km": 8.491417,
+      "total_stp_capacity_mld": 4
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 1.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 78,
     "ward_id_local": 35,
     "ward_name": "Vishwapriya Nagara",
-    "ward_name_kn": "\u0cb5\u0cbf\u0cb6\u0ccd\u0cb5\u0caa\u0ccd\u0cb0\u0cbf\u0caf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವಿಶ್ವಪ್ರಿಯ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -2337,20 +6257,74 @@
       77.632907,
       12.879818
     ],
-    "area_sq_km": 2.3259
+    "area_sq_km": 2.3259,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 3,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 3.955204
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 1.442532,
+      "total_stp_capacity_mld": 5
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 79,
     "ward_id_local": 8,
     "ward_name": "Halasuru",
-    "ward_name_kn": "\u0cb9\u0cb2\u0cb8\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಹಲಸೂರು",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -2367,20 +6341,73 @@
       77.623378,
       12.977191
     ],
-    "area_sq_km": 0.5131
+    "area_sq_km": 0.5131,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.949246
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 44,
+      "pumping_main_length_km": 3.011784,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 80,
     "ward_id_local": 33,
     "ward_name": "Naganathapura",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0ca8\u0cbe\u0ca5\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ನಾಗನಾಥಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -2397,20 +6424,73 @@
       77.665687,
       12.876492
     ],
-    "area_sq_km": 3.3472
+    "area_sq_km": 3.3472,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 9,
+      "total_length_km": 3.0513
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 81,
     "ward_id_local": 12,
     "ward_name": "Kasturi Nagar",
-    "ward_name_kn": "\u0c95\u0cb8\u0ccd\u0ca4\u0cc2\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕಸ್ತೂರಿ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -2427,20 +6507,66 @@
       77.651289,
       13.00173
     ],
-    "area_sq_km": 3.5012
+    "area_sq_km": 3.5012,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.318239
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 5.028028,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 82,
     "ward_id_local": 79,
     "ward_name": "Nagarbhavi",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0cb0\u0cad\u0cbe\u0cb5\u0cbf",
+    "ward_name_kn": "ನಾಗರಭಾವಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -2457,20 +6583,69 @@
       77.517203,
       12.950877
     ],
-    "area_sq_km": 2.1779
+    "area_sq_km": 2.1779,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 3.774531
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 92,
+      "pumping_main_length_km": 10.612707,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 83,
     "ward_id_local": 10,
     "ward_name": "Basavanapura",
-    "ward_name_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಬಸವನಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -2487,20 +6662,68 @@
       77.717145,
       13.0171
     ],
-    "area_sq_km": 3.9328
+    "area_sq_km": 3.9328,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 6.221245
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 232,
+      "pumping_main_length_km": 9.80671,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 84,
     "ward_id_local": 34,
     "ward_name": "Chikkathoguru",
-    "ward_name_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95 \u0ca4\u0ccb\u0c97\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಚಿಕ್ಕ ತೋಗೂರು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 5,
     "ro_division": "RO- Beguru",
@@ -2517,20 +6740,73 @@
       77.646405,
       12.863489
     ],
-    "area_sq_km": 5.7744
+    "area_sq_km": 5.7744,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 5.120797
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 0.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 85,
     "ward_id_local": 6,
     "ward_name": "Doddabettahalli",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1\u0cac\u0cc6\u0c9f\u0ccd\u0c9f\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ದೊಡ್ಡಬೆಟ್ಟಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -2547,20 +6823,73 @@
       77.561805,
       13.104181
     ],
-    "area_sq_km": 5.0757
+    "area_sq_km": 5.0757,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 2.0471
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 145,
+      "pumping_main_length_km": 10.226134,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 86,
     "ward_id_local": 55,
     "ward_name": "Ganganagar",
-    "ward_name_kn": "\u0c97\u0c82\u0c97\u0cbe\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಗಂಗಾನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -2577,20 +6906,73 @@
       77.590708,
       13.026926
     ],
-    "area_sq_km": 0.7424
+    "area_sq_km": 0.7424,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.708554
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 2.074334,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 87,
     "ward_id_local": 49,
     "ward_name": "Kasturbha Nagar",
-    "ward_name_kn": "\u0c95\u0cb8\u0ccd\u0ca4\u0cc2\u0cb0 \u0cac\u0cbe \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd\u200c",
+    "ward_name_kn": "ಕಸ್ತೂರ ಬಾ ವಾರ್ಡ್‌",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -2607,20 +6989,71 @@
       77.552193,
       12.954312
     ],
-    "area_sq_km": 0.3699
+    "area_sq_km": 0.3699,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.610849
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 1.417682,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 88,
     "ward_id_local": 11,
     "ward_name": "Jayanagar East",
-    "ward_name_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0 \u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "ward_name_kn": "ಜಯನಗರ ಪೂರ್ವ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -2637,20 +7070,71 @@
       77.600383,
       12.920624
     ],
-    "area_sq_km": 0.4575
+    "area_sq_km": 0.4575,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 2.457972,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 89,
     "ward_id_local": 33,
     "ward_name": "Dharmaraya Swamy Temple Ward",
-    "ward_name_kn": "\u0ca7\u0cb0\u0ccd\u0cae\u0cb0\u0cbe\u0caf \u0cb8\u0ccd\u0cb5\u0cbe\u0cae\u0cbf \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಧರ್ಮರಾಯ ಸ್ವಾಮಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -2667,20 +7151,73 @@
       77.58426,
       12.964753
     ],
-    "area_sq_km": 0.76
+    "area_sq_km": 0.76,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 2.256154,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 0.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 90,
     "ward_id_local": 38,
     "ward_name": "Kanakanapalya",
-    "ward_name_kn": "\u0c95\u0ca8\u0c95\u0ca8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಕನಕನಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -2697,20 +7234,71 @@
       77.588575,
       12.940687
     ],
-    "area_sq_km": 0.9683
+    "area_sq_km": 0.9683,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.287918
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 1.710479,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 0.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 91,
     "ward_id_local": 62,
     "ward_name": "Swatantra Palya Ward",
-    "ward_name_kn": "\u0cb8\u0ccd\u0cb5\u0ca4\u0c82\u0ca4\u0ccd\u0cb0 \u0caa\u0cbe\u0cb3\u0ccd\u0caf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಸ್ವತಂತ್ರ ಪಾಳ್ಯ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -2727,20 +7315,71 @@
       77.56929,
       12.988502
     ],
-    "area_sq_km": 0.3579
+    "area_sq_km": 0.3579,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.795116
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 3.672107,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 92,
     "ward_id_local": 49,
     "ward_name": "Aramane Nagara",
-    "ward_name_kn": "\u0c85\u0cb0\u0cae\u0ca8\u0cc6 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅರಮನೆ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -2757,20 +7396,71 @@
       77.564846,
       13.030007
     ],
-    "area_sq_km": 0.8736
+    "area_sq_km": 0.8736,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.347076
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 1.367651,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 0.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 93,
     "ward_id_local": 54,
     "ward_name": "Gangenahalli",
-    "ward_name_kn": "\u0c97\u0c82\u0c97\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಗಂಗೇನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -2787,20 +7477,71 @@
       77.588817,
       13.017735
     ],
-    "area_sq_km": 1.0753
+    "area_sq_km": 1.0753,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 1.950051,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 94,
     "ward_id_local": 1,
     "ward_name": "Raja Kempegowda ward",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c \u0c95\u0cc6\u0c82\u0caa\u0cc7\u0c97\u0ccc\u0ca1 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ರಾಜ ಕೆಂಪೇಗೌಡ ವಾರ್ಡ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -2817,20 +7558,71 @@
       77.596012,
       13.096786
     ],
-    "area_sq_km": 1.7961
+    "area_sq_km": 1.7961,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.890066
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 46,
+      "pumping_main_length_km": 7.313347,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 12.6
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 1.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 95,
     "ward_id_local": 14,
     "ward_name": "J.P Nagar",
-    "ward_name_kn": "\u0c9c\u0cc6.\u0caa\u0cbf. \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜೆ.ಪಿ. ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 10,
     "ro_division": "RO- JP Nagar",
@@ -2847,20 +7639,73 @@
       77.599187,
       12.911622
     ],
-    "area_sq_km": 1.2681
+    "area_sq_km": 1.2681,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.94471
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 6.096374,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 96,
     "ward_id_local": 27,
     "ward_name": "Sri Lakshmi Devi Ward",
-    "ward_name_kn": "\u0cb6\u0ccd\u0cb0\u0cc0 \u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cc0\u0ca6\u0cc7\u0cb5\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಶ್ರೀ ಲಕ್ಷ್ಮೀದೇವಿ ವಾರ್ಡ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -2877,20 +7722,75 @@
       77.625554,
       12.94003
     ],
-    "area_sq_km": 0.7228
+    "area_sq_km": 0.7228,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.204287
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 4.542396,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 97,
     "ward_id_local": 4,
     "ward_name": "Nyayanga Badavane",
-    "ward_name_kn": "\u0ca8\u0ccd\u0caf\u0cbe\u0caf\u0cbe\u0c82\u0c97 \u0cac\u0ca1\u0cbe\u0cb5\u0ca3\u0cc6",
+    "ward_name_kn": "ನ್ಯಾಯಾಂಗ ಬಡಾವಣೆ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -2907,20 +7807,74 @@
       77.58791,
       13.087015
     ],
-    "area_sq_km": 2.5473
+    "area_sq_km": 2.5473,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 4,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 3.393701
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 105,
+      "pumping_main_length_km": 11.214656,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 12.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 98,
     "ward_id_local": 65,
     "ward_name": "Abbigere",
-    "ward_name_kn": "\u0c85\u0cac\u0ccd\u0cac\u0cbf\u0c97\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಅಬ್ಬಿಗೆರೆ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -2937,20 +7891,66 @@
       77.520197,
       13.078474
     ],
-    "area_sq_km": 4.5757
+    "area_sq_km": 4.5757,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 14,
+      "total_length_km": 7.727852
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 3.279409,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 7.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 99,
     "ward_id_local": 18,
     "ward_name": "Viswamanava Kuvempu Ward",
-    "ward_name_kn": "\u0cb5\u0cbf\u0cb6\u0ccd\u0cb5\u0cae\u0cbe\u0ca8\u0cb5 \u0c95\u0cc1\u0cb5\u0cc6\u0c82\u0caa\u0cc1 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ವಿಶ್ವಮಾನವ ಕುವೆಂಪು ವಾರ್ಡ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -2967,20 +7967,74 @@
       77.610206,
       12.913658
     ],
-    "area_sq_km": 1.3871
+    "area_sq_km": 1.3871,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.678259
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 31,
+      "pumping_main_length_km": 4.331679,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 100,
     "ward_id_local": 42,
     "ward_name": "Priyadarshini Ward",
-    "ward_name_kn": "\u0caa\u0ccd\u0cb0\u0cbf\u0caf\u0ca6\u0cb0\u0ccd\u0cb6\u0cbf\u0ca8\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಪ್ರಿಯದರ್ಶಿನಿ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -2997,20 +8051,73 @@
       77.709979,
       12.961846
     ],
-    "area_sq_km": 1.5927
+    "area_sq_km": 1.5927,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 3.697927,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 2.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 101,
     "ward_id_local": 67,
     "ward_name": "Shettihalli",
-    "ward_name_kn": "\u0cb6\u0cc6\u0c9f\u0ccd\u0c9f\u0cbf\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಶೆಟ್ಟಿಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 3,
     "ro_division": "RO- Dasarahalli",
@@ -3027,20 +8134,68 @@
       77.521331,
       13.060324
     ],
-    "area_sq_km": 3.6985
+    "area_sq_km": 3.6985,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 5.113406
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 4.310446,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 102,
     "ward_id_local": 21,
     "ward_name": "Chikka Adugodi",
-    "ward_name_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95 \u0c86\u0ca1\u0cc1\u0c97\u0ccb\u0ca1\u0cbf",
+    "ward_name_kn": "ಚಿಕ್ಕ ಆಡುಗೋಡಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -3057,20 +8212,71 @@
       77.611833,
       12.928423
     ],
-    "area_sq_km": 0.7144
+    "area_sq_km": 0.7144,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.839644
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 63,
+      "pumping_main_length_km": 3.974779,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 103,
     "ward_id_local": 7,
     "ward_name": "Attur",
-    "ward_name_kn": "\u0c85\u0c9f\u0ccd\u0c9f\u0cc1\u0cb0\u0cc1",
+    "ward_name_kn": "ಅಟ್ಟುರು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Yelahanka",
-    "assembly_constituency_kn": "\u0caf\u0cb2\u0cb9\u0c82\u0c95",
+    "assembly_constituency_kn": "ಯಲಹಂಕ",
     "assembly_no": 150,
     "ro_code": 11,
     "ro_division": "RO- Yelahanka",
@@ -3087,20 +8293,71 @@
       77.557628,
       13.093126
     ],
-    "area_sq_km": 2.5235
+    "area_sq_km": 2.5235,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 1.340412,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 9.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 104,
     "ward_id_local": 19,
     "ward_name": "New Tavarekere",
-    "ward_name_kn": "\u0cb9\u0cca\u0cb8 \u0ca4\u0cbe\u0cb5\u0cb0\u0cc6\u0c95\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಹೊಸ ತಾವರೆಕೆರೆ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -3117,20 +8374,73 @@
       77.61102,
       12.920463
     ],
-    "area_sq_km": 0.5469
+    "area_sq_km": 0.5469,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.049391
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 47,
+      "pumping_main_length_km": 4.615292,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 105,
     "ward_id_local": 70,
     "ward_name": "Iblur",
-    "ward_name_kn": "\u0c87\u0cac\u0ccd\u0cac\u0cb2\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಇಬ್ಬಲೂರು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -3147,20 +8457,66 @@
       77.656385,
       12.915786
     ],
-    "area_sq_km": 2.7926
+    "area_sq_km": 2.7926,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.514407
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 5.184419,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 106,
     "ward_id_local": 48,
     "ward_name": "Vasanthapura",
-    "ward_name_kn": "\u0cb5\u0cb8\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ವಸಂತಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -3177,20 +8533,71 @@
       77.557,
       12.890871
     ],
-    "area_sq_km": 1.5764
+    "area_sq_km": 1.5764,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.355585
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 2.984475,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Thalaghattapura Piezometer",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 107,
     "ward_id_local": 61,
     "ward_name": "HMT Ward",
-    "ward_name_kn": "\u0c8e\u0c9a\u0ccd\u0c8e\u0cae\u0ccd.\u0c9f\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಎಚ್ಎಮ್.ಟಿ ವಾರ್ಡ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 8,
     "ro_division": "RO- Jalahalli",
@@ -3207,20 +8614,71 @@
       77.543483,
       13.043948
     ],
-    "area_sq_km": 4.1666
+    "area_sq_km": 4.1666,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.44483
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 6.152044,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 108,
     "ward_id_local": 51,
     "ward_name": "Manorayanapalya",
-    "ward_name_kn": "\u0cae\u0ca8\u0ccb\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಮನೋರಾಯನಪಾಳ್ಯ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -3237,20 +8695,73 @@
       77.604078,
       13.030375
     ],
-    "area_sq_km": 0.53
+    "area_sq_km": 0.53,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.098606
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 1.472165,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 109,
     "ward_id_local": 32,
     "ward_name": "Kudlu",
-    "ward_name_kn": "\u0c95\u0cc2\u0ca1\u0ccd\u0cb2\u0cc1",
+    "ward_name_kn": "ಕೂಡ್ಲು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Anekal",
-    "assembly_constituency_kn": "\u0c86\u0ca8\u0cc7\u0c95\u0cb2\u0ccd",
+    "assembly_constituency_kn": "ಆನೇಕಲ್",
     "assembly_no": 177,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -3267,20 +8778,74 @@
       77.658653,
       12.888822
     ],
-    "area_sq_km": 3.3492
+    "area_sq_km": 3.3492,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 12,
+      "total_length_km": 6.706876
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 110,
     "ward_id_local": 25,
     "ward_name": "National Games Village",
-    "ward_name_kn": "\u0ca8\u0ccd\u0caf\u0cbe\u0cb7\u0ca8\u0cb2\u0ccd \u0c97\u0cc7\u0cae\u0ccd\u0cb8\u0ccd \u0cb5\u0cbf\u0cb2\u0cc7\u0c9c\u0ccd",
+    "ward_name_kn": "ನ್ಯಾಷನಲ್ ಗೇಮ್ಸ್ ವಿಲೇಜ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -3297,20 +8862,73 @@
       77.621859,
       12.945184
     ],
-    "area_sq_km": 0.5133
+    "area_sq_km": 0.5133,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.495978
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 2.470545,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 111,
     "ward_id_local": 22,
     "ward_name": "S.G Palya",
-    "ward_name_kn": "\u0c8e\u0cb8\u0ccd.\u0c9c\u0cbf. \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಎಸ್.ಜಿ. ಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -3327,20 +8945,73 @@
       77.604963,
       12.93294
     ],
-    "area_sq_km": 1.2384
+    "area_sq_km": 1.2384,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.232352
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 4.618111,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 112,
     "ward_id_local": 36,
     "ward_name": "Someshwara Nagara",
-    "ward_name_kn": "\u0cb8\u0ccb\u0cae\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸೋಮೇಶ್ವರ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -3357,20 +9028,71 @@
       77.597934,
       12.943931
     ],
-    "area_sq_km": 0.6144
+    "area_sq_km": 0.6144,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.195906
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 1.619583,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 113,
     "ward_id_local": 49,
     "ward_name": "Jaya Chamarajendra Nagara",
-    "ward_name_kn": "\u0c9c\u0caf \u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0cc7\u0c82\u0ca6\u0ccd\u0cb0 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜಯ ಚಾಮರಾಜೇಂದ್ರ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -3387,20 +9109,73 @@
       77.595609,
       13.015118
     ],
-    "area_sq_km": 0.6636
+    "area_sq_km": 0.6636,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.580983
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 1.563839,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 114,
     "ward_id_local": 23,
     "ward_name": "Lakkasandra",
-    "ward_name_kn": "\u0cb2\u0c95\u0ccd\u0c95\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಲಕ್ಕಸಂದ್ರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -3417,20 +9192,71 @@
       77.604596,
       12.939812
     ],
-    "area_sq_km": 0.6853
+    "area_sq_km": 0.6853,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.045542
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 2.356156,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 115,
     "ward_id_local": 27,
     "ward_name": "Ambedkarnagar",
-    "ward_name_kn": "\u0c85\u0c82\u0cac\u0cc7\u0ca1\u0ccd\u0c95\u0cb0\u0ccd\u200c\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅಂಬೇಡ್ಕರ್‌ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -3447,20 +9273,73 @@
       77.619187,
       12.950599
     ],
-    "area_sq_km": 0.3908
+    "area_sq_km": 0.3908,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.321658
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 66,
+      "pumping_main_length_km": 7.118445,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 116,
     "ward_id_local": 65,
     "ward_name": "Garvebavi Palya",
-    "ward_name_kn": "\u0c97\u0cbe\u0cb0\u0ccd\u0cb5\u0cc6\u0cac\u0cbe\u0cb5\u0cbf \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಗಾರ್ವೆಬಾವಿ ಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -3477,20 +9356,73 @@
       77.633576,
       12.894009
     ],
-    "area_sq_km": 1.2684
+    "area_sq_km": 1.2684,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.997024
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 27,
+      "pumping_main_length_km": 3.289722,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 117,
     "ward_id_local": 12,
     "ward_name": "Pattabhirama Nagara",
-    "ward_name_kn": "\u0caa\u0c9f\u0ccd\u0c9f\u0cbe\u0cad\u0cbf\u0cb0\u0cbe\u0cae \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪಟ್ಟಾಭಿರಾಮ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -3507,20 +9439,71 @@
       77.584802,
       12.919506
     ],
-    "area_sq_km": 1.4936
+    "area_sq_km": 1.4936,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.299024
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 37,
+      "pumping_main_length_km": 1.979808,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 118,
     "ward_id_local": 33,
     "ward_name": "Lakshmi Devi Nagar",
-    "ward_name_kn": "\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0ca6\u0cc7\u0cb5\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಲಕ್ಷ್ಮಿ ದೇವಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -3537,20 +9520,71 @@
       77.527768,
       13.016568
     ],
-    "area_sq_km": 0.5232
+    "area_sq_km": 0.5232,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.285628
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 83,
+      "pumping_main_length_km": 5.188304,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 119,
     "ward_id_local": 31,
     "ward_name": "Kasavanahalli",
-    "ward_name_kn": "\u0c95\u0cb8\u0cb5\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕಸವನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -3567,20 +9601,71 @@
       77.671406,
       12.905363
     ],
-    "area_sq_km": 7.6706
+    "area_sq_km": 7.6706,
+    "water_bodies": {
+      "current_count": 6,
+      "census_records": 6,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 6.988614
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 1,
+      "pumping_main_length_km": 0.1758,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 120,
     "ward_id_local": 71,
     "ward_name": "Agara",
-    "ward_name_kn": "\u0c85\u0c97\u0cb0",
+    "ward_name_kn": "ಅಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -3597,20 +9682,74 @@
       77.64629,
       12.909417
     ],
-    "area_sq_km": 1.8541
+    "area_sq_km": 1.8541,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.147033
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 92,
+      "pumping_main_length_km": 8.178646,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 121,
     "ward_id_local": 17,
     "ward_name": "N.S Palya",
-    "ward_name_kn": "\u0c8e\u0ca8\u0ccd.\u0c8e\u0cb8\u0ccd. \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಎನ್.ಎಸ್. ಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -3627,20 +9766,71 @@
       77.607506,
       12.908299
     ],
-    "area_sq_km": 0.7204
+    "area_sq_km": 0.7204,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 22,
+      "pumping_main_length_km": 3.193425,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 122,
     "ward_id_local": 55,
     "ward_name": "Puttenahalli",
-    "ward_name_kn": "\u0caa\u0cc1\u0c9f\u0ccd\u0c9f\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಪುಟ್ಟೇನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -3657,20 +9847,71 @@
       77.586106,
       12.894228
     ],
-    "area_sq_km": 1.0354
+    "area_sq_km": 1.0354,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 24,
+      "pumping_main_length_km": 5.538508,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 123,
     "ward_id_local": 56,
     "ward_name": "Doresanipalya",
-    "ward_name_kn": "\u0ca6\u0cca\u0cb0\u0cc6\u0cb8\u0cbe\u0ca8\u0cbf\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ದೊರೆಸಾನಿಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -3687,20 +9928,71 @@
       77.593126,
       12.888114
     ],
-    "area_sq_km": 2.5136
+    "area_sq_km": 2.5136,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 2.414102
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 86,
+      "pumping_main_length_km": 6.628762,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 124,
     "ward_id_local": 53,
     "ward_name": "R.T Nagar",
-    "ward_name_kn": "\u0c86\u0cb0\u0ccd.\u0c9f\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಆರ್.ಟಿ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone2",
     "zone_name": "Yelahanka",
     "assembly_constituency": "Hebbal",
-    "assembly_constituency_kn": "\u0cb9\u0cc6\u0cac\u0ccd\u0cac\u0cbe\u0cb3",
+    "assembly_constituency_kn": "ಹೆಬ್ಬಾಳ",
     "assembly_no": 158,
     "ro_code": 5,
     "ro_division": "RO- R.T Nagar",
@@ -3717,20 +10009,73 @@
       77.59639,
       13.026884
     ],
-    "area_sq_km": 0.6272
+    "area_sq_km": 0.6272,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.839534
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 2.768899,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 125,
     "ward_id_local": 13,
     "ward_name": "Kodigehalli",
-    "ward_name_kn": "\u0c95\u0cca\u0ca1\u0cbf\u0c97\u0cc6\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕೊಡಿಗೆಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -3747,20 +10092,74 @@
       77.572715,
       13.053628
     ],
-    "area_sq_km": 1.3439
+    "area_sq_km": 1.3439,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 3,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.86821
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 2.167696,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 126,
     "ward_id_local": 37,
     "ward_name": "Jeevanahalli",
-    "ward_name_kn": "\u0c9c\u0cc0\u0cb5\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಜೀವನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -3777,20 +10176,66 @@
       77.633185,
       12.997962
     ],
-    "area_sq_km": 1.5244
+    "area_sq_km": 1.5244,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 1.836241
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 55,
+      "pumping_main_length_km": 5.979627,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 127,
     "ward_id_local": 39,
     "ward_name": "Kaval Byrasandra",
-    "ward_name_kn": "\u0c95\u0cbe\u0cb5\u0cb2\u0ccd \u0cac\u0cc8\u0cb0\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 6,
     "ro_division": "RO- Kavalbyrasandra",
@@ -3807,20 +10252,71 @@
       77.608039,
       13.021433
     ],
-    "area_sq_km": 0.7254
+    "area_sq_km": 0.7254,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 1.635712
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 58,
+      "pumping_main_length_km": 4.34893,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 128,
     "ward_id_local": 42,
     "ward_name": "Aruna Asif Ali Ward",
-    "ward_name_kn": "\u0c85\u0cb0\u0cc1\u0ca3\u0cbe \u0c86\u0cb8\u0cbf\u0cab\u0ccd \u0c85\u0cb2\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಅರುಣಾ ಆಸಿಫ್ ಅಲಿ ವಾರ್ಡ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 6,
     "ro_division": "RO- Kavalbyrasandra",
@@ -3837,20 +10333,71 @@
       77.609704,
       13.015424
     ],
-    "area_sq_km": 0.353
+    "area_sq_km": 0.353,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.24049
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 37,
+      "pumping_main_length_km": 4.882671,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 129,
     "ward_id_local": 35,
     "ward_name": "Kammanahalli",
-    "ward_name_kn": "\u0c95\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕಮ್ಮನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -3867,20 +10414,66 @@
       77.632726,
       13.007875
     ],
-    "area_sq_km": 0.5122
+    "area_sq_km": 0.5122,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.229497
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 3.910639,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 130,
     "ward_id_local": 45,
     "ward_name": "Kushal Nagar",
-    "ward_name_kn": "\u0c95\u0cc1\u0cb6\u0cbe\u0cb2\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕುಶಾಲ್ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -3897,20 +10490,66 @@
       77.614632,
       13.010986
     ],
-    "area_sq_km": 0.2763
+    "area_sq_km": 0.2763,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.493247
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 2.884105,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 131,
     "ward_id_local": 25,
     "ward_name": "Govindapura",
-    "ward_name_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಗೋವಿಂದಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -3927,20 +10566,68 @@
       77.616835,
       13.031234
     ],
-    "area_sq_km": 0.5625
+    "area_sq_km": 0.5625,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 0.784322
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 4.279456,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 13.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 132,
     "ward_id_local": 16,
     "ward_name": "Amruthahalli",
-    "ward_name_kn": "\u0c85\u0cae\u0cc3\u0ca4\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಅಮೃತಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -3957,20 +10644,71 @@
       77.601369,
       13.065095
     ],
-    "area_sq_km": 1.3136
+    "area_sq_km": 1.3136,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 2.677392,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 15.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 133,
     "ward_id_local": 32,
     "ward_name": "Banaswadi",
-    "ward_name_kn": "\u0cac\u0cbe\u0ca3\u0cb8\u0cb5\u0cbe\u0ca1\u0cbf",
+    "ward_name_kn": "ಬಾಣಸವಾಡಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -3987,20 +10725,66 @@
       77.652845,
       13.014726
     ],
-    "area_sq_km": 2.0131
+    "area_sq_km": 2.0131,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.832402
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 5.579241,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 134,
     "ward_id_local": 47,
     "ward_name": "Pulakeshi Nagar",
-    "ward_name_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪುಲಕೇಶಿ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -4017,20 +10801,73 @@
       77.614698,
       12.995773
     ],
-    "area_sq_km": 1.2944
+    "area_sq_km": 1.2944,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.631317
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 48,
+      "pumping_main_length_km": 4.552304,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 135,
     "ward_id_local": 28,
     "ward_name": "Kormangala East",
-    "ward_name_kn": "\u0c95\u0ccb\u0cb0\u0cae\u0c82\u0c97\u0cb2 \u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "ward_name_kn": "ಕೋರಮಂಗಲ ಪೂರ್ವ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -4047,20 +10884,74 @@
       77.631018,
       12.930384
     ],
-    "area_sq_km": 2.2811
+    "area_sq_km": 2.2811,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 2.335104
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 80,
+      "pumping_main_length_km": 14.76219,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 136,
     "ward_id_local": 24,
     "ward_name": "HBR Layout",
-    "ward_name_kn": "\u0c8e\u0c9a\u0ccd.\u0cac\u0cbf.\u0c86\u0cb0\u0ccd. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಎಚ್.ಬಿ.ಆರ್. ಲೇಔಟ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4077,20 +10968,66 @@
       77.629997,
       13.030337
     ],
-    "area_sq_km": 1.7822
+    "area_sq_km": 1.7822,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 2.610243
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 6.865365,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 137,
     "ward_id_local": 15,
     "ward_name": "Byatarayanapura",
-    "ward_name_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -4107,20 +11044,71 @@
       77.592845,
       13.068277
     ],
-    "area_sq_km": 5.0808
+    "area_sq_km": 5.0808,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 1.996442
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 5.362778,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 14.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 138,
     "ward_id_local": 48,
     "ward_name": "S.K Garden",
-    "ward_name_kn": "\u0c8e\u0cb8\u0ccd.\u0c95\u0cc6. \u0c97\u0cbe\u0cb0\u0ccd\u0ca1\u0ca8\u0ccd",
+    "ward_name_kn": "ಎಸ್.ಕೆ. ಗಾರ್ಡನ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -4137,20 +11125,71 @@
       77.605424,
       12.99839
     ],
-    "area_sq_km": 0.9855
+    "area_sq_km": 0.9855,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.699444
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 2.276433,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 139,
     "ward_id_local": 28,
     "ward_name": "Venkateshpuram",
-    "ward_name_kn": "\u0cb5\u0cc6\u0c82\u0c95\u0c9f\u0cc7\u0cb6\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ವೆಂಕಟೇಶಪುರಂ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4167,20 +11206,66 @@
       77.619041,
       13.012657
     ],
-    "area_sq_km": 0.3631
+    "area_sq_km": 0.3631,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.562715
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 1.724583,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 140,
     "ward_id_local": 36,
     "ward_name": "Maruthi Seva Nagara",
-    "ward_name_kn": "\u0cae\u0cbe\u0cb0\u0cc1\u0ca4\u0cbf \u0cb8\u0cc7\u0cb5\u0cbe \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಮಾರುತಿ ಸೇವಾ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -4197,20 +11282,66 @@
       77.625761,
       13.004299
     ],
-    "area_sq_km": 1.197
+    "area_sq_km": 1.197,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 2.035168
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 97,
+      "pumping_main_length_km": 11.243913,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 141,
     "ward_id_local": 46,
     "ward_name": "Sagayapuram",
-    "ward_name_kn": "\u0cb8\u0c97\u0cbe\u0caf\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ಸಗಾಯಪುರಂ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -4227,20 +11358,66 @@
       77.616923,
       13.005627
     ],
-    "area_sq_km": 0.6599
+    "area_sq_km": 0.6599,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.285664
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 3.179841,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 142,
     "ward_id_local": 50,
     "ward_name": "JJR Nagara",
-    "ward_name_kn": "\u0c9c\u0cc6\u0c9c\u0cc6\u0c86\u0cb0\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜೆಜೆಆರ್ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -4257,20 +11434,71 @@
       77.552136,
       12.960208
     ],
-    "area_sq_km": 0.5315
+    "area_sq_km": 0.5315,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 1.07746,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 143,
     "ward_id_local": 66,
     "ward_name": "Singasandra",
-    "ward_name_kn": "\u0cb8\u0cbf\u0c82\u0c97\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಸಿಂಗಸಂದ್ರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -4287,20 +11515,71 @@
       77.645571,
       12.876572
     ],
-    "area_sq_km": 1.8583
+    "area_sq_km": 1.8583,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 3.363993
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 4.206977,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 0.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 144,
     "ward_id_local": 67,
     "ward_name": "Bandepalya",
-    "ward_name_kn": "\u0cac\u0c82\u0ca1\u0cc7\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಬಂಡೇಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -4317,20 +11596,74 @@
       77.648845,
       12.880392
     ],
-    "area_sq_km": 1.761
+    "area_sq_km": 1.761,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.671586
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 24,
+      "pumping_main_length_km": 3.623853,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 145,
     "ward_id_local": 38,
     "ward_name": "Shampura",
-    "ward_name_kn": "\u0cb6\u0cbe\u0c82\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಶಾಂಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 6,
     "ro_division": "RO- Kavalbyrasandra",
@@ -4347,20 +11680,71 @@
       77.610467,
       13.028881
     ],
-    "area_sq_km": 0.8662
+    "area_sq_km": 0.8662,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.101005
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 12,
+      "pumping_main_length_km": 2.536226,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 146,
     "ward_id_local": 14,
     "ward_name": "Rajiv Gandhi Nagar",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cc0\u0cb5\u0ccd \u0c97\u0cbe\u0c82\u0ca7\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಜೀವ್ ಗಾಂಧಿ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -4377,20 +11761,80 @@
       77.58515,
       13.052088
     ],
-    "area_sq_km": 2.8847
+    "area_sq_km": 2.8847,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 1,
+      "avg_restoration_score": 66,
+      "top_bodies": [
+        {
+          "name": "Hebbal Lake",
+          "score": 66,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 3.220166
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 4.639797,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 13.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 147,
     "ward_id_local": 23,
     "ward_name": "Hennur",
-    "ward_name_kn": "\u0cb9\u0cc6\u0ca3\u0ccd\u0ca3\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಹೆಣ್ಣೂರು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4407,20 +11851,68 @@
       77.63192,
       13.038008
     ],
-    "area_sq_km": 1.9264
+    "area_sq_km": 1.9264,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 4.53184
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 9.284187,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 15.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 148,
     "ward_id_local": 26,
     "ward_name": "Ejipura",
-    "ward_name_kn": "\u0c88\u0c9c\u0cbf\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಈಜಿಪುರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -4437,20 +11929,73 @@
       77.62576,
       12.946879
     ],
-    "area_sq_km": 0.5069
+    "area_sq_km": 0.5069,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.820058
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 118,
+      "pumping_main_length_km": 6.812114,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 149,
     "ward_id_local": 44,
     "ward_name": "Doddanna Nagar",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1\u0ca3\u0ccd\u0ca3 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ದೊಡ್ಡಣ್ಣ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -4467,20 +12012,73 @@
       77.609011,
       13.008269
     ],
-    "area_sq_km": 0.4559
+    "area_sq_km": 0.4559,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.384235
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 3.810022,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 150,
     "ward_id_local": 8,
     "ward_name": "Singapura",
-    "ward_name_kn": "\u0cb8\u0cbf\u0c82\u0c97\u0cbe\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಸಿಂಗಾಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -4497,20 +12095,66 @@
       77.546095,
       13.081289
     ],
-    "area_sq_km": 2.4392
+    "area_sq_km": 2.4392,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.535071
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 5.300093,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 9.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 151,
     "ward_id_local": 72,
     "ward_name": "HSR Layout",
-    "ward_name_kn": "\u0c8e\u0c9a\u0ccd\u200c\u0c8e\u0cb8\u0ccd\u200c\u0c86\u0cb0\u0ccd \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಎಚ್‌ಎಸ್‌ಆರ್ ಲೇಔಟ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -4527,20 +12171,74 @@
       77.635735,
       12.913926
     ],
-    "area_sq_km": 2.6625
+    "area_sq_km": 2.6625,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": 58,
+      "top_bodies": [
+        {
+          "name": "Agara Lake",
+          "score": 58,
+          "level": "moderate"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 5.867464
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 85,
+      "pumping_main_length_km": 12.487222,
+      "total_stp_capacity_mld": 35
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 152,
     "ward_id_local": 10,
     "ward_name": "Vidyaranyapura",
-    "ward_name_kn": "\u0cb5\u0cbf\u0ca6\u0ccd\u0caf\u0cbe\u0cb0\u0ca3\u0ccd\u0caf\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -4557,20 +12255,68 @@
       77.559243,
       13.073115
     ],
-    "area_sq_km": 1.7448
+    "area_sq_km": 1.7448,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.854952
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 4.212215,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 153,
     "ward_id_local": 61,
     "ward_name": "Kodi Chikkanahalli",
-    "ward_name_kn": "\u0c95\u0ccb\u0ca1\u0cbf \u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕೋಡಿ ಚಿಕ್ಕನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -4587,20 +12333,68 @@
       77.618502,
       12.903693
     ],
-    "area_sq_km": 1.1262
+    "area_sq_km": 1.1262,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.468011
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 52,
+      "pumping_main_length_km": 4.02472,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 0.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 154,
     "ward_id_local": 60,
     "ward_name": "Bilekahalli",
-    "ward_name_kn": "\u0cac\u0cbf\u0cb3\u0cc7\u0c95\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಬಿಳೇಕಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -4617,20 +12411,79 @@
       77.60861,
       12.903213
     ],
-    "area_sq_km": 2.474
+    "area_sq_km": 2.474,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 1,
+      "avg_restoration_score": 70,
+      "top_bodies": [
+        {
+          "name": "Madiwala Lake",
+          "score": 70,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 4.423391
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 132,
+      "pumping_main_length_km": 6.674953,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 155,
     "ward_id_local": 29,
     "ward_name": "Lingarajpura",
-    "ward_name_kn": "\u0cb2\u0cbf\u0c82\u0c97\u0cb0\u0cbe\u0c9c\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಲಿಂಗರಾಜಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4647,20 +12500,68 @@
       77.625619,
       13.014214
     ],
-    "area_sq_km": 0.923
+    "area_sq_km": 0.923,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 3.298874
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 68,
+      "pumping_main_length_km": 9.831628,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 156,
     "ward_id_local": 33,
     "ward_name": "HRBR Layout",
-    "ward_name_kn": "\u0cb9\u0cc6\u0c9a\u0ccd\u200c\u0c86\u0cb0\u0ccd\u200c\u0cac\u0cbf\u0c86\u0cb0\u0ccd \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಹೆಚ್‌ಆರ್‌ಬಿಆರ್ ಲೇಔಟ್",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -4677,20 +12578,66 @@
       77.634851,
       13.013933
     ],
-    "area_sq_km": 0.7405
+    "area_sq_km": 0.7405,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.967777
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 90,
+      "pumping_main_length_km": 6.804067,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 157,
     "ward_id_local": 30,
     "ward_name": "Kacharakanahalli",
-    "ward_name_kn": "\u0c95\u0cbe\u0c9a\u0cb0\u0c95\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕಾಚರಕನಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4707,20 +12654,68 @@
       77.632685,
       13.022552
     ],
-    "area_sq_km": 1.4145
+    "area_sq_km": 1.4145,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.51367
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 72,
+      "pumping_main_length_km": 7.662275,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 158,
     "ward_id_local": 64,
     "ward_name": "Hongasandra",
-    "ward_name_kn": "\u0cb9\u0cca\u0c82\u0c97\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಹೊಂಗಸಂದ್ರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -4737,20 +12732,73 @@
       77.627298,
       12.897491
     ],
-    "area_sq_km": 0.498
+    "area_sq_km": 0.498,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.324908
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 1,
+      "pumping_main_length_km": 0.027487,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 0.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 159,
     "ward_id_local": 22,
     "ward_name": "Nagavara",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0cb5\u0cbe\u0cb0",
+    "ward_name_kn": "ನಾಗವಾರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -4767,20 +12815,68 @@
       77.616705,
       13.037338
     ],
-    "area_sq_km": 0.9597
+    "area_sq_km": 0.9597,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 3.895246,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 14
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 160,
     "ward_id_local": 34,
     "ward_name": "D.V Gundappa Ward",
-    "ward_name_kn": "\u0ca1\u0cbf.\u0cb5\u0cbf. \u0c97\u0cc1\u0c82\u0ca1\u0caa\u0ccd\u0caa \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಡಿ.ವಿ. ಗುಂಡಪ್ಪ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -4797,20 +12893,71 @@
       77.579504,
       12.959135
     ],
-    "area_sq_km": 0.7103
+    "area_sq_km": 0.7103,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.538083
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 51,
+      "pumping_main_length_km": 4.257094,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 1.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 161,
     "ward_id_local": 10,
     "ward_name": "Cox Town",
-    "ward_name_kn": "\u0c95\u0cbe\u0c95\u0ccd\u0cb8\u0ccd \u0c9f\u0ccc\u0ca8\u0ccd",
+    "ward_name_kn": "ಕಾಕ್ಸ್ ಟೌನ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -4827,20 +12974,73 @@
       77.623643,
       12.992917
     ],
-    "area_sq_km": 1.2417
+    "area_sq_km": 1.2417,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 3.157701
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 5.660181,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 162,
     "ward_id_local": 30,
     "ward_name": "Vinayakanagar",
-    "ward_name_kn": "\u0cb5\u0cbf\u0ca8\u0cbe\u0caf\u0c95\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವಿನಾಯಕನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -4857,20 +13057,73 @@
       77.608093,
       12.95652
     ],
-    "area_sq_km": 1.2759
+    "area_sq_km": 1.2759,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.043661
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 5.137369,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 163,
     "ward_id_local": 24,
     "ward_name": "A Adugodi",
-    "ward_name_kn": "\u0c8e. \u0c86\u0ca1\u0cc1\u0c97\u0ccb\u0ca1\u0cbf",
+    "ward_name_kn": "ಎ. ಆಡುಗೋಡಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -4887,20 +13140,73 @@
       77.613541,
       12.943068
     ],
-    "area_sq_km": 1.7344
+    "area_sq_km": 1.7344,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 3.270022
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 50,
+      "pumping_main_length_km": 4.298996,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 164,
     "ward_id_local": 65,
     "ward_name": "Manjunath Nagara",
-    "ward_name_kn": "\u0cae\u0c82\u0c9c\u0cc1\u0ca8\u0cbe\u0ca5\u0ccd  \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಮಂಜುನಾಥ್  ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 8,
     "ro_division": "RO- Basaveshwara Nagara",
@@ -4917,20 +13223,71 @@
       77.547775,
       12.995547
     ],
-    "area_sq_km": 0.2842
+    "area_sq_km": 0.2842,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 0.713433,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 165,
     "ward_id_local": 66,
     "ward_name": "Sane Guruvana Halli",
-    "ward_name_kn": "\u0cb8\u0cbe\u0ca3\u0cc6 \u0c97\u0cc1\u0cb0\u0cc1\u0cb5\u0ca8 \u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಸಾಣೆ ಗುರುವನ ಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 8,
     "ro_division": "RO- Basaveshwara Nagara",
@@ -4947,20 +13304,74 @@
       77.543782,
       12.991477
     ],
-    "area_sq_km": 0.352
+    "area_sq_km": 0.352,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 24,
+      "pumping_main_length_km": 2.084276,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 166,
     "ward_id_local": 77,
     "ward_name": "Maruthi Mandira Ward",
-    "ward_name_kn": "\u0cae\u0cbe\u0cb0\u0cc1\u0ca4\u0cbf \u0cae\u0c82\u0ca6\u0cbf\u0cb0 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಮಾರುತಿ ಮಂದಿರ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -4977,20 +13388,68 @@
       77.529735,
       12.967211
     ],
-    "area_sq_km": 0.5506
+    "area_sq_km": 0.5506,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.040438
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 46,
+      "pumping_main_length_km": 4.104722,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 167,
     "ward_id_local": 71,
     "ward_name": "Thimmenahalli",
-    "ward_name_kn": "\u0ca4\u0cbf\u0cae\u0ccd\u0cae\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ತಿಮ್ಮೇನಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -5007,20 +13466,66 @@
       77.540196,
       12.977089
     ],
-    "area_sq_km": 0.6915
+    "area_sq_km": 0.6915,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.826124
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 0.94032,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 168,
     "ward_id_local": 31,
     "ward_name": "Shanthinagar",
-    "ward_name_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಾಂತಿನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -5037,20 +13542,74 @@
       77.599262,
       12.957992
     ],
-    "area_sq_km": 1.5351
+    "area_sq_km": 1.5351,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.447283
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 82,
+      "pumping_main_length_km": 8.35138,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 1.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 169,
     "ward_id_local": 29,
     "ward_name": "Kormangala West",
-    "ward_name_kn": "\u0c95\u0ccb\u0cb0\u0cae\u0c82\u0c97\u0cb2 \u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "ward_name_kn": "ಕೋರಮಂಗಲ ಪಶ್ಚಿಮ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -5067,20 +13626,73 @@
       77.620236,
       12.929175
     ],
-    "area_sq_km": 2.4402
+    "area_sq_km": 2.4402,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 1.218003
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 4.420854,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 170,
     "ward_id_local": 54,
     "ward_name": "Kengal Hanumanthaiah South",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0c97\u0cb2\u0ccd \u0cb9\u0ca8\u0cc1\u0cae\u0c82\u0ca4\u0caf\u0ccd\u0caf \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "ward_name_kn": "ಕೆಂಗಲ್ ಹನುಮಂತಯ್ಯ ದಕ್ಷಿಣ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -5097,20 +13709,73 @@
       77.583029,
       12.902361
     ],
-    "area_sq_km": 0.8335
+    "area_sq_km": 0.8335,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.938548
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 4.193187,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 171,
     "ward_id_local": 20,
     "ward_name": "Madiwala",
-    "ward_name_kn": "\u0cae\u0ca1\u0cbf\u0cb5\u0cbe\u0cb3",
+    "ward_name_kn": "ಮಡಿವಾಳ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 2,
     "ro_division": "RO- B.T.M Layout",
@@ -5127,20 +13792,71 @@
       77.617289,
       12.92028
     ],
-    "area_sq_km": 0.6881
+    "area_sq_km": 0.6881,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.938426
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 5.117202,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 172,
     "ward_id_local": 9,
     "ward_name": "N.A.L Layout",
-    "ward_name_kn": "\u0c8e\u0ca8\u0ccd\u200c.\u0c8e.\u0c8e\u0cb2\u0ccd \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಎನ್‌.ಎ.ಎಲ್ ಲೇಔಟ್",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 9,
     "ro_division": "RO- Jayanagar",
@@ -5157,20 +13873,74 @@
       77.601141,
       12.925025
     ],
-    "area_sq_km": 0.3445
+    "area_sq_km": 0.3445,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 0.787957
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 4,
+      "pumping_main_length_km": 0.767408,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 3.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 173,
     "ward_id_local": 48,
     "ward_name": "Mathikere",
-    "ward_name_kn": "\u0cae\u0ca4\u0ccd\u0ca4\u0cbf\u0c95\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಮತ್ತಿಕೆರೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -5187,20 +13957,73 @@
       77.561149,
       13.035659
     ],
-    "area_sq_km": 0.6712
+    "area_sq_km": 0.6712,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.398574
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 1.388089,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 174,
     "ward_id_local": 62,
     "ward_name": "Devarachikkanahalli",
-    "ward_name_kn": "\u0ca6\u0cc7\u0cb5\u0cb0\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ದೇವರಚಿಕ್ಕನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -5217,20 +14040,73 @@
       77.621791,
       12.892495
     ],
-    "area_sq_km": 1.1875
+    "area_sq_km": 1.1875,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.595471
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 1.017277,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 175,
     "ward_id_local": 34,
     "ward_name": "Peenya",
-    "ward_name_kn": "\u0caa\u0cc0\u0ca3\u0ccd\u0caf",
+    "ward_name_kn": "ಪೀಣ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -5247,20 +14123,73 @@
       77.527654,
       13.032797
     ],
-    "area_sq_km": 3.9922
+    "area_sq_km": 3.9922,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 4.390896
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 18,
+      "pumping_main_length_km": 6.368421,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 176,
     "ward_id_local": 18,
     "ward_name": "Kempapura",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0caa\u0cbe\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕೆಂಪಾಪುರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -5277,20 +14206,69 @@
       77.610598,
       13.047165
     ],
-    "area_sq_km": 5.3026
+    "area_sq_km": 5.3026,
+    "water_bodies": {
+      "current_count": 6,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 8,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 6
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 6.208272
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 97,
+      "pumping_main_length_km": 11.863833,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 14.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 177,
     "ward_id_local": 7,
     "ward_name": "Rajagopala Nagara",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0c97\u0ccb\u0caa\u0cbe\u0cb2 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಜಗೋಪಾಲ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -5307,20 +14285,68 @@
       77.511309,
       13.008529
     ],
-    "area_sq_km": 0.9997
+    "area_sq_km": 0.9997,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.449435
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 12,
+      "pumping_main_length_km": 2.192618,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 178,
     "ward_id_local": 93,
     "ward_name": "Avalahalli",
-    "ward_name_kn": "\u0c86\u0cb5\u0cb2\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಆವಲಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 12,
     "ro_division": "RO- Hampi Nagar",
@@ -5337,20 +14363,71 @@
       77.543063,
       12.945594
     ],
-    "area_sq_km": 0.4517
+    "area_sq_km": 0.4517,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.397031
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 1.065167,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 179,
     "ward_id_local": 43,
     "ward_name": "Varalakshmi Nagar",
-    "ward_name_kn": "\u0cb5\u0cb0\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವರಲಕ್ಷ್ಮಿ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 6,
     "ro_division": "RO- Kavalbyrasandra",
@@ -5367,20 +14444,71 @@
       77.602789,
       13.014597
     ],
-    "area_sq_km": 1.6758
+    "area_sq_km": 1.6758,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.893816
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 2.194603,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 11.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 180,
     "ward_id_local": 88,
     "ward_name": "Sangolli Rayanna Ward",
-    "ward_name_kn": "\u0cb8\u0c82\u0c97\u0cca\u0cb3\u0ccd\u0cb3\u0cbf \u0cb0\u0cbe\u0caf\u0ca3\u0ccd\u0ca3 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಸಂಗೊಳ್ಳಿ ರಾಯಣ್ಣ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -5397,20 +14525,73 @@
       77.555024,
       12.970871
     ],
-    "area_sq_km": 0.1963
+    "area_sq_km": 0.1963,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.067621
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 1.60207,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 181,
     "ward_id_local": 20,
     "ward_name": "Sampigehalli",
-    "ward_name_kn": "\u0cb8\u0c82\u0caa\u0cbf\u0c97\u0cc6\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಸಂಪಿಗೆಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -5427,20 +14608,71 @@
       77.625902,
       13.08383
     ],
-    "area_sq_km": 8.7727
+    "area_sq_km": 8.7727,
+    "water_bodies": {
+      "current_count": 6,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 13,
+      "total_length_km": 7.92633
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 6.701998,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 16.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 182,
     "ward_id_local": 12,
     "ward_name": "Thindlu",
-    "ward_name_kn": "\u0ca4\u0cbf\u0c82\u0ca1\u0ccd\u0cb2\u0cc1",
+    "ward_name_kn": "ತಿಂಡ್ಲು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -5457,20 +14689,73 @@
       77.572997,
       13.078281
     ],
-    "area_sq_km": 7.395
+    "area_sq_km": 7.395,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.632939
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 1.490397,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 11.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 183,
     "ward_id_local": 87,
     "ward_name": "K.P Agrahara",
-    "ward_name_kn": "\u0c95\u0cc6.\u0caa\u0cbf. \u0c85\u0c97\u0ccd\u0cb0\u0cb9\u0cbe\u0cb0",
+    "ward_name_kn": "ಕೆ.ಪಿ. ಅಗ್ರಹಾರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -5487,20 +14772,71 @@
       77.553459,
       12.973757
     ],
-    "area_sq_km": 0.3364
+    "area_sq_km": 0.3364,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.496505
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 36,
+      "pumping_main_length_km": 2.769651,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 184,
     "ward_id_local": 21,
     "ward_name": "Uday Nagar",
-    "ward_name_kn": "\u0c89\u0ca6\u0caf\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಉದಯ್ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -5517,20 +14853,66 @@
       77.671939,
       12.990562
     ],
-    "area_sq_km": 0.7749
+    "area_sq_km": 0.7749,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.395273
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 60,
+      "pumping_main_length_km": 5.266391,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 185,
     "ward_id_local": 9,
     "ward_name": "Srigandhanagar",
-    "ward_name_kn": "\u0cb6\u0ccd\u0cb0\u0cc0\u0c97\u0c82\u0ca7\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶ್ರೀಗಂಧನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -5547,20 +14929,66 @@
       77.503971,
       13.001197
     ],
-    "area_sq_km": 0.7505
+    "area_sq_km": 0.7505,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 1.099693,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 186,
     "ward_id_local": 102,
     "ward_name": "Hanumanthanagar",
-    "ward_name_kn": "\u0cb9\u0ca8\u0cc1\u0cae\u0c82\u0ca4\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಹನುಮಂತನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -5577,20 +15005,71 @@
       77.558963,
       12.942624
     ],
-    "area_sq_km": 0.6819
+    "area_sq_km": 0.6819,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.318776
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 1.948705,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 187,
     "ward_id_local": 19,
     "ward_name": "Thanisandra",
-    "ward_name_kn": "\u0ca5\u0ca3\u0cbf\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಥಣಿಸಂದ್ರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -5607,20 +15086,68 @@
       77.632122,
       13.052824
     ],
-    "area_sq_km": 2.7228
+    "area_sq_km": 2.7228,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.364331
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 1.925882,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 16
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 188,
     "ward_id_local": 17,
     "ward_name": "Jakkur",
-    "ward_name_kn": "\u0c9c\u0c95\u0ccd\u0c95\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಜಕ್ಕೂರು",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 2,
     "ro_division": "RO- Thanisandra",
@@ -5637,20 +15164,79 @@
       77.614337,
       13.06881
     ],
-    "area_sq_km": 7.793
+    "area_sq_km": 7.793,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 1,
+      "avg_restoration_score": 64,
+      "top_bodies": [
+        {
+          "name": "Jakkur Lake",
+          "score": 64,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 14,
+      "total_length_km": 12.687047
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 44,
+      "pumping_main_length_km": 13.522842,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 15.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Yelahanka",
+        "block": "BANGALORE NORTH",
+        "distance_km": 4.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 189,
     "ward_id_local": 54,
     "ward_name": "Subedarpalya",
-    "ward_name_kn": "\u0cb8\u0cc1\u0cac\u0cc7\u0ca6\u0cbe\u0cb0\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಸುಬೇದಾರಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -5667,20 +15253,73 @@
       77.558503,
       13.020988
     ],
-    "area_sq_km": 0.5271
+    "area_sq_km": 0.5271,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.495823
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 0.980563,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 190,
     "ward_id_local": 3,
     "ward_name": "Nelagadaranahalli",
-    "ward_name_kn": "\u0ca8\u0cc6\u0cb2\u0c97\u0ca6\u0cb0\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ನೆಲಗದರನಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -5697,20 +15336,66 @@
       77.508217,
       13.0292
     ],
-    "area_sq_km": 2.164
+    "area_sq_km": 2.164,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 2.689128
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 2.033849,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.7
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 191,
     "ward_id_local": 53,
     "ward_name": "Jaraganahalli",
-    "ward_name_kn": "\u0c9c\u0cb0\u0c97\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಜರಗನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -5727,20 +15412,71 @@
       77.576208,
       12.898811
     ],
-    "area_sq_km": 0.8584
+    "area_sq_km": 0.8584,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.284329
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 80,
+      "pumping_main_length_km": 8.177631,
+      "total_stp_capacity_mld": 5
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 192,
     "ward_id_local": 57,
     "ward_name": "Hulimavu",
-    "ward_name_kn": "\u0cb9\u0cc1\u0cb3\u0cbf\u0cae\u0cbe\u0cb5\u0cc1",
+    "ward_name_kn": "ಹುಳಿಮಾವು",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -5757,20 +15493,74 @@
       77.601532,
       12.877332
     ],
-    "area_sq_km": 1.3303
+    "area_sq_km": 1.3303,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.541571
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 61,
+      "pumping_main_length_km": 2.13263,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 193,
     "ward_id_local": 9,
     "ward_name": "Kuvempunagara",
-    "ward_name_kn": "\u0c95\u0cc1\u0cb5\u0cc6\u0c82\u0caa\u0cc1\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕುವೆಂಪುನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -5787,20 +15577,68 @@
       77.542727,
       13.068016
     ],
-    "area_sq_km": 5.4721
+    "area_sq_km": 5.4721,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 3.753782
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 21,
+      "pumping_main_length_km": 3.381392,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 194,
     "ward_id_local": 47,
     "ward_name": "Chandranagara",
-    "ward_name_kn": "\u0c9a\u0c82\u0ca6\u0ccd\u0cb0\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಚಂದ್ರನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Bangalore South",
-    "assembly_constituency_kn": "\u0cac\u0cc6\u0c82\u0c97\u0cb3\u0cc2\u0cb0\u0cc1 \u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "assembly_constituency_kn": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "assembly_no": 176,
     "ro_code": 4,
     "ro_division": "RO- Anjanapura",
@@ -5817,20 +15655,73 @@
       77.565001,
       12.901167
     ],
-    "area_sq_km": 0.6124
+    "area_sq_km": 0.6124,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 0.57484
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 70,
+      "pumping_main_length_km": 3.234718,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 195,
     "ward_id_local": 11,
     "ward_name": "Doddabommasandra",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1\u0cac\u0cca\u0cae\u0ccd\u0cae\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ದೊಡ್ಡಬೊಮ್ಮಸಂದ್ರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Byatarayanapura",
-    "assembly_constituency_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0c9f\u0cb0\u0cbe\u0caf\u0ca8\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಬ್ಯಾಟರಾಯನಪುರ",
     "assembly_no": 152,
     "ro_code": 1,
     "ro_division": "RO- Bytarayanapura",
@@ -5847,20 +15738,71 @@
       77.560288,
       13.055534
     ],
-    "area_sq_km": 4.202
+    "area_sq_km": 4.202,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 4.244858
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 3.620104,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "arkavati-hesaraghatta",
+      "nearest_river_id": "arkavati",
+      "nearest_km": 12.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 196,
     "ward_id_local": 5,
     "ward_name": "Hoysala Nagara East",
-    "ward_name_kn": "\u0cb9\u0cca\u0caf\u0ccd\u0cb8\u0cb3 \u0ca8\u0c97\u0cb0 \u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "ward_name_kn": "ಹೊಯ್ಸಳ ನಗರ ಪೂರ್ವ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -5877,20 +15819,69 @@
       77.667366,
       13.01998
     ],
-    "area_sq_km": 1.6114
+    "area_sq_km": 1.6114,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 3.061016
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 3.016376,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 197,
     "ward_id_local": 8,
     "ward_name": "Anandapura",
-    "ward_name_kn": "\u0c86\u0ca8\u0c82\u0ca6\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಆನಂದಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -5907,20 +15898,68 @@
       77.690562,
       13.015708
     ],
-    "area_sq_km": 2.2084
+    "area_sq_km": 2.2084,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.735057
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 64,
+      "pumping_main_length_km": 4.749569,
+      "total_stp_capacity_mld": 20
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 15
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 198,
     "ward_id_local": 72,
     "ward_name": "Kaveripura",
-    "ward_name_kn": "\u0c95\u0cbe\u0cb5\u0cc7\u0cb0\u0cbf\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕಾವೇರಿಪುರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -5937,20 +15976,66 @@
       77.524559,
       12.981757
     ],
-    "area_sq_km": 1.0132
+    "area_sq_km": 1.0132,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.274647
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 2.321851,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 199,
     "ward_id_local": 58,
     "ward_name": "Arakere",
-    "ward_name_kn": "\u0c85\u0cb0\u0c95\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಅರಕೆರೆ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 6,
     "ro_division": "RO- Arakere",
@@ -5967,20 +16052,75 @@
       77.603019,
       12.885329
     ],
-    "area_sq_km": 1.2603
+    "area_sq_km": 1.2603,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.908465
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 72,
+      "pumping_main_length_km": 2.696264,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-begur",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Jayanagar",
+        "block": "BBMP",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 200,
     "ward_id_local": 47,
     "ward_name": "Bellanduru",
-    "ward_name_kn": "\u0cac\u0cc6\u0cb3\u0ccd\u0cb3\u0c82\u0ca6\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಬೆಳ್ಳಂದೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -5997,20 +16137,71 @@
       77.679123,
       12.931359
     ],
-    "area_sq_km": 1.9096
+    "area_sq_km": 1.9096,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.77135
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 3.228242,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 2.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 201,
     "ward_id_local": 20,
     "ward_name": "A Narayanapura",
-    "ward_name_kn": "\u0c8e \u0ca8\u0cbe\u0cb0\u0cbe\u0caf\u0ca3\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಎ ನಾರಾಯಣಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -6027,20 +16218,66 @@
       77.680615,
       12.996979
     ],
-    "area_sq_km": 1.2996
+    "area_sq_km": 1.2996,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 2.728369
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 27,
+      "pumping_main_length_km": 1.53024,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 202,
     "ward_id_local": 27,
     "ward_name": "Vibhootipura",
-    "ward_name_kn": "\u0cb5\u0cbf\u0cad\u0cc2\u0ca4\u0cbf\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ವಿಭೂತಿಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -6057,20 +16294,73 @@
       77.671213,
       12.953835
     ],
-    "area_sq_km": 4.7067
+    "area_sq_km": 4.7067,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.71285
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 2.298827,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 7.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 203,
     "ward_id_local": 33,
     "ward_name": "S.M Krishna Ward",
-    "ward_name_kn": "\u0c8e\u0cb8\u0ccd.\u0c8e\u0c82 \u0c95\u0cc3\u0cb7\u0ccd\u0ca3 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಎಸ್.ಎಂ ಕೃಷ್ಣ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -6087,20 +16377,69 @@
       77.740248,
       12.978594
     ],
-    "area_sq_km": 4.9043
+    "area_sq_km": 4.9043,
+    "water_bodies": {
+      "current_count": 5,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.394348
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 45,
+      "pumping_main_length_km": 8.43468,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 204,
     "ward_id_local": 29,
     "ward_name": "Chowdeshwari Nagar",
-    "ward_name_kn": "\u0c9a\u0ccc\u0ca1\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಚೌಡೇಶ್ವರಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -6117,20 +16456,68 @@
       77.515462,
       12.997704
     ],
-    "area_sq_km": 1.1728
+    "area_sq_km": 1.1728,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.998006
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 62,
+      "pumping_main_length_km": 5.06532,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 205,
     "ward_id_local": 49,
     "ward_name": "Shivanasamudra Ward",
-    "ward_name_kn": "\u0cb6\u0cbf\u0cb5\u0ca8\u0cb8\u0cae\u0cc1\u0ca6\u0ccd\u0cb0 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಶಿವನಸಮುದ್ರ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -6147,20 +16534,73 @@
       77.684455,
       12.921485
     ],
-    "area_sq_km": 4.5658
+    "area_sq_km": 4.5658,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 17,
+      "total_length_km": 7.443842
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0.299475,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 206,
     "ward_id_local": 18,
     "ward_name": "Dooravaninagar",
-    "ward_name_kn": "\u0ca6\u0cc2\u0cb0\u0cb5\u0cbe\u0ca3\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ದೂರವಾಣಿನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -6177,20 +16617,66 @@
       77.666299,
       13.007309
     ],
-    "area_sq_km": 1.2434
+    "area_sq_km": 1.2434,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 9,
+      "total_length_km": 1.915952
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 2.342347,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 207,
     "ward_id_local": 29,
     "ward_name": "Hoodi",
-    "ward_name_kn": "\u0cb9\u0cc2\u0ca1\u0cbf",
+    "ward_name_kn": "ಹೂಡಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -6207,20 +16693,66 @@
       77.721348,
       12.999692
     ],
-    "area_sq_km": 4.1817
+    "area_sq_km": 4.1817,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 12,
+      "total_length_km": 5.389884
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 3.58402,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 208,
     "ward_id_local": 68,
     "ward_name": "Mangammana Palya",
-    "ward_name_kn": "\u0cae\u0c82\u0c97\u0cae\u0ccd\u0cae\u0ca8 \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಮಂಗಮ್ಮನ ಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -6237,20 +16769,73 @@
       77.639021,
       12.901469
     ],
-    "area_sq_km": 0.5905
+    "area_sq_km": 0.5905,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 2.690087,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 1.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 209,
     "ward_id_local": 16,
     "ward_name": "Sarakki",
-    "ward_name_kn": "\u0cb8\u0cbe\u0cb0\u0c95\u0ccd\u0c95\u0cbf",
+    "ward_name_kn": "ಸಾರಕ್ಕಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Jayanagar",
-    "assembly_constituency_kn": "\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಜಯನಗರ",
     "assembly_no": 173,
     "ro_code": 10,
     "ro_division": "RO- JP Nagar",
@@ -6267,20 +16852,71 @@
       77.577203,
       12.908713
     ],
-    "area_sq_km": 0.6784
+    "area_sq_km": 0.6784,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 42,
+      "pumping_main_length_km": 2.392751,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 210,
     "ward_id_local": 19,
     "ward_name": "Jeevan Bhimanagar",
-    "ward_name_kn": "\u0c9c\u0cc0\u0cb5\u0ca8\u0ccd \u0cad\u0cc0\u0cae\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜೀವನ್ ಭೀಮನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -6297,20 +16933,68 @@
       77.654925,
       12.962969
     ],
-    "area_sq_km": 1.402
+    "area_sq_km": 1.402,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 1.823313
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 55,
+      "pumping_main_length_km": 7.083141,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 7.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 211,
     "ward_id_local": 38,
     "ward_name": "Nandini Layout",
-    "ward_name_kn": "\u0ca8\u0c82\u0ca6\u0cbf\u0ca8\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ನಂದಿನಿ ಲೇಔಟ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -6327,20 +17011,73 @@
       77.533715,
       13.014158
     ],
-    "area_sq_km": 0.3703
+    "area_sq_km": 0.3703,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.048556
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 0.356143,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 212,
     "ward_id_local": 3,
     "ward_name": "Yarab nagar",
-    "ward_name_kn": "\u0caf\u0cbe\u0cb0\u0cac\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಯಾರಬ್ ನಗರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone1",
     "zone_name": "Jayanagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 11,
     "ro_division": "RO- Padmanabhanagara",
@@ -6357,20 +17094,71 @@
       77.567611,
       12.915285
     ],
-    "area_sq_km": 0.283
+    "area_sq_km": 0.283,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.298035
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 6,
+      "pumping_main_length_km": 0.474761,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 213,
     "ward_id_local": 69,
     "ward_name": "Hosapalya",
-    "ward_name_kn": "\u0cb9\u0cca\u0cb8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಹೊಸಪಾಳ್ಯ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 1,
     "ro_division": "RO- HSR Layout",
@@ -6387,20 +17175,71 @@
       77.647426,
       12.896643
     ],
-    "area_sq_km": 1.3139
+    "area_sq_km": 1.3139,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 18,
+      "pumping_main_length_km": 2.863364,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 214,
     "ward_id_local": 57,
     "ward_name": "Kuvempu Ward",
-    "ward_name_kn": "\u0c95\u0cc1\u0cb5\u0cc6\u0c82\u0caa\u0cc1 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕುವೆಂಪು ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -6417,20 +17256,71 @@
       77.563211,
       12.996793
     ],
-    "area_sq_km": 0.4668
+    "area_sq_km": 0.4668,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.591587
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 4,
+      "pumping_main_length_km": 0.710857,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 215,
     "ward_id_local": 23,
     "ward_name": "Sangama Ward",
-    "ward_name_kn": "\u0cb8\u0c82\u0c97\u0cae \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಸಂಗಮ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -6447,20 +17337,73 @@
       77.684462,
       12.966384
     ],
-    "area_sq_km": 1.9869
+    "area_sq_km": 1.9869,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 3
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.991745
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 75,
+      "pumping_main_length_km": 3.505931,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 216,
     "ward_id_local": 32,
     "ward_name": "Channasandra",
-    "ward_name_kn": "\u0c9a\u0ca8\u0ccd\u0ca8\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಚನ್ನಸಂದ್ರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -6477,20 +17420,66 @@
       77.768405,
       12.981653
     ],
-    "area_sq_km": 2.2691
+    "area_sq_km": 2.2691,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 12,
+      "total_length_km": 5.873506
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 2,
+      "pumping_main_length_km": 0.440529,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 217,
     "ward_id_local": 73,
     "ward_name": "Dr. Vishnuvardhan Ward",
-    "ward_name_kn": "\u0ca1\u0cbeII \u0cb5\u0cbf\u0cb7\u0ccd\u0ca3\u0cc1\u0cb5\u0cb0\u0ccd\u0ca7\u0ca8\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಡಾII ವಿಷ್ಣುವರ್ಧನ್ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -6507,20 +17496,66 @@
       77.533451,
       12.974568
     ],
-    "area_sq_km": 0.893
+    "area_sq_km": 0.893,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.593639
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 2.624934,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 218,
     "ward_id_local": 107,
     "ward_name": "Dharmagiri Ward",
-    "ward_name_kn": "\u0ca7\u0cb0\u0ccd\u0cae\u0c97\u0cbf\u0cb0\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಧರ್ಮಗಿರಿ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -6537,20 +17572,71 @@
       77.57019,
       12.920281
     ],
-    "area_sq_km": 0.6341
+    "area_sq_km": 0.6341,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.239574,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 219,
     "ward_id_local": 27,
     "ward_name": "Srigandada Kaval",
-    "ward_name_kn": "\u0cb6\u0ccd\u0cb0\u0cc0\u0c97\u0c82\u0ca7\u0ca6 \u0c95\u0cbe\u0cb5\u0cb2\u0ccd",
+    "ward_name_kn": "ಶ್ರೀಗಂಧದ ಕಾವಲ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -6567,20 +17653,68 @@
       77.504074,
       12.984093
     ],
-    "area_sq_km": 2.2391
+    "area_sq_km": 2.2391,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 4.758603,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 220,
     "ward_id_local": 31,
     "ward_name": "Kadugodi",
-    "ward_name_kn": "\u0c95\u0cbe\u0ca1\u0cc1\u0c97\u0ccb\u0ca1\u0cbf",
+    "ward_name_kn": "ಕಾಡುಗೋಡಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -6597,20 +17731,68 @@
       77.764748,
       12.994275
     ],
-    "area_sq_km": 4.5012
+    "area_sq_km": 4.5012,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 25,
+      "total_length_km": 9.414908
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 5.481631,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 221,
     "ward_id_local": 81,
     "ward_name": "Nayanda Halli",
-    "ward_name_kn": "\u0ca8\u0cbe\u0caf\u0c82\u0ca1 \u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ನಾಯಂಡ ಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -6627,20 +17809,68 @@
       77.52243,
       12.943779
     ],
-    "area_sq_km": 0.8764
+    "area_sq_km": 0.8764,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.723047
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 5.312661,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 0.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 222,
     "ward_id_local": 58,
     "ward_name": "Chickpete",
-    "ward_name_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "ward_name_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -6657,20 +17887,71 @@
       77.578277,
       12.97054
     ],
-    "area_sq_km": 0.6135
+    "area_sq_km": 0.6135,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 34,
+      "pumping_main_length_km": 3.736761,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 1.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 223,
     "ward_id_local": 40,
     "ward_name": "Varthur",
-    "ward_name_kn": "\u0cb5\u0cb0\u0ccd\u0ca4\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ವರ್ತೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -6687,20 +17968,79 @@
       77.745006,
       12.941272
     ],
-    "area_sq_km": 9.1354
+    "area_sq_km": 9.1354,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 1,
+      "restoration_high": 0,
+      "avg_restoration_score": 88,
+      "top_bodies": [
+        {
+          "name": "Varthur Lake",
+          "score": 88,
+          "level": "critical"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 20,
+      "total_length_km": 13.819629
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 6,
+      "pumping_main_length_km": 2.91545,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 4.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 224,
     "ward_id_local": 41,
     "ward_name": "Munnenkolalu",
-    "ward_name_kn": "\u0cae\u0cc1\u0ca8\u0ccd\u0ca8\u0cc7\u0ca8\u0c95\u0cca\u0cb3\u0cb2\u0cc1",
+    "ward_name_kn": "ಮುನ್ನೇನಕೊಳಲು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -6717,20 +18057,74 @@
       77.708598,
       12.948735
     ],
-    "area_sq_km": 2.4792
+    "area_sq_km": 2.4792,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.396179
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 7.455902,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 1.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 225,
     "ward_id_local": 69,
     "ward_name": "Agrahara Dasarahalli",
-    "ward_name_kn": "\u0c85\u0c97\u0ccd\u0cb0\u0cb9\u0cbe\u0cb0 \u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -6747,20 +18141,66 @@
       77.540164,
       12.982699
     ],
-    "area_sq_km": 0.5229
+    "area_sq_km": 0.5229,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.099723
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 0.272039,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 226,
     "ward_id_local": 36,
     "ward_name": "Bharath Aikya Ward",
-    "ward_name_kn": "\u0cad\u0cbe\u0cb0\u0ca4\u0ccd \u0c90\u0c95\u0ccd\u0caf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಭಾರತ್ ಐಕ್ಯ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -6777,20 +18217,71 @@
       77.71031,
       12.976921
     ],
-    "area_sq_km": 3.9282
+    "area_sq_km": 3.9282,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.89391
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 4,
+      "pumping_main_length_km": 1.856817,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 4.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 227,
     "ward_id_local": 35,
     "ward_name": "Garudachar Palya",
-    "ward_name_kn": "\u0c97\u0cb0\u0cc1\u0ca1\u0cbe\u0c9a\u0cbe\u0cb0\u0ccd \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಗರುಡಾಚಾರ್ ಪಾಳ್ಯ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -6807,20 +18298,68 @@
       77.697706,
       12.991274
     ],
-    "area_sq_km": 1.3082
+    "area_sq_km": 1.3082,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.303992
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 13,
+      "pumping_main_length_km": 1.430613,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 228,
     "ward_id_local": 86,
     "ward_name": "Vidyaranyanagara",
-    "ward_name_kn": "\u0cb5\u0cbf\u0ca6\u0ccd\u0caf\u0cbe\u0cb0\u0ca3\u0ccd\u0caf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವಿದ್ಯಾರಣ್ಯನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -6837,20 +18376,74 @@
       77.549661,
       12.970127
     ],
-    "area_sq_km": 0.3049
+    "area_sq_km": 0.3049,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.106399
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 49,
+      "pumping_main_length_km": 2.992949,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 229,
     "ward_id_local": 37,
     "ward_name": "Kundalahalli",
-    "ward_name_kn": "\u0c95\u0cc1\u0c82\u0ca6\u0cb2\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕುಂದಲಹಳ್ಳಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -6867,20 +18460,73 @@
       77.724265,
       12.959947
     ],
-    "area_sq_km": 5.6399
+    "area_sq_km": 5.6399,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 10,
+      "total_length_km": 5.68212
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 54,
+      "pumping_main_length_km": 10.613257,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 230,
     "ward_id_local": 34,
     "ward_name": "Kaveri Nagara",
-    "ward_name_kn": "\u0c95\u0cbe\u0cb5\u0cc7\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕಾವೇರಿ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -6897,20 +18543,69 @@
       77.716967,
       12.988086
     ],
-    "area_sq_km": 2.877
+    "area_sq_km": 2.877,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.429553
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 2.022938,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 231,
     "ward_id_local": 28,
     "ward_name": "Neelasandra",
-    "ward_name_kn": "\u0ca8\u0cc0\u0cb2\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ನೀಲಸಂದ್ರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -6927,20 +18622,71 @@
       77.614816,
       12.952299
     ],
-    "area_sq_km": 0.2642
+    "area_sq_km": 0.2642,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.199025
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 73,
+      "pumping_main_length_km": 4.453572,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 232,
     "ward_id_local": 22,
     "ward_name": "Mahadevapura",
-    "ward_name_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಮಹದೇವಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -6957,20 +18703,69 @@
       77.685331,
       12.9875
     ],
-    "area_sq_km": 2.703
+    "area_sq_km": 2.703,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 3,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 6,
+      "total_length_km": 4.514982
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 111,
+      "pumping_main_length_km": 6.904342,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.9
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 233,
     "ward_id_local": 38,
     "ward_name": "Whitefield",
-    "ward_name_kn": "\u0cb5\u0cc8\u0c9f\u0ccd\u200c\u0cab\u0cc0\u0cb2\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ವೈಟ್‌ಫೀಲ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -6987,20 +18782,69 @@
       77.745106,
       12.96569
     ],
-    "area_sq_km": 4.4424
+    "area_sq_km": 4.4424,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 15,
+      "total_length_km": 6.739245
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 7.1489,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.6
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 234,
     "ward_id_local": 30,
     "ward_name": "Jakkasandra",
-    "ward_name_kn": "\u0c9c\u0c95\u0ccd\u0c95\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಜಕ್ಕಸಂದ್ರ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "B.T.M Layout",
-    "assembly_constituency_kn": "\u0cac\u0cbf.\u0c9f\u0cbf.\u0c8e\u0c82. \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಬಿ.ಟಿ.ಎಂ. ಲೇಔಟ್",
     "assembly_no": 172,
     "ro_code": 3,
     "ro_division": "RO- Kormangala",
@@ -7017,20 +18861,68 @@
       77.634012,
       12.919897
     ],
-    "area_sq_km": 0.7915
+    "area_sq_km": 0.7915,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 42,
+      "pumping_main_length_km": 4.341361,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 2.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 235,
     "ward_id_local": 50,
     "ward_name": "Gunjur",
-    "ward_name_kn": "\u0c97\u0cc1\u0c82\u0c9c\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಗುಂಜೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -7047,20 +18939,73 @@
       77.724552,
       12.919674
     ],
-    "area_sq_km": 12.7146
+    "area_sq_km": 12.7146,
+    "water_bodies": {
+      "current_count": 7,
+      "census_records": 5,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 28,
+      "total_length_km": 12.816273
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 1,
+      "pumping_main_length_km": 0.23715,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 236,
     "ward_id_local": 13,
     "ward_name": "Rajarajeshwari Temple ward",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ರಾಜರಾಜೇಶ್ವರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -7077,20 +19022,66 @@
       77.691515,
       13.002468
     ],
-    "area_sq_km": 1.3547
+    "area_sq_km": 1.3547,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.440787
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 5,
+      "pumping_main_length_km": 0.211688,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 237,
     "ward_id_local": 43,
     "ward_name": "Dodda Nekkundi",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1 \u0ca8\u0cc6\u0c95\u0ccd\u0c95\u0cc1\u0c82\u0ca1\u0cbf",
+    "ward_name_kn": "ದೊಡ್ಡ ನೆಕ್ಕುಂಡಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -7107,20 +19098,73 @@
       77.695681,
       12.973522
     ],
-    "area_sq_km": 3.6332
+    "area_sq_km": 3.6332,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 2.496051
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 7.179888,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 238,
     "ward_id_local": 9,
     "ward_name": "Bhattarahalli",
-    "ward_name_kn": "\u0cad\u0c9f\u0ccd\u0c9f\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಭಟ್ಟರಹಳ್ಳಿ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -7137,20 +19181,66 @@
       77.709851,
       13.025059
     ],
-    "area_sq_km": 2.5607
+    "area_sq_km": 2.5607,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 1.370664
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 50,
+      "pumping_main_length_km": 2.739826,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-East",
+        "class": "Over Exploited",
+        "development_pct": 305.8
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 239,
     "ward_id_local": 26,
     "ward_name": "Jagadish Nagar",
-    "ward_name_kn": "\u0c9c\u0c97\u0ca6\u0cc0\u0cb6\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜಗದೀಶ್ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -7167,20 +19257,66 @@
       77.66437,
       12.965799
     ],
-    "area_sq_km": 1.4126
+    "area_sq_km": 1.4126,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.245463
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 1.727164,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 240,
     "ward_id_local": 12,
     "ward_name": "Devasandra",
-    "ward_name_kn": "\u0ca6\u0cc7\u0cb5\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ದೇವಸಂದ್ರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -7197,20 +19333,66 @@
       77.70102,
       13.001295
     ],
-    "area_sq_km": 1.2858
+    "area_sq_km": 1.2858,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 2.614763
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 63,
+      "pumping_main_length_km": 2.917687,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 13.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 241,
     "ward_id_local": 63,
     "ward_name": "Bommanahalli",
-    "ward_name_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "corporation": "South",
-    "corporation_kn": "\u0ca6\u0c95\u0ccd\u0cb7\u0cbf\u0ca3",
+    "corporation_kn": "ದಕ್ಷಿಣ",
     "corporation_id": 4,
     "zone": "Zone2",
     "zone_name": "Bommanahalli",
     "assembly_constituency": "Bommanahalli",
-    "assembly_constituency_kn": "\u0cac\u0cca\u0cae\u0ccd\u0cae\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "assembly_no": 175,
     "ro_code": 7,
     "ro_division": "RO- Bommanahalli",
@@ -7227,20 +19409,73 @@
       77.624283,
       12.903483
     ],
-    "area_sq_km": 0.8833
+    "area_sq_km": 0.8833,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.025801
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 21,
+      "pumping_main_length_km": 2.083449,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 0.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Singasandra",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 242,
     "ward_id_local": 3,
     "ward_name": "Chellakere",
-    "ward_name_kn": "\u0c9a\u0cc6\u0cb2\u0ccd\u0cb2\u0c95\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಚೆಲ್ಲಕೆರೆ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -7257,20 +19492,69 @@
       77.644143,
       13.031515
     ],
-    "area_sq_km": 1.6706
+    "area_sq_km": 1.6706,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 3.07021
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 12,
+      "pumping_main_length_km": 3.36861,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 14.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 243,
     "ward_id_local": 26,
     "ward_name": "Mallathahalli",
-    "ward_name_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0ca4\u0ccd\u0ca4\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಮಲ್ಲತ್ತಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 11,
     "ro_division": "RO- Rajarajeswari Nagara",
@@ -7287,20 +19571,68 @@
       77.500654,
       12.970115
     ],
-    "area_sq_km": 2.6147
+    "area_sq_km": 2.6147,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.334552
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 4.805756,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 244,
     "ward_id_local": 44,
     "ward_name": "Ashwath Nagar",
-    "ward_name_kn": "\u0c85\u0cb6\u0ccd\u0cb5\u0ca5\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅಶ್ವಥ್ ನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 7,
     "ro_division": "RO- Marathahalli",
@@ -7317,20 +19649,71 @@
       77.695845,
       12.960466
     ],
-    "area_sq_km": 1.2698
+    "area_sq_km": 1.2698,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.399104
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 3.793771,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 245,
     "ward_id_local": 30,
     "ward_name": "Belathur",
-    "ward_name_kn": "\u0cac\u0cc6\u0cb3\u0ca4\u0ccd\u0ca4\u0cc2\u0cb0\u0ccd",
+    "ward_name_kn": "ಬೆಳತ್ತೂರ್",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 6,
     "ro_division": "RO- Hoodi",
@@ -7347,20 +19730,68 @@
       77.743798,
       12.998913
     ],
-    "area_sq_km": 7.6368
+    "area_sq_km": 7.6368,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 17,
+      "total_length_km": 11.547532
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 53,
+      "pumping_main_length_km": 3.61968,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-sulibele",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 11.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 246,
     "ward_id_local": 48,
     "ward_name": "Panathur",
-    "ward_name_kn": "\u0caa\u0ca3\u0ca4\u0ccd\u0ca4\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಪಣತ್ತೂರು",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone1",
     "zone_name": "Mahadevapura",
     "assembly_constituency": "Mahadevapura",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0ca6\u0cc7\u0cb5\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಮಹದೇವಪುರ",
     "assembly_no": 174,
     "ro_code": 5,
     "ro_division": "RO- Bellanduru",
@@ -7377,20 +19808,73 @@
       77.708066,
       12.934554
     ],
-    "area_sq_km": 8.6447
+    "area_sq_km": 8.6447,
+    "water_bodies": {
+      "current_count": 5,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 12,
+      "total_length_km": 11.855308
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 2.248212,
+      "total_stp_capacity_mld": 140
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 247,
     "ward_id_local": 41,
     "ward_name": "Nagapura",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ನಾಗಪುರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -7407,20 +19891,71 @@
       77.544412,
       13.003921
     ],
-    "area_sq_km": 0.9668
+    "area_sq_km": 0.9668,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 71,
+      "pumping_main_length_km": 3.670938,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 248,
     "ward_id_local": 6,
     "ward_name": "Kalkere",
-    "ward_name_kn": "\u0c95\u0cb2\u0ccd\u0c95\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಕಲ್ಕೆರೆ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 1,
     "ro_division": "RO- Horamavu",
@@ -7437,20 +19972,66 @@
       77.674422,
       13.035357
     ],
-    "area_sq_km": 3.8352
+    "area_sq_km": 3.8352,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 15,
+      "total_length_km": 5.103411
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 15,
+      "pumping_main_length_km": 0.550361,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 16.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 249,
     "ward_id_local": 7,
     "ward_name": "K Chennasandra",
-    "ward_name_kn": "\u0c95\u0cc6 \u0c9a\u0cc6\u0ca8\u0ccd\u0ca8\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಕೆ ಚೆನ್ನಸಂದ್ರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 2,
     "ro_division": "RO- KR Pura",
@@ -7467,20 +20048,68 @@
       77.681856,
       13.032472
     ],
-    "area_sq_km": 2.1173
+    "area_sq_km": 2.1173,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.93269
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 4,
+      "pumping_main_length_km": 0.147707,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 15.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 250,
     "ward_id_local": 17,
     "ward_name": "Vijinapura",
-    "ward_name_kn": "\u0cb5\u0cbf\u0c9c\u0cbf\u0ca8\u0cbe\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ವಿಜಿನಾಪುರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 3,
     "ro_division": "RO- Ramamurthy Nagara",
@@ -7497,20 +20126,68 @@
       77.673896,
       13.004337
     ],
-    "area_sq_km": 0.3265
+    "area_sq_km": 0.3265,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.092589
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 44,
+      "pumping_main_length_km": 1.678057,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 251,
     "ward_id_local": 24,
     "ward_name": "Vignananagara",
-    "ward_name_kn": "\u0cb5\u0cbf\u0c9c\u0ccd\u0c9e\u0cbe\u0ca8\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವಿಜ್ಞಾನನಗರ",
     "corporation": "East",
-    "corporation_kn": "\u0caa\u0cc2\u0cb0\u0ccd\u0cb5",
+    "corporation_kn": "ಪೂರ್ವ",
     "corporation_id": 3,
     "zone": "Zone2",
     "zone_name": "K.R. Pura",
     "assembly_constituency": "K.R. Pura",
-    "assembly_constituency_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಕೆ.ಆರ್. ಪುರ",
     "assembly_no": 151,
     "ro_code": 4,
     "ro_division": "RO- Vignananagara",
@@ -7527,20 +20204,73 @@
       77.676202,
       12.970721
     ],
-    "area_sq_km": 1.3248
+    "area_sq_km": 1.3248,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.044004
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 71,
+      "pumping_main_length_km": 3.28912,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Adugodi",
+        "block": "BBMP",
+        "distance_km": 4.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 252,
     "ward_id_local": 46,
     "ward_name": "Cheluvadi Palya",
-    "ward_name_kn": "\u0c9a\u0cc6\u0cb2\u0cc1\u0cb5\u0cbe\u0ca6\u0cbf \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಚೆಲುವಾದಿ ಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -7557,20 +20287,74 @@
       77.567893,
       12.965598
     ],
-    "area_sq_km": 0.2157
+    "area_sq_km": 0.2157,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 2.133368,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 253,
     "ward_id_local": 43,
     "ward_name": "Devaraj Urs Ward",
-    "ward_name_kn": "\u0ca6\u0cc7\u0cb5\u0cb0\u0cbe\u0c9c \u0c85\u0cb0\u0cb8\u0cc1 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd\u200c",
+    "ward_name_kn": "ದೇವರಾಜ ಅರಸು ವಾರ್ಡ್‌",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -7587,20 +20371,71 @@
       77.565024,
       12.952117
     ],
-    "area_sq_km": 0.5321
+    "area_sq_km": 0.5321,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.3955
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 64,
+      "pumping_main_length_km": 3.889103,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 2.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 254,
     "ward_id_local": 4,
     "ward_name": "Parvathi Nagar",
-    "ward_name_kn": "\u0caa\u0cbe\u0cb0\u0ccd\u0cb5\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪಾರ್ವತಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -7617,20 +20452,66 @@
       77.51814,
       13.021164
     ],
-    "area_sq_km": 1.4616
+    "area_sq_km": 1.4616,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.481902
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 55,
+      "pumping_main_length_km": 3.032976,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 255,
     "ward_id_local": 15,
     "ward_name": "Byadarahalli",
-    "ward_name_kn": "\u0cac\u0ccd\u0caf\u0cbe\u0ca1\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಬ್ಯಾಡರಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 14,
     "ro_division": "RO- Herohalli",
@@ -7647,20 +20528,66 @@
       77.484132,
       12.978825
     ],
-    "area_sq_km": 4.151
+    "area_sq_km": 4.151,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 5.431404
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 127,
+      "pumping_main_length_km": 22.17858,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 256,
     "ward_id_local": 5,
     "ward_name": "Shivajinagar",
-    "ward_name_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಿವಾಜಿನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -7677,20 +20604,73 @@
       77.605484,
       12.982994
     ],
-    "area_sq_km": 1.1607
+    "area_sq_km": 1.1607,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 48,
+      "pumping_main_length_km": 4.738605,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 257,
     "ward_id_local": 23,
     "ward_name": "Jogpalya",
-    "ward_name_kn": "\u0c9c\u0ccb\u0c97\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಜೋಗಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -7707,20 +20687,74 @@
       77.634199,
       12.971892
     ],
-    "area_sq_km": 1.0867
+    "area_sq_km": 1.0867,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.532705
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 54,
+      "pumping_main_length_km": 5.037639,
+      "total_stp_capacity_mld": 2
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 258,
     "ward_id_local": 20,
     "ward_name": "Kodihalli",
-    "ward_name_kn": "\u0c95\u0ccb\u0ca1\u0cbf\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕೋಡಿಹಳ್ಳಿ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -7737,20 +20771,75 @@
       77.646054,
       12.964127
     ],
-    "area_sq_km": 1.293
+    "area_sq_km": 1.293,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": 42,
+      "top_bodies": [
+        {
+          "name": "Domlur tank",
+          "score": 42,
+          "level": "moderate"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 10,
+      "total_length_km": 4.837576
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 60,
+      "pumping_main_length_km": 8.090357,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 7.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 259,
     "ward_id_local": 29,
     "ward_name": "Austin Town",
-    "ward_name_kn": "\u0c86\u0cb8\u0ccd\u0c9f\u0cbf\u0ca8\u0ccd \u0c9f\u0ccc\u0ca8\u0ccd",
+    "ward_name_kn": "ಆಸ್ಟಿನ್ ಟೌನ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -7767,20 +20856,71 @@
       77.614395,
       12.957591
     ],
-    "area_sq_km": 0.4231
+    "area_sq_km": 0.4231,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.199257
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 47,
+      "pumping_main_length_km": 3.614265,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 2.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 260,
     "ward_id_local": 26,
     "ward_name": "Vannarpet",
-    "ward_name_kn": "\u0cb5\u0ca8\u0ccd\u0ca8\u0cbe\u0cb0\u0ccd\u200c\u0caa\u0cc7\u0c9f\u0cc6",
+    "ward_name_kn": "ವನ್ನಾರ್‌ಪೇಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -7797,20 +20937,73 @@
       77.619612,
       12.956607
     ],
-    "area_sq_km": 0.5189
+    "area_sq_km": 0.5189,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.988827
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 56,
+      "pumping_main_length_km": 4.036015,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 261,
     "ward_id_local": 55,
     "ward_name": "Bhuvaneshwari Nagar",
-    "ward_name_kn": "\u0cad\u0cc1\u0cb5\u0ca8\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಭುವನೇಶ್ವರಿ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -7827,20 +21020,71 @@
       77.559668,
       12.971625
     ],
-    "area_sq_km": 0.2363
+    "area_sq_km": 0.2363,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 5,
+      "pumping_main_length_km": 1.232039,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 262,
     "ward_id_local": 14,
     "ward_name": "Nagavarapalya",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0cb5\u0cbe\u0cb0\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ನಾಗವಾರಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -7857,20 +21101,66 @@
       77.658249,
       12.98679
     ],
-    "area_sq_km": 1.9586
+    "area_sq_km": 1.9586,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 2.116124
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 2.940071,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 263,
     "ward_id_local": 60,
     "ward_name": "Prakash Nagara",
-    "ward_name_kn": "\u0caa\u0ccd\u0cb0\u0c95\u0cbe\u0cb6 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಪ್ರಕಾಶ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -7887,20 +21177,73 @@
       77.556683,
       12.994993
     ],
-    "area_sq_km": 0.3962
+    "area_sq_km": 0.3962,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.76925
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 2.320772,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 264,
     "ward_id_local": 1,
     "ward_name": "Ramaswamy Palya",
-    "ward_name_kn": "\u0cb0\u0cbe\u0cae\u0cb8\u0ccd\u0cb5\u0cbe\u0cae\u0cbf \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ರಾಮಸ್ವಾಮಿ ಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -7917,20 +21260,73 @@
       77.598744,
       13.00651
     ],
-    "area_sq_km": 0.6983
+    "area_sq_km": 0.6983,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.149087
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 2.749949,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 265,
     "ward_id_local": 58,
     "ward_name": "Dayanand Nagara",
-    "ward_name_kn": "\u0ca6\u0caf\u0cbe\u0ca8\u0c82\u0ca6 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ದಯಾನಂದ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -7947,20 +21343,71 @@
       77.565539,
       12.990918
     ],
-    "area_sq_km": 0.2708
+    "area_sq_km": 0.2708,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 0.872434,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 266,
     "ward_id_local": 35,
     "ward_name": "Hombegowda Nagara",
-    "ward_name_kn": "\u0cb9\u0cca\u0c82\u0cac\u0cc7\u0c97\u0ccc\u0ca1 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -7977,20 +21424,74 @@
       77.593254,
       12.951841
     ],
-    "area_sq_km": 0.9601
+    "area_sq_km": 0.9601,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 2.357402
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 66,
+      "pumping_main_length_km": 5.330138,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 0.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 267,
     "ward_id_local": 7,
     "ward_name": "K Kamaraj Ward",
-    "ward_name_kn": "\u0c95\u0cc6 \u0c95\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕೆ ಕಾಮರಾಜ್ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -8007,20 +21508,80 @@
       77.61603,
       12.981677
     ],
-    "area_sq_km": 1.9811
+    "area_sq_km": 1.9811,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 1,
+      "avg_restoration_score": 68,
+      "top_bodies": [
+        {
+          "name": "Halasuru (Ulsoor) Lake",
+          "score": 68,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.199047
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 70,
+      "pumping_main_length_km": 9.591149,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 268,
     "ward_id_local": 40,
     "ward_name": "Ashoka Pillar",
-    "ward_name_kn": "\u0c85\u0cb6\u0ccb\u0c95 \u0caa\u0cbf\u0cb2\u0ccd\u0cb2\u0cb0\u0ccd\u200c",
+    "ward_name_kn": "ಅಶೋಕ ಪಿಲ್ಲರ್‌",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -8037,20 +21598,79 @@
       77.584378,
       12.947258
     ],
-    "area_sq_km": 1.5443
+    "area_sq_km": 1.5443,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": 48,
+      "top_bodies": [
+        {
+          "name": "Lalbagh Tank",
+          "score": 48,
+          "level": "moderate"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.242082
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 4.693656,
+      "total_stp_capacity_mld": 1.5
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 0.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 269,
     "ward_id_local": 37,
     "ward_name": "BHEL Ward",
-    "ward_name_kn": "\u0cac\u0cbf\u0c8e\u0c9a\u0ccd\u200c\u0c87\u0c8e\u0cb2\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಬಿಎಚ್‌ಇಎಲ್ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -8067,20 +21687,74 @@
       77.596671,
       12.933771
     ],
-    "area_sq_km": 1.0569
+    "area_sq_km": 1.0569,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.766999
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 3.50218,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 270,
     "ward_id_local": 45,
     "ward_name": "K.R Market",
-    "ward_name_kn": "\u0c95\u0cc6.\u0c86\u0cb0\u0ccd. \u0cae\u0cbe\u0cb0\u0cc1\u0c95\u0c9f\u0ccd\u0c9f\u0cc6",
+    "ward_name_kn": "ಕೆ.ಆರ್. ಮಾರುಕಟ್ಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -8097,20 +21771,71 @@
       77.572055,
       12.96361
     ],
-    "area_sq_km": 0.7337
+    "area_sq_km": 0.7337,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 2.392514,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 271,
     "ward_id_local": 23,
     "ward_name": "Rajarajeshwari Nagara",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 11,
     "ro_division": "RO- Rajarajeswari Nagara",
@@ -8127,20 +21852,70 @@
       77.515908,
       12.920252
     ],
-    "area_sq_km": 4.1228
+    "area_sq_km": 4.1228,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 12,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 8
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 18,
+      "total_length_km": 10.662501
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 118,
+      "pumping_main_length_km": 14.645517,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 272,
     "ward_id_local": 22,
     "ward_name": "Domluru",
-    "ward_name_kn": "\u0ca6\u0cca\u0cae\u0ccd\u0cae\u0cb2\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ದೊಮ್ಮಲೂರು",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -8157,20 +21932,68 @@
       77.639024,
       12.960648
     ],
-    "area_sq_km": 1.1537
+    "area_sq_km": 1.1537,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.789638
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 91,
+      "pumping_main_length_km": 9.11811,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 273,
     "ward_id_local": 60,
     "ward_name": "Seshadripuram",
-    "ward_name_kn": "\u0cb6\u0cc7\u0cb7\u0cbe\u0ca6\u0ccd\u0cb0\u0cbf\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ಶೇಷಾದ್ರಿಪುರಂ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -8187,20 +22010,74 @@
       77.575561,
       12.995057
     ],
-    "area_sq_km": 0.3827
+    "area_sq_km": 0.3827,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.430137
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 64,
+      "pumping_main_length_km": 2.746391,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 274,
     "ward_id_local": 39,
     "ward_name": "Venkat Reddy Nagara",
-    "ward_name_kn": "\u0cb5\u0cc6\u0c82\u0c95\u0c9f \u0cb0\u0cc6\u0ca1\u0ccd\u0ca1\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವೆಂಕಟ ರೆಡ್ಡಿ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -8217,20 +22094,74 @@
       77.59208,
       12.945877
     ],
-    "area_sq_km": 0.202
+    "area_sq_km": 0.202,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.440789
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 2.29337,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 5.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 0.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 275,
     "ward_id_local": 25,
     "ward_name": "Ashokanagar",
-    "ward_name_kn": "\u0c85\u0cb6\u0ccb\u0c95\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅಶೋಕನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "Shanthinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbe\u0c82\u0ca4\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಾಂತಿನಗರ",
     "assembly_no": 163,
     "ro_code": 6,
     "ro_division": "RO - Shanthinagar",
@@ -8247,20 +22178,85 @@
       77.606846,
       12.969862
     ],
-    "area_sq_km": 3.9187
+    "area_sq_km": 3.9187,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 2,
+      "avg_restoration_score": 70,
+      "top_bodies": [
+        {
+          "name": "Sampangi tank",
+          "score": 78,
+          "level": "high"
+        },
+        {
+          "name": "Karanji Anjaneya tank",
+          "score": 62,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 2,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.636355
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 116,
+      "pumping_main_length_km": 11.575557,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 7.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 276,
     "ward_id_local": 70,
     "ward_name": "Dr Rajkumar Ward",
-    "ward_name_kn": "\u0ca1\u0cbe. \u0cb0\u0cbe\u0c9c\u0ccd\u200c\u0c95\u0cc1\u0cae\u0cbe\u0cb0\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಡಾ. ರಾಜ್‌ಕುಮಾರ್ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -8277,20 +22273,74 @@
       77.54848,
       12.979653
     ],
-    "area_sq_km": 0.9819
+    "area_sq_km": 0.9819,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.338151
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 63,
+      "pumping_main_length_km": 5.400671,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 277,
     "ward_id_local": 14,
     "ward_name": "Herohalli",
-    "ward_name_kn": "\u0cb9\u0cc6\u0cb0\u0ccb\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹೆರೋಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 14,
     "ro_division": "RO- Herohalli",
@@ -8307,20 +22357,68 @@
       77.493116,
       12.992216
     ],
-    "area_sq_km": 1.4938
+    "area_sq_km": 1.4938,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 2.021774
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 37,
+      "pumping_main_length_km": 3.114085,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 278,
     "ward_id_local": 59,
     "ward_name": "Bandi Reddy Circle Ward",
-    "ward_name_kn": "\u0cac\u0c82\u0ca1\u0cbf \u0cb0\u0cc6\u0ca1\u0ccd\u0ca1\u0cbf \u0cb5\u0cc3\u0ca4\u0ccd\u0ca4 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಬಂಡಿ ರೆಡ್ಡಿ ವೃತ್ತ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -8337,20 +22435,71 @@
       77.561226,
       12.991764
     ],
-    "area_sq_km": 0.2584
+    "area_sq_km": 0.2584,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.695074
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 4,
+      "pumping_main_length_km": 0.420456,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 279,
     "ward_id_local": 6,
     "ward_name": "Bharathi Nagar",
-    "ward_name_kn": "\u0cad\u0cbe\u0cb0\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಭಾರತಿ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -8367,20 +22516,71 @@
       77.609509,
       12.990047
     ],
-    "area_sq_km": 0.3357
+    "area_sq_km": 0.3357,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 2.385637,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 280,
     "ward_id_local": 82,
     "ward_name": "Attigupe",
-    "ward_name_kn": "\u0c85\u0ca4\u0ccd\u0ca4\u0cbf\u0c97\u0cc1\u0caa\u0ccd\u0caa\u0cc6",
+    "ward_name_kn": "ಅತ್ತಿಗುಪ್ಪೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 12,
     "ro_division": "RO- Hampi Nagar",
@@ -8397,20 +22597,66 @@
       77.528033,
       12.959233
     ],
-    "area_sq_km": 0.8491
+    "area_sq_km": 0.8491,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.244591
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 16,
+      "pumping_main_length_km": 0.862407,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 281,
     "ward_id_local": 61,
     "ward_name": "Dattatreya Ward",
-    "ward_name_kn": "\u0ca6\u0ca4\u0ccd\u0ca4\u0cbe\u0ca4\u0ccd\u0cb0\u0cc7\u0caf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ದತ್ತಾತ್ರೇಯ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -8427,20 +22673,73 @@
       77.571737,
       12.996624
     ],
-    "area_sq_km": 0.4974
+    "area_sq_km": 0.4974,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.445009
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 28,
+      "pumping_main_length_km": 2.158246,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 282,
     "ward_id_local": 89,
     "ward_name": "Bapuji Nagara",
-    "ward_name_kn": "\u0cac\u0cbe\u0caa\u0cc2\u0c9c\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಬಾಪೂಜಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -8457,20 +22756,73 @@
       77.544372,
       12.956992
     ],
-    "area_sq_km": 0.348
+    "area_sq_km": 0.348,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.033224
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 45,
+      "pumping_main_length_km": 3.145523,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 283,
     "ward_id_local": 80,
     "ward_name": "Chandra Layout",
-    "ward_name_kn": "\u0c9a\u0c82\u0ca6\u0ccd\u0cb0 \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಚಂದ್ರ ಲೇಔಟ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -8487,20 +22839,66 @@
       77.5237,
       12.955651
     ],
-    "area_sq_km": 0.6727
+    "area_sq_km": 0.6727,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 11,
+      "total_length_km": 2.207127
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 0.941412,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 284,
     "ward_id_local": 95,
     "ward_name": "Swamy Vivekananda Ward",
-    "ward_name_kn": "\u0cb8\u0ccd\u0cb5\u0cbe\u0cae\u0cbf \u0cb5\u0cbf\u0cb5\u0cc7\u0c95\u0cbe\u0ca8\u0c82\u0ca6 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಸ್ವಾಮಿ ವಿವೇಕಾನಂದ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -8517,20 +22915,71 @@
       77.544864,
       12.936859
     ],
-    "area_sq_km": 1.519
+    "area_sq_km": 1.519,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.826875
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 95,
+      "pumping_main_length_km": 7.341495,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 285,
     "ward_id_local": 42,
     "ward_name": "Sunkenahalli",
-    "ward_name_kn": "\u0cb8\u0cc1\u0c82\u0c95\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಸುಂಕೇನಹಳ್ಳಿ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -8547,20 +22996,71 @@
       77.570789,
       12.947777
     ],
-    "area_sq_km": 1.5649
+    "area_sq_km": 1.5649,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 67,
+      "pumping_main_length_km": 6.607478,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 286,
     "ward_id_local": 32,
     "ward_name": "SilverJubilee Park Ward",
-    "ward_name_kn": "\u0cb8\u0cbf\u0cb2\u0ccd\u0cb5\u0cb0\u0ccd \u0c9c\u0cc1\u0cac\u0cbf\u0cb2\u0cbf \u0caa\u0cbe\u0cb0\u0ccd\u0c95\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಸಿಲ್ವರ್ ಜುಬಿಲಿ ಪಾರ್ಕ್ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chickpet",
-    "assembly_constituency_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಿಕ್ಕಪೇಟೆ",
     "assembly_no": 169,
     "ro_code": 4,
     "ro_division": "RO - Chickpet",
@@ -8577,20 +23077,80 @@
       77.588081,
       12.959606
     ],
-    "area_sq_km": 0.6253
+    "area_sq_km": 0.6253,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 1,
+      "avg_restoration_score": 60,
+      "top_bodies": [
+        {
+          "name": "Akkithimmanahalli tank",
+          "score": 60,
+          "level": "high"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.59034
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 71,
+      "pumping_main_length_km": 5.860957,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 1.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 287,
     "ward_id_local": 97,
     "ward_name": "Srinivasa Nagara",
-    "ward_name_kn": "\u0cb6\u0ccd\u0cb0\u0cc0\u0ca8\u0cbf\u0cb5\u0cbe\u0cb8 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶ್ರೀನಿವಾಸ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -8607,20 +23167,73 @@
       77.555194,
       12.935702
     ],
-    "area_sq_km": 0.4273
+    "area_sq_km": 0.4273,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 1.835663
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 65,
+      "pumping_main_length_km": 2.588264,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 288,
     "ward_id_local": 83,
     "ward_name": "Hampi Nagar",
-    "ward_name_kn": "\u0cb9\u0c82\u0caa\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಹಂಪಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 12,
     "ro_division": "RO- Hampi Nagar",
@@ -8637,20 +23250,66 @@
       77.533235,
       12.959023
     ],
-    "area_sq_km": 0.8981
+    "area_sq_km": 0.8981,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.593639
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 2.103864,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 289,
     "ward_id_local": 63,
     "ward_name": "Rajajinagara",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಜಾಜಿನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -8667,20 +23326,71 @@
       77.5518,
       12.990004
     ],
-    "area_sq_km": 0.8777
+    "area_sq_km": 0.8777,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 0.786764,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 290,
     "ward_id_local": 21,
     "ward_name": "Kengeri",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0c97\u0cc7\u0cb0\u0cbf",
+    "ward_name_kn": "ಕೆಂಗೇರಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -8697,20 +23407,69 @@
       77.499463,
       12.915427
     ],
-    "area_sq_km": 6.0898
+    "area_sq_km": 6.0898,
+    "water_bodies": {
+      "current_count": 10,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 6,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 4
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 11,
+      "total_length_km": 10.023765
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 119,
+      "pumping_main_length_km": 13.950206,
+      "total_stp_capacity_mld": 135
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 1
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 291,
     "ward_id_local": 68,
     "ward_name": "Kamakshipalya",
-    "ward_name_kn": "\u0c95\u0cbe\u0cae\u0cbe\u0c95\u0ccd\u0cb7\u0cbf\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 8,
     "ro_division": "RO- Basaveshwara Nagara",
@@ -8727,20 +23486,66 @@
       77.533424,
       12.985468
     ],
-    "area_sq_km": 0.6674
+    "area_sq_km": 0.6674,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.19995
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 2.210055,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 292,
     "ward_id_local": 44,
     "ward_name": "Chamarajpet",
-    "ward_name_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "ward_name_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -8757,20 +23562,73 @@
       77.564621,
       12.957868
     ],
-    "area_sq_km": 0.8856
+    "area_sq_km": 0.8856,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.582579
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 11,
+      "pumping_main_length_km": 1.822431,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 293,
     "ward_id_local": 15,
     "ward_name": "Indiranagar",
-    "ward_name_kn": "\u0c87\u0c82\u0ca6\u0cbf\u0cb0\u0cbe\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಇಂದಿರಾನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 1,
     "ro_division": "RO- Indiranagar",
@@ -8787,20 +23645,69 @@
       77.642774,
       12.981782
     ],
-    "area_sq_km": 2.9775
+    "area_sq_km": 2.9775,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 3.801031
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 4.481086,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 8.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 294,
     "ward_id_local": 19,
     "ward_name": "Shivanapalya",
-    "ward_name_kn": "\u0cb6\u0cbf\u0cb5\u0ca8\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಶಿವನಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -8817,20 +23724,66 @@
       77.489996,
       12.926106
     ],
-    "area_sq_km": 1.6802
+    "area_sq_km": 1.6802,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.7385
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 4.552902,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 295,
     "ward_id_local": 92,
     "ward_name": "Muneshwara Block",
-    "ward_name_kn": "\u0cae\u0cc1\u0ca8\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0 \u0cac\u0ccd\u0cb2\u0cbe\u0c95\u0ccd",
+    "ward_name_kn": "ಮುನೇಶ್ವರ ಬ್ಲಾಕ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 12,
     "ro_division": "RO- Hampi Nagar",
@@ -8847,20 +23800,73 @@
       77.547099,
       12.949825
     ],
-    "area_sq_km": 0.6337
+    "area_sq_km": 0.6337,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.282242
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 39,
+      "pumping_main_length_km": 2.309956,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 4.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 296,
     "ward_id_local": 18,
     "ward_name": "G.M Palya",
-    "ward_name_kn": "\u0c9c\u0cbf.\u0c8e\u0c82. \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಜಿ.ಎಂ. ಪಾಳ್ಯ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -8877,20 +23883,66 @@
       77.671387,
       12.975669
     ],
-    "area_sq_km": 0.8367
+    "area_sq_km": 0.8367,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 1.920248
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 38,
+      "pumping_main_length_km": 1.964027,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 297,
     "ward_id_local": 18,
     "ward_name": "Kengal Hanumanthaiah West",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0c97\u0cb2\u0ccd \u0cb9\u0ca8\u0cc1\u0cae\u0c82\u0ca4\u0caf\u0ccd\u0caf \u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "ward_name_kn": "ಕೆಂಗಲ್ ಹನುಮಂತಯ್ಯ ಪಶ್ಚಿಮ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -8907,20 +23959,66 @@
       77.479836,
       12.924386
     ],
-    "area_sq_km": 2.3231
+    "area_sq_km": 2.3231,
+    "water_bodies": {
+      "current_count": 3,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 3.096157
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 64,
+      "pumping_main_length_km": 5.892185,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 298,
     "ward_id_local": 3,
     "ward_name": "Vasanth Nagar",
-    "ward_name_kn": "\u0cb5\u0cb8\u0c82\u0ca4 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವಸಂತ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -8937,20 +24035,71 @@
       77.592725,
       12.989805
     ],
-    "area_sq_km": 1.9422
+    "area_sq_km": 1.9422,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.547686
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 39,
+      "pumping_main_length_km": 3.470701,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 299,
     "ward_id_local": 56,
     "ward_name": "Gayathri Nagara",
-    "ward_name_kn": "\u0c97\u0cbe\u0caf\u0ca4\u0ccd\u0cb0\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಗಾಯತ್ರಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -8967,20 +24116,71 @@
       77.557884,
       13.000268
     ],
-    "area_sq_km": 0.4375
+    "area_sq_km": 0.4375,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.053233
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.890769,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 300,
     "ward_id_local": 55,
     "ward_name": "Subramanyanagara",
-    "ward_name_kn": "\u0cb8\u0cc1\u0cac\u0ccd\u0cb0\u0cb9\u0ccd\u0cae\u0ca3\u0ccd\u0caf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸುಬ್ರಹ್ಮಣ್ಯನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -8997,20 +24197,71 @@
       77.556833,
       13.007666
     ],
-    "area_sq_km": 0.8281
+    "area_sq_km": 0.8281,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 7,
+      "pumping_main_length_km": 0.549623,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 301,
     "ward_id_local": 13,
     "ward_name": "Nada prabhu Kempegowda Nagara",
-    "ward_name_kn": "\u0ca8\u0cbe\u0ca1 \u0caa\u0ccd\u0cb0\u0cad\u0cc1 \u0c95\u0cc6\u0c82\u0caa\u0cc7\u0c97\u0ccc\u0ca1 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ನಾಡ ಪ್ರಭು ಕೆಂಪೇಗೌಡ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 14,
     "ro_division": "RO- Herohalli",
@@ -9027,20 +24278,69 @@
       77.484358,
       12.997369
     ],
-    "area_sq_km": 4.2038
+    "area_sq_km": 4.2038,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 3,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 3.845996
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 3,
+      "pumping_main_length_km": 0.300964,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 302,
     "ward_id_local": 21,
     "ward_name": "Konena Agrahara",
-    "ward_name_kn": "\u0c95\u0ccb\u0ca8\u0cc7\u0ca8 \u0c85\u0c97\u0ccd\u0cb0\u0cb9\u0cbe\u0cb0",
+    "ward_name_kn": "ಕೋನೇನ ಅಗ್ರಹಾರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -9057,20 +24357,69 @@
       77.652459,
       12.954423
     ],
-    "area_sq_km": 1.4768
+    "area_sq_km": 1.4768,
+    "water_bodies": {
+      "current_count": 7,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.800059
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 56,
+      "pumping_main_length_km": 6.541559,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 303,
     "ward_id_local": 16,
     "ward_name": "New Thippasandra",
-    "ward_name_kn": "\u0ca8\u0ccd\u0caf\u0cc2 \u0ca4\u0cbf\u0caa\u0ccd\u0caa\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ನ್ಯೂ ತಿಪ್ಪಸಂದ್ರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone1",
     "zone_name": "C.V. Raman Nagar",
     "assembly_constituency": "C.V. Raman Nagar",
-    "assembly_constituency_kn": "\u0cb8\u0cbf.\u0cb5\u0cbf. \u0cb0\u0cbe\u0cae\u0ca8\u0ccd \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸಿ.ವಿ. ರಾಮನ್ ನಗರ",
     "assembly_no": 161,
     "ro_code": 2,
     "ro_division": "RO- Jeevan Bhimanagar",
@@ -9087,20 +24436,68 @@
       77.658516,
       12.976543
     ],
-    "area_sq_km": 1.9764
+    "area_sq_km": 1.9764,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 4.150975
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 4.175924,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 9.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 304,
     "ward_id_local": 24,
     "ward_name": "Jnana Bharathi Ward",
-    "ward_name_kn": "\u0c9c\u0ccd\u0c9e\u0cbe\u0ca8 \u0cad\u0cbe\u0cb0\u0ca4\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಜ್ಞಾನ ಭಾರತಿ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 11,
     "ro_division": "RO- Rajarajeswari Nagara",
@@ -9117,20 +24514,68 @@
       77.501485,
       12.946959
     ],
-    "area_sq_km": 6.6054
+    "area_sq_km": 6.6054,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 6.990698
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 51,
+      "pumping_main_length_km": 8.612913,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 305,
     "ward_id_local": 52,
     "ward_name": "Kodandarampura",
-    "ward_name_kn": "\u0c95\u0ccb\u0ca6\u0c82\u0ca1\u0cb0\u0cbe\u0cae\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಕೋದಂಡರಾಮಪುರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -9147,20 +24592,71 @@
       77.574988,
       13.004197
     ],
-    "area_sq_km": 0.5001
+    "area_sq_km": 0.5001,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 9,
+      "total_length_km": 2.279321
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 0.895119,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 306,
     "ward_id_local": 2,
     "ward_name": "Jayamahal",
-    "ward_name_kn": "\u0c9c\u0caf\u0cae\u0cb9\u0cb2\u0ccd",
+    "ward_name_kn": "ಜಯಮಹಲ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Shivajinagar",
-    "assembly_constituency_kn": "\u0cb6\u0cbf\u0cb5\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಶಿವಾಜಿನಗರ",
     "assembly_no": 162,
     "ro_code": 7,
     "ro_division": "RO- Shivajinagar",
@@ -9177,20 +24673,74 @@
       77.600185,
       12.996756
     ],
-    "area_sq_km": 1.4205
+    "area_sq_km": 1.4205,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 5,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 3
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 8,
+      "pumping_main_length_km": 1.405183,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 307,
     "ward_id_local": 59,
     "ward_name": "Nehru Nagar",
-    "ward_name_kn": "\u0ca8\u0cc6\u0cb9\u0cb0\u0cc1 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ನೆಹರು ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -9207,20 +24757,79 @@
       77.575914,
       12.981628
     ],
-    "area_sq_km": 1.7972
+    "area_sq_km": 1.7972,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 0,
+      "restoration_critical": 1,
+      "restoration_high": 0,
+      "avg_restoration_score": 86,
+      "top_bodies": [
+        {
+          "name": "Dharmambudhi",
+          "score": 86,
+          "level": "critical"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 2
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 2.458256
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 164,
+      "pumping_main_length_km": 6.483295,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 308,
     "ward_id_local": 16,
     "ward_name": "Ullal",
-    "ward_name_kn": "\u0c89\u0cb3\u0ccd\u0cb3\u0cbe\u0cb2",
+    "ward_name_kn": "ಉಳ್ಳಾಲ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -9237,20 +24846,68 @@
       77.481831,
       12.957184
     ],
-    "area_sq_km": 5.575
+    "area_sq_km": 5.575,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "vulnerable_unnamed": 3
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 5.782843
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 57,
+      "pumping_main_length_km": 11.604438,
+      "total_stp_capacity_mld": 5
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 309,
     "ward_id_local": 64,
     "ward_name": "Shivanagara",
-    "ward_name_kn": "\u0cb6\u0cbf\u0cb5\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಿವನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -9267,20 +24924,73 @@
       77.548234,
       12.99052
     ],
-    "area_sq_km": 0.293
+    "area_sq_km": 0.293,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 310,
     "ward_id_local": 12,
     "ward_name": "Andrahalli",
-    "ward_name_kn": "\u0c85\u0c82\u0ca6\u0ccd\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಅಂದ್ರಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 14,
     "ro_division": "RO- Herohalli",
@@ -9297,20 +25007,66 @@
       77.483851,
       13.017901
     ],
-    "area_sq_km": 5.5738
+    "area_sq_km": 5.5738,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 18,
+      "total_length_km": 10.362706
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 0,
+      "pumping_main_length_km": 0,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 9.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 311,
     "ward_id_local": 90,
     "ward_name": "Krishnadevaraya ward",
-    "ward_name_kn": "\u0c95\u0cc3\u0cb7\u0ccd\u0ca3\u0ca6\u0cc7\u0cb5\u0cb0\u0cbe\u0caf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕೃಷ್ಣದೇವರಾಯ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -9327,20 +25083,69 @@
       77.539517,
       12.959376
     ],
-    "area_sq_km": 0.4743
+    "area_sq_km": 0.4743,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.63479
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 21,
+      "pumping_main_length_km": 1.396895,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 312,
     "ward_id_local": 40,
     "ward_name": "Shakthi Nagar",
-    "ward_name_kn": "\u0cb6\u0c95\u0ccd\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಕ್ತಿ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Pulakeshinagar",
-    "assembly_constituency_kn": "\u0caa\u0cc1\u0cb2\u0c95\u0cc7\u0cb6\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪುಲಕೇಶಿನಗರ",
     "assembly_no": 159,
     "ro_code": 7,
     "ro_division": "RO- Pulikeshinagar",
@@ -9357,20 +25162,66 @@
       77.615939,
       13.018033
     ],
-    "area_sq_km": 0.3329
+    "area_sq_km": 0.3329,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.946535
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 47,
+      "pumping_main_length_km": 2.795868,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 313,
     "ward_id_local": 10,
     "ward_name": "Sunkadakatte",
-    "ward_name_kn": "\u0cb8\u0cc1\u0c82\u0c95\u0ca6\u0c95\u0c9f\u0ccd\u0c9f\u0cc6",
+    "ward_name_kn": "ಸುಂಕದಕಟ್ಟೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -9387,20 +25238,66 @@
       77.501548,
       12.995169
     ],
-    "area_sq_km": 0.7686
+    "area_sq_km": 0.7686,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.143477
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 2.678219,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 314,
     "ward_id_local": 27,
     "ward_name": "K.G.Halli",
-    "ward_name_kn": "\u0c95\u0cc6.\u0c9c\u0cbf.\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕೆ.ಜಿ.ಹಳ್ಳಿ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -9417,20 +25314,68 @@
       77.621054,
       13.019632
     ],
-    "area_sq_km": 0.3992
+    "area_sq_km": 0.3992,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 2.199465,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 315,
     "ward_id_local": 51,
     "ward_name": "Rajamahal",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cae\u0cb9\u0cb2\u0ccd",
+    "ward_name_kn": "ರಾಜಮಹಲ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -9447,20 +25392,73 @@
       77.586966,
       13.003174
     ],
-    "area_sq_km": 2.4329
+    "area_sq_km": 2.4329,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 7,
+      "total_length_km": 3.233017
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 19,
+      "pumping_main_length_km": 1.394057,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 316,
     "ward_id_local": 2,
     "ward_name": "Chokkasandra",
-    "ward_name_kn": "\u0c9a\u0cca\u0c95\u0ccd\u0c95\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಚೊಕ್ಕಸಂದ್ರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -9477,20 +25475,68 @@
       77.511154,
       13.04016
     ],
-    "area_sq_km": 1.0879
+    "area_sq_km": 1.0879,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 4.316827
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 65,
+      "pumping_main_length_km": 5.257852,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 317,
     "ward_id_local": 31,
     "ward_name": "Freedom Fighter Ward",
-    "ward_name_kn": "\u0cab\u0ccd\u0cb0\u0cc0\u0ca1\u0c82 \u0cab\u0cc8\u0c9f\u0cb0\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಫ್ರೀಡಂ ಫೈಟರ್ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -9507,20 +25553,68 @@
       77.52361,
       13.008132
     ],
-    "area_sq_km": 0.4969
+    "area_sq_km": 0.4969,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.598914
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 54,
+      "pumping_main_length_km": 3.944068,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 318,
     "ward_id_local": 5,
     "ward_name": "Rajeshwarinagar",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ರಾಜೇಶ್ವರಿನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -9537,20 +25631,66 @@
       77.516273,
       13.013569
     ],
-    "area_sq_km": 0.47
+    "area_sq_km": 0.47,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.649183
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 0.713108,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 319,
     "ward_id_local": 31,
     "ward_name": "Kalyan Nagar",
-    "ward_name_kn": "\u0c95\u0cb2\u0ccd\u0caf\u0cbe\u0ca3 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕಲ್ಯಾಣ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 10,
     "ro_division": "RO- Maruthi Sevanagar",
@@ -9567,20 +25707,68 @@
       77.643036,
       13.015864
     ],
-    "area_sq_km": 1.4532
+    "area_sq_km": 1.4532,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 5,
+      "total_length_km": 4.189407
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 62,
+      "pumping_main_length_km": 8.483452,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "dakshina-pinakini-bommanahalli",
+      "nearest_river_id": "dakshina-pinakini",
+      "nearest_km": 12.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 320,
     "ward_id_local": 11,
     "ward_name": "Dodda Bidarakallu",
-    "ward_name_kn": "\u0ca6\u0cca\u0ca1\u0ccd\u0ca1 \u0cac\u0cbf\u0ca6\u0cb0\u0c95\u0cb2\u0ccd\u0cb2\u0cc1",
+    "ward_name_kn": "ದೊಡ್ಡ ಬಿದರಕಲ್ಲು",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 14,
     "ro_division": "RO- Herohalli",
@@ -9597,20 +25785,69 @@
       77.49109,
       13.03417
     ],
-    "area_sq_km": 4.2335
+    "area_sq_km": 4.2335,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_low_lying": 2,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 15,
+      "total_length_km": 7.447052
+    },
+    "sewerage": {
+      "stp_count": 2,
+      "sps_count": 0,
+      "pumping_main_count": 60,
+      "pumping_main_length_km": 4.276296,
+      "total_stp_capacity_mld": 40
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.6
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 321,
     "ward_id_local": 112,
     "ward_name": "Hosakerehalli",
-    "ward_name_kn": "\u0cb9\u0cca\u0cb8\u0c95\u0cc6\u0cb0\u0cc6\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -9627,20 +25864,68 @@
       77.537124,
       12.930599
     ],
-    "area_sq_km": 0.6462
+    "area_sq_km": 0.6462,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.385842
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 0.707624,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 322,
     "ward_id_local": 32,
     "ward_name": "Laggere",
-    "ward_name_kn": "\u0cb2\u0c97\u0ccd\u0c97\u0cc6\u0cb0\u0cc6",
+    "ward_name_kn": "ಲಗ್ಗೆರೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -9657,20 +25942,66 @@
       77.523391,
       13.01327
     ],
-    "area_sq_km": 0.5103
+    "area_sq_km": 0.5103,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 3,
+      "total_length_km": 0.645978
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 39,
+      "pumping_main_length_km": 2.541988,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 323,
     "ward_id_local": 100,
     "ward_name": "Srinagar",
-    "ward_name_kn": "\u0cb6\u0ccd\u0cb0\u0cc0\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶ್ರೀನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9687,20 +26018,71 @@
       77.551452,
       12.948443
     ],
-    "area_sq_km": 0.2921
+    "area_sq_km": 0.2921,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.78825
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 25,
+      "pumping_main_length_km": 0.658068,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 324,
     "ward_id_local": 74,
     "ward_name": "Pattegar Palya",
-    "ward_name_kn": "\u0caa\u0c9f\u0ccd\u0c9f\u0cc6\u0c97\u0cbe\u0cb0\u0ccd \u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಪಟ್ಟೆಗಾರ್ ಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 4,
     "ro_division": "RO- Govindraj Nagar",
@@ -9717,20 +26099,66 @@
       77.524854,
       12.977232
     ],
-    "area_sq_km": 0.4224
+    "area_sq_km": 0.4224,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.19908
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 50,
+      "pumping_main_length_km": 4.190752,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 325,
     "ward_id_local": 26,
     "ward_name": "Samadhana Nagar",
-    "ward_name_kn": "\u0cb8\u0cae\u0cbe\u0ca7\u0cbe\u0ca8 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸಮಾಧಾನ ನಗರ",
     "corporation": "North",
-    "corporation_kn": "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0",
+    "corporation_kn": "ಉತ್ತರ",
     "corporation_id": 2,
     "zone": "Zone1",
     "zone_name": "Byatarayanapura",
     "assembly_constituency": "Sarvagnanagar",
-    "assembly_constituency_kn": "\u0cb8\u0cb0\u0ccd\u0cb5\u0c9c\u0ccd\u0c9e\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಸರ್ವಜ್ಞನಗರ",
     "assembly_no": 160,
     "ro_code": 9,
     "ro_division": "RO- HBR Layout",
@@ -9747,20 +26175,68 @@
       77.616685,
       13.023663
     ],
-    "area_sq_km": 0.5722
+    "area_sq_km": 0.5722,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.849691
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 4.906992,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 12.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 326,
     "ward_id_local": 96,
     "ward_name": "Kathriguppe",
-    "ward_name_kn": "\u0c95\u0ca4\u0ccd\u0cb0\u0cbf\u0c97\u0cc1\u0caa\u0ccd\u0caa\u0cc6",
+    "ward_name_kn": "ಕತ್ರಿಗುಪ್ಪೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9777,20 +26253,71 @@
       77.552919,
       12.929168
     ],
-    "area_sq_km": 1.0065
+    "area_sq_km": 1.0065,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 10,
+      "total_length_km": 1.830938
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 45,
+      "pumping_main_length_km": 2.782288,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 327,
     "ward_id_local": 17,
     "ward_name": "Nagadevanahalli",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0ca6\u0cc7\u0cb5\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ನಾಗದೇವನಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Yeshwanthapura",
-    "assembly_constituency_kn": "\u0caf\u0cb6\u0cb5\u0c82\u0ca4\u0caa\u0cc1\u0cb0",
+    "assembly_constituency_kn": "ಯಶವಂತಪುರ",
     "assembly_no": 153,
     "ro_code": 15,
     "ro_division": "RO- Kengeri",
@@ -9807,20 +26334,66 @@
       77.492657,
       12.940003
     ],
-    "area_sq_km": 2.4792
+    "area_sq_km": 2.4792,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 8,
+      "total_length_km": 2.375609
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 5.183457,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 328,
     "ward_id_local": 103,
     "ward_name": "N.R Colony",
-    "ward_name_kn": "\u0c8e\u0ca8\u0ccd.\u0c86\u0cb0\u0ccd. \u0c95\u0cbe\u0cb2\u0ccb\u0ca8\u0cbf",
+    "ward_name_kn": "ಎನ್.ಆರ್. ಕಾಲೋನಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9837,20 +26410,71 @@
       77.568983,
       12.937955
     ],
-    "area_sq_km": 1.0547
+    "area_sq_km": 1.0547,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.567428
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 26,
+      "pumping_main_length_km": 3.184573,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 329,
     "ward_id_local": 104,
     "ward_name": "Thyagarajnagar",
-    "ward_name_kn": "\u0ca4\u0ccd\u0caf\u0cbe\u0c97\u0cb0\u0cbe\u0c9c\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ತ್ಯಾಗರಾಜನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9867,20 +26491,71 @@
       77.560796,
       12.931824
     ],
-    "area_sq_km": 0.4236
+    "area_sq_km": 0.4236,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.825818
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 0.876015,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 330,
     "ward_id_local": 105,
     "ward_name": "Yediyuru",
-    "ward_name_kn": "\u0caf\u0ca1\u0cbf\u0caf\u0cc2\u0cb0\u0cc1",
+    "ward_name_kn": "ಯಡಿಯೂರು",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -9897,20 +26572,71 @@
       77.576769,
       12.934772
     ],
-    "area_sq_km": 1.0377
+    "area_sq_km": 1.0377,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.524658
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 72,
+      "pumping_main_length_km": 4.463791,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 1.9,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 331,
     "ward_id_local": 99,
     "ward_name": "T.R Shamanna Nagar",
-    "ward_name_kn": "\u0c9f\u0cbf.\u0c86\u0cb0\u0ccd.\u0cb6\u0cbe\u0cae\u0ca3\u0ccd\u0ca3 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಟಿ.ಆರ್.ಶಾಮಣ್ಣ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9927,20 +26653,71 @@
       77.556455,
       12.945508
     ],
-    "area_sq_km": 0.3497
+    "area_sq_km": 0.3497,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.737868
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 2,
+      "pumping_main_length_km": 0.145509,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 332,
     "ward_id_local": 101,
     "ward_name": "Kempambudhi Ward",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0caa\u0cbe\u0c82\u0cac\u0cc1\u0ca7\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಕೆಂಪಾಂಬುಧಿ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -9957,20 +26734,73 @@
       77.558999,
       12.949656
     ],
-    "area_sq_km": 0.6019
+    "area_sq_km": 0.6019,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.697664
+    },
+    "sewerage": {
+      "stp_count": 1,
+      "sps_count": 0,
+      "pumping_main_count": 20,
+      "pumping_main_length_km": 1.959935,
+      "total_stp_capacity_mld": 1
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 333,
     "ward_id_local": 111,
     "ward_name": "Ittamadu",
-    "ward_name_kn": "\u0c87\u0c9f\u0ccd\u0c9f\u0cae\u0ca1\u0cc1",
+    "ward_name_kn": "ಇಟ್ಟಮಡು",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -9987,20 +26817,68 @@
       77.541103,
       12.923166
     ],
-    "area_sq_km": 0.4579
+    "area_sq_km": 0.4579,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.294546
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 18,
+      "pumping_main_length_km": 1.52488,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 334,
     "ward_id_local": 109,
     "ward_name": "Kamakya Layout",
-    "ward_name_kn": "\u0c95\u0cbe\u0cae\u0c95\u0ccd\u0caf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "ward_name_kn": "ಕಾಮಕ್ಯ ಲೇಔಟ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -10017,20 +26895,71 @@
       77.548163,
       12.923902
     ],
-    "area_sq_km": 0.9448
+    "area_sq_km": 0.9448,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.077532
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 60,
+      "pumping_main_length_km": 3.473313,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 4.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 335,
     "ward_id_local": 110,
     "ward_name": "Chikkalasandra",
-    "ward_name_kn": "\u0c9a\u0cbf\u0c95\u0ccd\u0c95\u0cb2\u0ccd\u0cb2\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ಚಿಕ್ಕಲ್ಲಸಂದ್ರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -10047,20 +26976,66 @@
       77.545478,
       12.920624
     ],
-    "area_sq_km": 0.3853
+    "area_sq_km": 0.3853,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.940535
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 33,
+      "pumping_main_length_km": 2.032835,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 336,
     "ward_id_local": 106,
     "ward_name": "Devagiri Temple Ward",
-    "ward_name_kn": "\u0ca6\u0cc7\u0cb5\u0c97\u0cbf\u0cb0\u0cbf \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ದೇವಗಿರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -10077,20 +27052,71 @@
       77.574944,
       12.927969
     ],
-    "area_sq_km": 0.8454
+    "area_sq_km": 0.8454,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 1.083385
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 1.768519,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 2.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 337,
     "ward_id_local": 108,
     "ward_name": "Ganesh Mandira Ward",
-    "ward_name_kn": "\u0c97\u0ca3\u0cc7\u0cb6\u0ccd \u0cae\u0c82\u0ca6\u0cbf\u0cb0\u0cbe \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಗಣೇಶ್ ಮಂದಿರಾ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Padmanabanagar",
-    "assembly_constituency_kn": "\u0caa\u0ca6\u0ccd\u0cae\u0ca8\u0cbe\u0cad\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಪದ್ಮನಾಭನಗರ",
     "assembly_no": 171,
     "ro_code": 7,
     "ro_division": "RO- Yediyuru",
@@ -10107,20 +27133,71 @@
       77.563653,
       12.925449
     ],
-    "area_sq_km": 1.4304
+    "area_sq_km": 1.4304,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.241896
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 2.956519,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.5,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 338,
     "ward_id_local": 76,
     "ward_name": "Moodalapalya",
-    "ward_name_kn": "\u0cae\u0cc2\u0ca1\u0cb2\u0caa\u0cbe\u0cb3\u0ccd\u0caf",
+    "ward_name_kn": "ಮೂಡಲಪಾಳ್ಯ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -10137,20 +27214,68 @@
       77.521213,
       12.972086
     ],
-    "area_sq_km": 0.401
+    "area_sq_km": 0.401,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.647009
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 22,
+      "pumping_main_length_km": 1.615984,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 339,
     "ward_id_local": 91,
     "ward_name": "Gali Anjaneya Temple Ward",
-    "ward_name_kn": "\u0c97\u0cbe\u0cb3\u0cbf \u0c86\u0c82\u0c9c\u0ca8\u0cc7\u0caf \u0ca6\u0cc7\u0cb5\u0cb8\u0ccd\u0ca5\u0cbe\u0ca8 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಗಾಳಿ ಆಂಜನೇಯ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -10167,20 +27292,70 @@
       77.539814,
       12.954125
     ],
-    "area_sq_km": 0.7736
+    "area_sq_km": 0.7736,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 1.927821
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 32,
+      "pumping_main_length_km": 4.156405,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 1.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 340,
     "ward_id_local": 40,
     "ward_name": "Mahalakshmipuram",
-    "ward_name_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf\u0caa\u0cc1\u0cb0\u0c82",
+    "ward_name_kn": "ಮಹಾಲಕ್ಷ್ಮಿಪುರಂ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10197,20 +27372,71 @@
       77.540809,
       13.008461
     ],
-    "area_sq_km": 0.5213
+    "area_sq_km": 0.5213,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.239032
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 48,
+      "pumping_main_length_km": 2.051083,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 341,
     "ward_id_local": 30,
     "ward_name": "Kempegowda Layout",
-    "ward_name_kn": "\u0c95\u0cc6\u0c82\u0caa\u0cc7\u0c97\u0ccc\u0ca1 \u0cac\u0ca1\u0cbe\u0cb5\u0ca3\u0cc6",
+    "ward_name_kn": "ಕೆಂಪೇಗೌಡ ಬಡಾವಣೆ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Rajarajeshwarinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cb0\u0cbe\u0c9c\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "assembly_no": 154,
     "ro_code": 10,
     "ro_division": "RO- Peenya",
@@ -10227,20 +27453,68 @@
       77.524388,
       13.004157
     ],
-    "area_sq_km": 0.6328
+    "area_sq_km": 0.6328,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.099874
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 76,
+      "pumping_main_length_km": 3.463968,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 342,
     "ward_id_local": 43,
     "ward_name": "Kethamaranahalli",
-    "ward_name_kn": "\u0c95\u0cc7\u0ca4\u0cae\u0cbe\u0cb0\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಕೇತಮಾರನಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10257,20 +27531,71 @@
       77.546788,
       13.002404
     ],
-    "area_sq_km": 1.4343
+    "area_sq_km": 1.4343,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.067918
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 1.576546,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 343,
     "ward_id_local": 1,
     "ward_name": "Nagasandra",
-    "ward_name_kn": "\u0ca8\u0cbe\u0c97\u0cb8\u0c82\u0ca6\u0ccd\u0cb0",
+    "ward_name_kn": "ನಾಗಸಂದ್ರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -10287,20 +27612,69 @@
       77.501681,
       13.038647
     ],
-    "area_sq_km": 1.908
+    "area_sq_km": 1.908,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.382102
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 2.640744,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 344,
     "ward_id_local": 45,
     "ward_name": "Shakthi Ganapathi Nagara",
-    "ward_name_kn": "\u0cb6\u0c95\u0ccd\u0ca4\u0cbf \u0c97\u0ca3\u0caa\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಶಕ್ತಿ ಗಣಪತಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10317,20 +27691,66 @@
       77.53252,
       12.994143
     ],
-    "area_sq_km": 0.3927
+    "area_sq_km": 0.3927,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 0.883965,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 345,
     "ward_id_local": 78,
     "ward_name": "Anubhava Nagara",
-    "ward_name_kn": "\u0c85\u0ca8\u0cc1\u0cad\u0cb5 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅನುಭವ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -10347,20 +27767,66 @@
       77.522408,
       12.965886
     ],
-    "area_sq_km": 0.6177
+    "area_sq_km": 0.6177,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 0.344507
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 2.939924,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 346,
     "ward_id_local": 94,
     "ward_name": "Deepanjali Nagara",
-    "ward_name_kn": "\u0ca6\u0cc0\u0caa\u0cbe\u0c82\u0c9c\u0cb2\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ದೀಪಾಂಜಲಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 12,
     "ro_division": "RO- Hampi Nagar",
@@ -10377,20 +27843,69 @@
       77.534634,
       12.94454
     ],
-    "area_sq_km": 1.7701
+    "area_sq_km": 1.7701,
+    "water_bodies": {
+      "current_count": 1,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 3,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.535821
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 74,
+      "pumping_main_length_km": 8.431592,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 0.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 347,
     "ward_id_local": 84,
     "ward_name": "Hosahalli",
-    "ward_name_kn": "\u0cb9\u0cca\u0cb8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹೊಸಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -10407,20 +27922,66 @@
       77.540948,
       12.967034
     ],
-    "area_sq_km": 0.6273
+    "area_sq_km": 0.6273,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.242151
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 6,
+      "pumping_main_length_km": 0.362534,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 348,
     "ward_id_local": 6,
     "ward_name": "Shivapura",
-    "ward_name_kn": "\u0cb6\u0cbf\u0cb5\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಶಿವಪುರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -10437,20 +27998,69 @@
       77.504589,
       13.016656
     ],
-    "area_sq_km": 2.6778
+    "area_sq_km": 2.6778,
+    "water_bodies": {
+      "current_count": 2,
+      "census_records": 1,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 3.495146
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 70,
+      "pumping_main_length_km": 5.554859,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 349,
     "ward_id_local": 42,
     "ward_name": "Raja Mayura Varma Ward",
-    "ward_name_kn": "\u0cb0\u0cbe\u0c9c \u0cae\u0caf\u0cc2\u0cb0 \u0cb5\u0cb0\u0ccd\u0cae\u0cbe \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ರಾಜ ಮಯೂರ ವರ್ಮಾ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10467,20 +28077,68 @@
       77.532139,
       13.002537
     ],
-    "area_sq_km": 0.478
+    "area_sq_km": 0.478,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 4,
+      "by_category": {
+        "vulnerable_unnamed": 4
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.443177
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 35,
+      "pumping_main_length_km": 1.470746,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 350,
     "ward_id_local": 44,
     "ward_name": "Shankar Mutt",
-    "ward_name_kn": "\u0cb6\u0c82\u0c95\u0cb0 \u0cae\u0ca0",
+    "ward_name_kn": "ಶಂಕರ ಮಠ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10497,20 +28155,66 @@
       77.532036,
       12.997948
     ],
-    "area_sq_km": 0.4982
+    "area_sq_km": 0.4982,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.596313
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 67,
+      "pumping_main_length_km": 3.258271,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.8
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 351,
     "ward_id_local": 75,
     "ward_name": "Marenahalli West",
-    "ward_name_kn": "\u0cae\u0cbe\u0cb0\u0cc7\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf \u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "ward_name_kn": "ಮಾರೇನಹಳ್ಳಿ ಪಶ್ಚಿಮ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Govindraj Nagar",
-    "assembly_constituency_kn": "\u0c97\u0ccb\u0cb5\u0cbf\u0c82\u0ca6\u0cb0\u0cbe\u0c9c \u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗೋವಿಂದರಾಜ ನಗರ",
     "assembly_no": 166,
     "ro_code": 3,
     "ro_division": "RO- Chandra Layout",
@@ -10527,20 +28231,66 @@
       77.529427,
       12.971453
     ],
-    "area_sq_km": 0.4853
+    "area_sq_km": 0.4853,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.24735
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 17,
+      "pumping_main_length_km": 2.033942,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 2.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 352,
     "ward_id_local": 36,
     "ward_name": "Nalwadi Krishnaraja Wadiyar Ward",
-    "ward_name_kn": "\u0ca8\u0cbe\u0cb2\u0ccd\u0cb5\u0ca1\u0cbf \u0c95\u0cc3\u0cb7\u0ccd\u0ca3\u0cb0\u0cbe\u0c9c \u0c92\u0ca1\u0cc6\u0caf\u0cb0\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ನಾಲ್ವಡಿ ಕೃಷ್ಣರಾಜ ಒಡೆಯರ್ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10557,20 +28307,73 @@
       77.547129,
       13.017659
     ],
-    "area_sq_km": 1.7837
+    "area_sq_km": 1.7837,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 52,
+      "pumping_main_length_km": 4.871535,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 353,
     "ward_id_local": 37,
     "ward_name": "Dr. Puneeth Rajkumar Ward",
-    "ward_name_kn": "\u0ca1\u0cbe. \u0caa\u0cc1\u0ca8\u0cc0\u0ca4\u0ccd \u0cb0\u0cbe\u0c9c\u0ccd\u200c\u0c95\u0cc1\u0cae\u0cbe\u0cb0\u0ccd \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಡಾ. ಪುನೀತ್ ರಾಜ್‌ಕುಮಾರ್ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10587,20 +28390,71 @@
       77.537736,
       13.017389
     ],
-    "area_sq_km": 0.5588
+    "area_sq_km": 0.5588,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.048556
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 1.569801,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 8.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 354,
     "ward_id_local": 85,
     "ward_name": "Adi Chunchanagiri Ward",
-    "ward_name_kn": "\u0c86\u0ca6\u0cbf \u0c9a\u0cc1\u0c82\u0c9a\u0ca8\u0c97\u0cbf\u0cb0\u0cbf \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಆದಿ ಚುಂಚನಗಿರಿ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Vijayanagar",
-    "assembly_constituency_kn": "\u0cb5\u0cbf\u0c9c\u0caf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ವಿಜಯನಗರ",
     "assembly_no": 167,
     "ro_code": 13,
     "ro_division": "RO- Vijayanagar",
@@ -10617,20 +28471,73 @@
       77.545273,
       12.968298
     ],
-    "area_sq_km": 0.7045
+    "area_sq_km": 0.7045,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 1.442274
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 57,
+      "pumping_main_length_km": 3.816478,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 355,
     "ward_id_local": 53,
     "ward_name": "Malleshwaram",
-    "ward_name_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "ward_name_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -10647,20 +28554,73 @@
       77.56475,
       13.007297
     ],
-    "area_sq_km": 2.1352
+    "area_sq_km": 2.1352,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 1.798029
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 18,
+      "pumping_main_length_km": 2.375012,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 2.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 356,
     "ward_id_local": 62,
     "ward_name": "Rama Mandira",
-    "ward_name_kn": "\u0cb0\u0cbe\u0cae \u0cae\u0c82\u0ca6\u0cbf\u0cb0",
+    "ward_name_kn": "ರಾಮ ಮಂದಿರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -10677,20 +28637,74 @@
       77.555041,
       12.984788
     ],
-    "area_sq_km": 0.6604
+    "area_sq_km": 0.6604,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 1.665834,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.9
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 4.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 357,
     "ward_id_local": 67,
     "ward_name": "Basaveshwara Nagara",
-    "ward_name_kn": "\u0cac\u0cb8\u0cb5\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಬಸವೇಶ್ವರ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 8,
     "ro_division": "RO- Basaveshwara Nagara",
@@ -10707,20 +28721,68 @@
       77.539752,
       12.991257
     ],
-    "area_sq_km": 0.8675
+    "area_sq_km": 0.8675,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_low_lying",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.099916
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 9,
+      "pumping_main_length_km": 0.8684,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 358,
     "ward_id_local": 39,
     "ward_name": "Jai Maruthi Nagar",
-    "ward_name_kn": "\u0c9c\u0cc8 \u0cae\u0cbe\u0cb0\u0cc1\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಜೈ ಮಾರುತಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10737,20 +28799,73 @@
       77.534682,
       13.010449
     ],
-    "area_sq_km": 0.9075
+    "area_sq_km": 0.9075,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 5,
+      "by_category": {
+        "vulnerable_unnamed": 5
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 2,
+      "total_length_km": 2.027434
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 90,
+      "pumping_main_length_km": 4.317648,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 7.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 4.4,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 359,
     "ward_id_local": 46,
     "ward_name": "Kamalanagara",
-    "ward_name_kn": "\u0c95\u0cae\u0cb2\u0cbe\u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಕಮಲಾನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10767,20 +28882,66 @@
       77.526274,
       12.992944
     ],
-    "area_sq_km": 0.4549
+    "area_sq_km": 0.4549,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.09954
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 30,
+      "pumping_main_length_km": 2.30605,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.4
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 360,
     "ward_id_local": 47,
     "ward_name": "Vrishabhavathi Nagar",
-    "ward_name_kn": "\u0cb5\u0cc3\u0cb7\u0cad\u0cbe\u0cb5\u0ca4\u0cbf \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ವೃಷಭಾವತಿ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Mahalakshmi Layout",
-    "assembly_constituency_kn": "\u0cae\u0cb9\u0cbe\u0cb2\u0c95\u0ccd\u0cb7\u0ccd\u0cae\u0cbf \u0cb2\u0cc7\u0c94\u0c9f\u0ccd",
+    "assembly_constituency_kn": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "assembly_no": 156,
     "ro_code": 5,
     "ro_division": "RO- Mahalakshmi Layout",
@@ -10797,20 +28958,69 @@
       77.525397,
       12.988072
     ],
-    "area_sq_km": 0.5894
+    "area_sq_km": 0.5894,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 40,
+      "pumping_main_length_km": 1.270011,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.7
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 361,
     "ward_id_local": 98,
     "ward_name": "Ashoka Nagara",
-    "ward_name_kn": "\u0c85\u0cb6\u0ccb\u0c95 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಅಶೋಕ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Basavanagudi",
-    "assembly_constituency_kn": "\u0cac\u0cb8\u0cb5\u0ca8\u0c97\u0cc1\u0ca1\u0cbf",
+    "assembly_constituency_kn": "ಬಸವನಗುಡಿ",
     "assembly_no": 170,
     "ro_code": 1,
     "ro_division": "RO- Basavanagudi",
@@ -10827,20 +29037,73 @@
       77.556393,
       12.938808
     ],
-    "area_sq_km": 0.7248
+    "area_sq_km": 0.7248,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.487564
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 14,
+      "pumping_main_length_km": 1.006684,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Nimhans",
+        "block": "BANGALORE SOUTH",
+        "distance_km": 3.8,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 362,
     "ward_id_local": 8,
     "ward_name": "Hegganahalli",
-    "ward_name_kn": "\u0cb9\u0cc6\u0c97\u0ccd\u0c97\u0ca8\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "ward_name_kn": "ಹೆಗ್ಗನಹಳ್ಳಿ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone1",
     "zone_name": "Rajarajeshwarinagar",
     "assembly_constituency": "Dasarahalli",
-    "assembly_constituency_kn": "\u0ca6\u0cbe\u0cb8\u0cb0\u0cb9\u0cb3\u0ccd\u0cb3\u0cbf",
+    "assembly_constituency_kn": "ದಾಸರಹಳ್ಳಿ",
     "assembly_no": 155,
     "ro_code": 2,
     "ro_division": "RO- Hegganahalli",
@@ -10857,20 +29120,68 @@
       77.510584,
       13.003425
     ],
-    "area_sq_km": 0.8794
+    "area_sq_km": 0.8794,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "vulnerable_unnamed": 1
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.648198
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 58,
+      "pumping_main_length_km": 2.395243,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 6.5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": null
+    }
   },
   {
     "ward_number": 363,
     "ward_id_local": 50,
     "ward_name": "Sadashiva Nagara",
-    "ward_name_kn": "\u0cb8\u0ca6\u0cbe\u0cb6\u0cbf\u0cb5 \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಸದಾಶಿವ ನಗರ",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Malleshwaram",
-    "assembly_constituency_kn": "\u0cae\u0cb2\u0ccd\u0cb2\u0cc7\u0cb6\u0ccd\u0cb5\u0cb0\u0c82",
+    "assembly_constituency_kn": "ಮಲ್ಲೇಶ್ವರಂ",
     "assembly_no": 157,
     "ro_code": 6,
     "ro_division": "RO- Malleshwaram",
@@ -10887,20 +29198,79 @@
       77.573854,
       13.01767
     ],
-    "area_sq_km": 4.961
+    "area_sq_km": 4.961,
+    "water_bodies": {
+      "current_count": 4,
+      "census_records": 2,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": 55,
+      "top_bodies": [
+        {
+          "name": "Sankey Tank",
+          "score": 55,
+          "level": "moderate"
+        }
+      ]
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 4,
+      "total_length_km": 6.308033
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 23,
+      "pumping_main_length_km": 3.288559,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 10
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Indian Institute Of Science",
+        "block": "BBMP",
+        "distance_km": 1.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 364,
     "ward_id_local": 48,
     "ward_name": "Azad Nagar",
-    "ward_name_kn": "\u0c86\u0c9c\u0cbe\u0ca6\u0ccd \u0ca8\u0c97\u0cb0",
+    "ward_name_kn": "ಆಜಾದ್ ನಗರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -10917,20 +29287,71 @@
       77.556966,
       12.956945
     ],
-    "area_sq_km": 0.4058
+    "area_sq_km": 0.4058,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 0.221566
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 29,
+      "pumping_main_length_km": 1.755569,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 3.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Lalbagh Garden",
+        "block": "BBMP",
+        "distance_km": 3.7,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 365,
     "ward_id_local": 56,
     "ward_name": "Gopalpura",
-    "ward_name_kn": "\u0c97\u0ccb\u0caa\u0cbe\u0cb2\u0caa\u0cc1\u0cb0",
+    "ward_name_kn": "ಗೋಪಾಲಪುರ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -10947,20 +29368,74 @@
       77.563926,
       12.978166
     ],
-    "area_sq_km": 1.2685
+    "area_sq_km": 1.2685,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 6,
+      "by_category": {
+        "named_flood_prone": 2,
+        "vulnerable_unnamed": 4
+      },
+      "dominant_hazard": "vulnerable_unnamed",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 1,
+      "total_length_km": 3.330526
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 43,
+      "pumping_main_length_km": 2.559184,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 366,
     "ward_id_local": 57,
     "ward_name": "Cottonpete",
-    "ward_name_kn": "\u0c95\u0cbe\u0c9f\u0ca8\u0ccd\u200c\u0caa\u0cc7\u0c9f\u0cc6",
+    "ward_name_kn": "ಕಾಟನ್‌ಪೇಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -10977,20 +29452,75 @@
       77.569744,
       12.972805
     ],
-    "area_sq_km": 0.9539
+    "area_sq_km": 0.9539,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 5,
+      "by_category": {
+        "named_flood_prone": 2,
+        "named_low_lying": 1,
+        "vulnerable_unnamed": 2
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 81,
+      "pumping_main_length_km": 5.276392,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 2.1,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 367,
     "ward_id_local": 54,
     "ward_name": "Binnypete",
-    "ward_name_kn": "\u0cac\u0cbf\u0ca8\u0ccd\u0ca8\u0cbf\u0caa\u0cc7\u0c9f\u0cc6",
+    "ward_name_kn": "ಬಿನ್ನಿಪೇಟೆ",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Gandhinagara",
-    "assembly_constituency_kn": "\u0c97\u0cbe\u0c82\u0ca7\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ಗಾಂಧಿನಗರ",
     "assembly_no": 164,
     "ro_code": 5,
     "ro_division": "RO - Gandhinagara",
@@ -11007,20 +29537,71 @@
       77.560764,
       12.968324
     ],
-    "area_sq_km": 0.4763
+    "area_sq_km": 0.4763,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 0,
+      "by_category": {},
+      "dominant_hazard": null,
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 18,
+      "pumping_main_length_km": 1.146832,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.3,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 368,
     "ward_id_local": 47,
     "ward_name": "IPD Salappa Ward",
-    "ward_name_kn": "\u0c90\u0caa\u0cbf\u0ca1\u0cbf \u0cb8\u0cbe\u0cb2\u0caa\u0ccd\u0caa \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ಐಪಿಡಿ ಸಾಲಪ್ಪ ವಾರ್ಡ್",
     "corporation": "Central",
-    "corporation_kn": "\u0c95\u0cc7\u0c82\u0ca6\u0ccd\u0cb0",
+    "corporation_kn": "ಕೇಂದ್ರ",
     "corporation_id": 1,
     "zone": "Zone2",
     "zone_name": "Gandhinagara",
     "assembly_constituency": "Chamrajapet",
-    "assembly_constituency_kn": "\u0c9a\u0cbe\u0cae\u0cb0\u0cbe\u0c9c\u0caa\u0cc7\u0c9f\u0cc6",
+    "assembly_constituency_kn": "ಚಾಮರಾಜಪೇಟೆ",
     "assembly_no": 168,
     "ro_code": 3,
     "ro_division": "RO - Chamrajapet",
@@ -11037,20 +29618,73 @@
       77.561197,
       12.963791
     ],
-    "area_sq_km": 0.4924
+    "area_sq_km": 0.4924,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 1,
+      "by_category": {
+        "named_flood_prone": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 10,
+      "pumping_main_length_km": 1.074055,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 4.1
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.2,
+        "latest": null
+      }
+    }
   },
   {
     "ward_number": 369,
     "ward_id_local": 61,
     "ward_name": "Da.Ra. Bendre Ward",
-    "ward_name_kn": "\u0ca6.\u0cb0\u0cbe.\u0cac\u0cc7\u0c82\u0ca6\u0ccd\u0cb0\u0cc6 \u0cb5\u0cbe\u0cb0\u0ccd\u0ca1\u0ccd",
+    "ward_name_kn": "ದ.ರಾ.ಬೇಂದ್ರೆ ವಾರ್ಡ್",
     "corporation": "West",
-    "corporation_kn": "\u0caa\u0cb6\u0ccd\u0c9a\u0cbf\u0cae",
+    "corporation_kn": "ಪಶ್ಚಿಮ",
     "corporation_id": 5,
     "zone": "Zone2",
     "zone_name": "Malleshwaram",
     "assembly_constituency": "Rajajinagar",
-    "assembly_constituency_kn": "\u0cb0\u0cbe\u0c9c\u0cbe\u0c9c\u0cbf\u0ca8\u0c97\u0cb0",
+    "assembly_constituency_kn": "ರಾಜಾಜಿನಗರ",
     "assembly_no": 165,
     "ro_code": 9,
     "ro_division": "RO- Rajajinagara",
@@ -11067,6 +29701,60 @@
       77.558475,
       12.983503
     ],
-    "area_sq_km": 0.5262
+    "area_sq_km": 0.5262,
+    "water_bodies": {
+      "current_count": 0,
+      "census_records": 0,
+      "restoration_critical": 0,
+      "restoration_high": 0,
+      "avg_restoration_score": null,
+      "top_bodies": []
+    },
+    "lost_bodies": {
+      "count": 0,
+      "names": []
+    },
+    "flood": {
+      "hazard_zone_count": 2,
+      "by_category": {
+        "named_flood_prone": 1,
+        "named_low_lying": 1
+      },
+      "dominant_hazard": "named_flood_prone",
+      "hotspot_2015_count": 0,
+      "hotspot_2020_count": 0
+    },
+    "drainage": {
+      "line_count": 0,
+      "total_length_km": 0.844031
+    },
+    "sewerage": {
+      "stp_count": 0,
+      "sps_count": 0,
+      "pumping_main_count": 41,
+      "pumping_main_length_km": 2.003545,
+      "total_stp_capacity_mld": 0
+    },
+    "rivers": {
+      "nearest_station_id": "vrishabhavathi-nayandahalli",
+      "nearest_river_id": "vrishabhavathi",
+      "nearest_km": 5.2
+    },
+    "industrial": {
+      "zone_count": 0
+    },
+    "groundwater_assessment": {
+      "block": {
+        "name": "Bangalore-City",
+        "class": "Over Exploited",
+        "development_pct": 242.1
+      },
+      "nearest_well": {
+        "name": "Cubbon Park",
+        "block": "BBMP",
+        "distance_km": 3.6,
+        "latest": null
+      }
+    }
   }
 ]

--- a/scripts/compute-bangalore-ward-profiles.ts
+++ b/scripts/compute-bangalore-ward-profiles.ts
@@ -1,0 +1,698 @@
+/**
+ * Compute Bangalore ward profiles by spatially joining the data layers we
+ * have for Bangalore onto the 369 GBA wards (post 19-Nov-2025 notification).
+ *
+ * Mirrors scripts/compute-ward-profiles.ts (Chennai) so the UI consumes
+ * both through the same code path; preserves the admin-only fields that
+ * already live in public/data/bangalore-ward-profiles.json (ward_name,
+ * ward_name_kn, corporation, zone, assembly_constituency, population,
+ * voter ranges, etc.) by reading that file as the base and enriching
+ * each entry with analytical sections in place.
+ *
+ * Layers joined:
+ *   - water_bodies            from bangalore-water-bodies-current.geojson (OSM)
+ *                             + bangalore-water-bodies-census.geojson
+ *                             + restoration-priority-bangalore.json
+ *   - lost_bodies             water-bodies-lost-bangalore.json is name-only
+ *                             (no coords); emitted as zero per ward, with
+ *                             totals exposed on /bangalore/water-bodies.
+ *   - flood                   bangalore-flood-hotspots.geojson (398 Points,
+ *                             3 categories). Treated like Chennai's hazard
+ *                             zones; hotspot_2015/2020 sub-counts left 0
+ *                             since Bangalore has no annual snapshot.
+ *   - drainage                bangalore-swd-primary.geojson +
+ *                             bangalore-swd-secondary.geojson (LineStrings,
+ *                             midpoint count + length-by-ward distribution).
+ *   - sewerage                bangalore-stps.geojson (39 Points, capacity_mld)
+ *                             + bangalore-sewerage-trunks.geojson (14k
+ *                             LineStrings as pumping mains). SPS count
+ *                             stays 0 (no public SPS layer for BWSSB).
+ *   - rivers                  nearest station from river-quality-bangalore.json
+ *   - industrial              industrial-sources-bangalore.json (14 Points)
+ *   - groundwater_assessment  CGWB block (PIP ward centroid -> 6 GWR
+ *                             block polygons) + nearest CGWB well
+ *                             (gated <=5 km) from bangalore-cgwb-stations.json.
+ *
+ * Fully deterministic from repo contents.
+ *
+ * Run: npx tsx scripts/compute-bangalore-ward-profiles.ts
+ * Output: public/data/bangalore-ward-profiles.json (overwritten in place)
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import centroid from "@turf/centroid";
+import bbox from "@turf/bbox";
+import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
+import { point as turfPoint } from "@turf/helpers";
+import turfArea from "@turf/area";
+import along from "@turf/along";
+import length from "@turf/length";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Coord {
+  lat: number;
+  lng: number;
+}
+
+interface WardInfo {
+  ward_number: number;
+  centroid: [number, number]; // [lng, lat]
+  feature: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+  bbox: [number, number, number, number];
+}
+
+interface GroundwaterAssessment {
+  block: {
+    name: string;
+    class: string;
+    development_pct: number | null;
+  } | null;
+  nearest_well: {
+    name: string;
+    block: string;
+    distance_km: number;
+    latest: { year: number; month: number; depth_m_bgl: number } | null;
+  } | null;
+}
+
+interface AnalyticalSections {
+  water_bodies: {
+    current_count: number;
+    census_records: number;
+    restoration_critical: number;
+    restoration_high: number;
+    avg_restoration_score: number | null;
+    top_bodies: { name: string; score: number; level: string }[];
+  };
+  lost_bodies: { count: number; names: string[] };
+  flood: {
+    hazard_zone_count: number;
+    by_category: Record<string, number>;
+    dominant_hazard: string | null;
+    hotspot_2015_count: number;
+    hotspot_2020_count: number;
+  };
+  drainage: { line_count: number; total_length_km: number };
+  sewerage: {
+    stp_count: number;
+    sps_count: number;
+    pumping_main_count: number;
+    pumping_main_length_km: number;
+    total_stp_capacity_mld: number;
+  };
+  rivers: {
+    nearest_station_id: string | null;
+    nearest_river_id: string | null;
+    nearest_km: number | null;
+  };
+  industrial: { zone_count: number };
+  groundwater_assessment: GroundwaterAssessment;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const R_EARTH_KM = 6371;
+const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+function haversine(a: Coord, b: Coord): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const sinLat = Math.sin(dLat / 2);
+  const sinLng = Math.sin(dLng / 2);
+  const h =
+    sinLat * sinLat +
+    Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sinLng * sinLng;
+  return 2 * R_EARTH_KM * Math.asin(Math.sqrt(h));
+}
+
+function featureCentroid(feat: GeoJSON.Feature): Coord {
+  const c = centroid(feat);
+  return { lat: c.geometry.coordinates[1], lng: c.geometry.coordinates[0] };
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+// ── Spatial grid index ───────────────────────────────────────────────────────
+
+interface GridIndex {
+  minLng: number;
+  minLat: number;
+  cellW: number;
+  cellH: number;
+  cols: number;
+  rows: number;
+  cells: Map<string, number[]>;
+}
+
+function buildGridIndex(wards: WardInfo[], gridSize = 20): GridIndex {
+  let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+  for (const w of wards) {
+    if (w.bbox[0] < minLng) minLng = w.bbox[0];
+    if (w.bbox[1] < minLat) minLat = w.bbox[1];
+    if (w.bbox[2] > maxLng) maxLng = w.bbox[2];
+    if (w.bbox[3] > maxLat) maxLat = w.bbox[3];
+  }
+
+  const cellW = (maxLng - minLng) / gridSize;
+  const cellH = (maxLat - minLat) / gridSize;
+  const cells = new Map<string, number[]>();
+
+  for (let i = 0; i < wards.length; i++) {
+    const [wMinX, wMinY, wMaxX, wMaxY] = wards[i].bbox;
+    const colStart = Math.max(0, Math.floor((wMinX - minLng) / cellW));
+    const colEnd = Math.min(gridSize - 1, Math.floor((wMaxX - minLng) / cellW));
+    const rowStart = Math.max(0, Math.floor((wMinY - minLat) / cellH));
+    const rowEnd = Math.min(gridSize - 1, Math.floor((wMaxY - minLat) / cellH));
+
+    for (let col = colStart; col <= colEnd; col++) {
+      for (let row = rowStart; row <= rowEnd; row++) {
+        const key = `${col},${row}`;
+        const arr = cells.get(key);
+        if (arr) arr.push(i);
+        else cells.set(key, [i]);
+      }
+    }
+  }
+
+  return { minLng, minLat, cellW, cellH, cols: gridSize, rows: gridSize, cells };
+}
+
+function findWard(
+  lng: number,
+  lat: number,
+  wards: WardInfo[],
+  grid: GridIndex,
+): number | null {
+  const col = Math.floor((lng - grid.minLng) / grid.cellW);
+  const row = Math.floor((lat - grid.minLat) / grid.cellH);
+  const key = `${Math.max(0, Math.min(grid.cols - 1, col))},${Math.max(0, Math.min(grid.rows - 1, row))}`;
+  const candidates = grid.cells.get(key);
+  if (!candidates) return null;
+
+  const pt = turfPoint([lng, lat]);
+  for (const idx of candidates) {
+    if (booleanPointInPolygon(pt, wards[idx].feature)) {
+      return wards[idx].ward_number;
+    }
+  }
+  return null;
+}
+
+function distributeLineLengthByWard(
+  geom: GeoJSON.LineString,
+  wards: WardInfo[],
+  grid: GridIndex,
+  sampleStepKm = 0.05,
+): Map<number, number> {
+  const line = { type: "Feature" as const, properties: {}, geometry: geom };
+  const lenKm = length(line, { units: "kilometers" });
+  if (lenKm <= 0) return new Map();
+  const sampleCount = Math.max(1, Math.ceil(lenKm / sampleStepKm));
+  const contributionKm = lenKm / sampleCount;
+  const byWard = new Map<number, number>();
+  for (let i = 0; i < sampleCount; i++) {
+    const distanceKm = ((i + 0.5) / sampleCount) * lenKm;
+    const sample = along(line, distanceKm, { units: "kilometers" });
+    const [lng, lat] = sample.geometry.coordinates;
+    const ward = findWard(lng, lat, wards, grid);
+    if (ward != null) {
+      byWard.set(ward, (byWard.get(ward) ?? 0) + contributionKm);
+    }
+  }
+  return byWard;
+}
+
+function midpointWard(
+  geom: GeoJSON.LineString,
+  wards: WardInfo[],
+  grid: GridIndex,
+): number | null {
+  const line = { type: "Feature" as const, properties: {}, geometry: geom };
+  const len = length(line, { units: "kilometers" });
+  if (len === 0) return null;
+  const mid = along(line, len / 2, { units: "kilometers" });
+  const [lng, lat] = mid.geometry.coordinates;
+  return findWard(lng, lat, wards, grid);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+function main() {
+  const root = resolve(new URL(".", import.meta.url).pathname, "..");
+  console.log("Computing Bangalore ward profiles (369 GBA wards)...");
+
+  // 1. Load ward polygons
+  const wardGeo = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-wards-2025.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+
+  const wards: WardInfo[] = wardGeo.features.map((f) => {
+    const props = f.properties as Record<string, unknown>;
+    const wardNum = props.ward_no as number;
+    const feat = f as GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+    const c = centroid(feat);
+    const b = bbox(feat);
+    return {
+      ward_number: wardNum,
+      centroid: c.geometry.coordinates as [number, number],
+      feature: feat,
+      bbox: b as [number, number, number, number],
+    };
+  });
+  wards.sort((a, b) => a.ward_number - b.ward_number);
+  const grid = buildGridIndex(wards);
+
+  // 2. Load existing admin profile (kept as base; we enrich in place)
+  const existing = JSON.parse(
+    readFileSync(resolve(root, "public/data/bangalore-ward-profiles.json"), "utf8"),
+  ) as Array<Record<string, unknown> & { ward_number: number }>;
+  const existingByWard = new Map<number, Record<string, unknown>>();
+  for (const e of existing) existingByWard.set(e.ward_number, e);
+
+  // Per-ward accumulators
+  interface Accumulator {
+    waterBodyCount: number;
+    censusRecords: number;
+    restorationCritical: number;
+    restorationHigh: number;
+    topBodies: { name: string; score: number; level: string }[];
+    hazardZoneCount: number;
+    hazardByCategory: Record<string, number>;
+    drainageCount: number;
+    drainageLengthKm: number;
+    stpCount: number;
+    pumpingMainCount: number;
+    pumpingMainLengthKm: number;
+    totalStpCapacityMld: number;
+    industrialCount: number;
+  }
+  const acc = new Map<number, Accumulator>();
+  for (const w of wards) {
+    acc.set(w.ward_number, {
+      waterBodyCount: 0,
+      censusRecords: 0,
+      restorationCritical: 0,
+      restorationHigh: 0,
+      topBodies: [],
+      hazardZoneCount: 0,
+      hazardByCategory: {},
+      drainageCount: 0,
+      drainageLengthKm: 0,
+      stpCount: 0,
+      pumpingMainCount: 0,
+      pumpingMainLengthKm: 0,
+      totalStpCapacityMld: 0,
+      industrialCount: 0,
+    });
+  }
+
+  // 3. Water bodies current (OSM polygons) - centroid PIP
+  console.log("Processing water bodies (current)...");
+  const waterBodies = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-water-bodies-current.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  let waterBodyAssigned = 0;
+  for (const feat of waterBodies.features) {
+    const c = featureCentroid(feat);
+    const ward = findWard(c.lng, c.lat, wards, grid);
+    if (ward != null) {
+      acc.get(ward)!.waterBodyCount++;
+      waterBodyAssigned++;
+    }
+  }
+  console.log(`  ${waterBodyAssigned}/${waterBodies.features.length} current water bodies assigned`);
+
+  // 4. Water bodies census (Points) - direct PIP for census_records count
+  console.log("Processing water bodies (census)...");
+  const censusGeo = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-water-bodies-census.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  let censusAssigned = 0;
+  for (const feat of censusGeo.features) {
+    const geom = feat.geometry as GeoJSON.Point;
+    if (!geom || geom.type !== "Point") continue;
+    const [lng, lat] = geom.coordinates;
+    const ward = findWard(lng, lat, wards, grid);
+    if (ward != null) {
+      acc.get(ward)!.censusRecords++;
+      censusAssigned++;
+    }
+  }
+  console.log(`  ${censusAssigned}/${censusGeo.features.length} census records assigned`);
+
+  // 5. Restoration priority - centroid PIP. Bangalore taxonomy: source =
+  //    "osm" with priority_level "critical"|"high"|"moderate". Centroid
+  //    arrives as [lat, lng] (matches Chennai/Madurai shape).
+  console.log("Processing restoration priority...");
+  const restorationData = JSON.parse(
+    readFileSync(resolve(root, "public/data/restoration-priority-bangalore.json"), "utf8"),
+  ) as {
+    water_bodies: Array<{
+      source: string;
+      name: string;
+      centroid: [number, number];
+      priority_score: number;
+      priority_level: string;
+    }>;
+  };
+  let restorationAssigned = 0;
+  for (const body of restorationData.water_bodies) {
+    const [lat, lng] = body.centroid;
+    const ward = findWard(lng, lat, wards, grid);
+    if (ward != null) {
+      const p = acc.get(ward)!;
+      restorationAssigned++;
+      if (body.priority_level === "critical") p.restorationCritical++;
+      else if (body.priority_level === "high") p.restorationHigh++;
+      p.topBodies.push({
+        name: body.name || "(unnamed)",
+        score: body.priority_score,
+        level: body.priority_level,
+      });
+    }
+  }
+  console.log(`  ${restorationAssigned}/${restorationData.water_bodies.length} restoration records assigned`);
+
+  // 6. Flood hotspots - Points with category (no annual breakdown)
+  console.log("Processing flood hotspots...");
+  const floodGeo = JSON.parse(
+    readFileSync(resolve(root, "public/data/bangalore-flood-hotspots.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  let floodAssigned = 0;
+  for (const feat of floodGeo.features) {
+    const geom = feat.geometry as GeoJSON.Point;
+    if (!geom || geom.type !== "Point") continue;
+    const [lng, lat] = geom.coordinates;
+    const props = (feat.properties ?? {}) as Record<string, unknown>;
+    const category = (props.category as string) || "unknown";
+    const ward = findWard(lng, lat, wards, grid);
+    if (ward != null) {
+      const p = acc.get(ward)!;
+      p.hazardZoneCount++;
+      p.hazardByCategory[category] = (p.hazardByCategory[category] || 0) + 1;
+      floodAssigned++;
+    }
+  }
+  console.log(`  ${floodAssigned}/${floodGeo.features.length} flood hotspots assigned`);
+
+  // 7. SWD drainage (primary + secondary, LineStrings)
+  console.log("Processing SWD primary + secondary...");
+  const swdPaths = [
+    "public/geojson/bangalore-swd-primary.geojson",
+    "public/geojson/bangalore-swd-secondary.geojson",
+  ];
+  let drainageTotal = 0, drainageAssigned = 0;
+  for (const p of swdPaths) {
+    const geo = JSON.parse(readFileSync(resolve(root, p), "utf8")) as GeoJSON.FeatureCollection;
+    drainageTotal += geo.features.length;
+    for (const feat of geo.features) {
+      const geom = feat.geometry;
+      if (!geom || geom.type !== "LineString") continue;
+      const mid = midpointWard(geom as GeoJSON.LineString, wards, grid);
+      if (mid != null) {
+        acc.get(mid)!.drainageCount++;
+        drainageAssigned++;
+      }
+      const distributed = distributeLineLengthByWard(geom as GeoJSON.LineString, wards, grid);
+      for (const [w, km] of distributed) acc.get(w)!.drainageLengthKm += km;
+    }
+  }
+  console.log(`  ${drainageAssigned}/${drainageTotal} SWD lines assigned`);
+
+  // 8. Sewerage: STPs (Points) + trunks (LineStrings as pumping mains)
+  console.log("Processing STPs...");
+  const stpsGeo = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-stps.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  let stpAssigned = 0;
+  for (const feat of stpsGeo.features) {
+    const geom = feat.geometry as GeoJSON.Point;
+    if (!geom || geom.type !== "Point") continue;
+    const [lng, lat] = geom.coordinates;
+    const props = (feat.properties ?? {}) as Record<string, unknown>;
+    const capacityMld = (props.capacity_mld as number) ?? 0;
+    const ward = findWard(lng, lat, wards, grid);
+    if (ward != null) {
+      const p = acc.get(ward)!;
+      p.stpCount++;
+      p.totalStpCapacityMld += capacityMld;
+      stpAssigned++;
+    }
+  }
+  console.log(`  ${stpAssigned}/${stpsGeo.features.length} STPs assigned`);
+
+  console.log("Processing sewerage trunks (pumping mains)...");
+  const trunksGeo = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-sewerage-trunks.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  let trunkAssigned = 0;
+  for (const feat of trunksGeo.features) {
+    const geom = feat.geometry;
+    if (!geom || geom.type !== "LineString") continue;
+    const mid = midpointWard(geom as GeoJSON.LineString, wards, grid);
+    if (mid != null) {
+      acc.get(mid)!.pumpingMainCount++;
+      trunkAssigned++;
+    }
+    const distributed = distributeLineLengthByWard(geom as GeoJSON.LineString, wards, grid);
+    for (const [w, km] of distributed) acc.get(w)!.pumpingMainLengthKm += km;
+  }
+  console.log(`  ${trunkAssigned}/${trunksGeo.features.length} trunk midpoints assigned`);
+
+  // 9. Industrial sources (Points)
+  console.log("Processing industrial sources...");
+  const industrial = JSON.parse(
+    readFileSync(resolve(root, "public/data/industrial-sources-bangalore.json"), "utf8"),
+  ) as { sources: Array<{ id: string; name: string; lat: number; lng: number }> };
+  let industrialAssigned = 0;
+  for (const src of industrial.sources) {
+    if (typeof src.lat !== "number" || typeof src.lng !== "number") continue;
+    const ward = findWard(src.lng, src.lat, wards, grid);
+    if (ward != null) {
+      acc.get(ward)!.industrialCount++;
+      industrialAssigned++;
+    }
+  }
+  console.log(`  ${industrialAssigned}/${industrial.sources.length} industrial sources assigned`);
+
+  // 10. Nearest river station per ward (haversine from centroid)
+  console.log("Processing river stations...");
+  const riverQuality = JSON.parse(
+    readFileSync(resolve(root, "public/data/river-quality-bangalore.json"), "utf8"),
+  ) as { rivers: Array<{ id: string; stations: Array<{ id: string; lat: number; lng: number }> }> };
+  const stations: Array<{ id: string; riverId: string; coord: Coord }> = [];
+  for (const river of riverQuality.rivers) {
+    if (!Array.isArray(river.stations)) continue;
+    for (const st of river.stations) {
+      if (typeof st.lat !== "number" || typeof st.lng !== "number") continue;
+      stations.push({ id: st.id, riverId: river.id, coord: { lat: st.lat, lng: st.lng } });
+    }
+  }
+  const wardRivers = new Map<number, { stationId: string; riverId: string; km: number }>();
+  for (const w of wards) {
+    const wardC: Coord = { lat: w.centroid[1], lng: w.centroid[0] };
+    let bestDist = Infinity;
+    let best: { id: string; riverId: string } | null = null;
+    for (const st of stations) {
+      const d = haversine(wardC, st.coord);
+      if (d < bestDist) { bestDist = d; best = { id: st.id, riverId: st.riverId }; }
+    }
+    if (best) {
+      wardRivers.set(w.ward_number, {
+        stationId: best.id,
+        riverId: best.riverId,
+        km: roundTo(bestDist, 1),
+      });
+    }
+  }
+
+  // 11. CGWB block assignment (PIP ward centroid -> 6 GWR blocks; fall
+  //     back to nearest block centroid if PIP misses).
+  console.log("Processing CGWB blocks...");
+  const blocksGeo = JSON.parse(
+    readFileSync(resolve(root, "public/geojson/bangalore-gwr-blocks.geojson"), "utf8"),
+  ) as GeoJSON.FeatureCollection;
+  interface BlockInfo {
+    name: string;
+    klass: string;
+    devPct: number | null;
+    feature: GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+    centroid: Coord;
+  }
+  const blocks: BlockInfo[] = blocksGeo.features.map((f) => {
+    const props = (f.properties ?? {}) as Record<string, unknown>;
+    const c = centroid(f);
+    return {
+      name: String(props.block ?? props.name ?? ""),
+      klass: String(props.class ?? ""),
+      devPct: typeof props.sgw_dev_pe === "number"
+        ? roundTo(props.sgw_dev_pe as number, 1)
+        : null,
+      feature: f as GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
+      centroid: { lat: c.geometry.coordinates[1], lng: c.geometry.coordinates[0] },
+    };
+  });
+
+  function blockForWard(w: WardInfo): BlockInfo | null {
+    const pt = turfPoint(w.centroid);
+    for (const b of blocks) {
+      if (booleanPointInPolygon(pt, b.feature)) return b;
+    }
+    let best: BlockInfo | null = null;
+    let bestDist = Infinity;
+    const wardC: Coord = { lat: w.centroid[1], lng: w.centroid[0] };
+    for (const b of blocks) {
+      const d = haversine(wardC, b.centroid);
+      if (d < bestDist) { bestDist = d; best = b; }
+    }
+    return best;
+  }
+
+  // 12. CGWB nearest well per ward (<=5 km)
+  console.log("Processing CGWB Year Book wells...");
+  const cgwb = JSON.parse(
+    readFileSync(resolve(root, "public/data/bangalore-cgwb-stations.json"), "utf8"),
+  ) as {
+    wells: Array<{
+      name: string;
+      block: string;
+      lat: number;
+      lng: number;
+      readings: Array<{ year: number; month: number; depth_m_bgl: number }>;
+    }>;
+  };
+  const NEAREST_WELL_MAX_KM = 5;
+  function nearestWellForWard(w: WardInfo): AnalyticalSections["groundwater_assessment"]["nearest_well"] {
+    const wardC: Coord = { lat: w.centroid[1], lng: w.centroid[0] };
+    let best: { well: typeof cgwb.wells[number]; km: number } | null = null;
+    for (const well of cgwb.wells) {
+      if (typeof well.lat !== "number" || typeof well.lng !== "number") continue;
+      const d = haversine(wardC, { lat: well.lat, lng: well.lng });
+      if (best == null || d < best.km) best = { well, km: d };
+    }
+    if (!best || best.km > NEAREST_WELL_MAX_KM) return null;
+    const readings = Array.isArray(best.well.readings) ? best.well.readings : [];
+    const sorted = [...readings].sort((a, b) => b.year - a.year || b.month - a.month);
+    const latest = sorted[0]
+      ? { year: sorted[0].year, month: sorted[0].month, depth_m_bgl: sorted[0].depth_m_bgl }
+      : null;
+    return {
+      name: best.well.name,
+      block: best.well.block,
+      distance_km: roundTo(best.km, 1),
+      latest,
+    };
+  }
+
+  // 13. Build merged output (admin fields + analytical sections)
+  console.log("Building output...");
+  const output: Array<Record<string, unknown>> = [];
+  for (const w of wards) {
+    const p = acc.get(w.ward_number)!;
+    const river = wardRivers.get(w.ward_number);
+
+    const topBodies = p.topBodies
+      .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+      .slice(0, 3)
+      .map((b) => ({ name: b.name, score: b.score, level: b.level }));
+
+    let dominantHazard: string | null = null;
+    let maxCount = 0;
+    const sortedCategories = Object.entries(p.hazardByCategory).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    for (const [cat, count] of sortedCategories) {
+      if (count > maxCount) { maxCount = count; dominantHazard = cat; }
+    }
+
+    const block = blockForWard(w);
+    const groundwater_assessment: GroundwaterAssessment = {
+      block: block
+        ? { name: block.name, class: block.klass, development_pct: block.devPct }
+        : null,
+      nearest_well: nearestWellForWard(w),
+    };
+
+    const analytical: AnalyticalSections = {
+      water_bodies: {
+        current_count: p.waterBodyCount,
+        census_records: p.censusRecords,
+        restoration_critical: p.restorationCritical,
+        restoration_high: p.restorationHigh,
+        avg_restoration_score: p.topBodies.length > 0
+          ? roundTo(p.topBodies.reduce((s, b) => s + b.score, 0) / p.topBodies.length, 6)
+          : null,
+        top_bodies: topBodies,
+      },
+      lost_bodies: { count: 0, names: [] },
+      flood: {
+        hazard_zone_count: p.hazardZoneCount,
+        by_category: Object.fromEntries(sortedCategories),
+        dominant_hazard: dominantHazard,
+        hotspot_2015_count: 0,
+        hotspot_2020_count: 0,
+      },
+      drainage: {
+        line_count: p.drainageCount,
+        total_length_km: roundTo(p.drainageLengthKm, 6),
+      },
+      sewerage: {
+        stp_count: p.stpCount,
+        sps_count: 0,
+        pumping_main_count: p.pumpingMainCount,
+        pumping_main_length_km: roundTo(p.pumpingMainLengthKm, 6),
+        total_stp_capacity_mld: Math.round(p.totalStpCapacityMld * 10) / 10,
+      },
+      rivers: {
+        nearest_station_id: river?.stationId ?? null,
+        nearest_river_id: river?.riverId ?? null,
+        nearest_km: river?.km ?? null,
+      },
+      industrial: { zone_count: p.industrialCount },
+      groundwater_assessment,
+    };
+
+    const existingRec = existingByWard.get(w.ward_number) ?? { ward_number: w.ward_number };
+    output.push({ ...existingRec, ...analytical });
+  }
+
+  const outPath = resolve(root, "public/data/bangalore-ward-profiles.json");
+  writeFileSync(outPath, JSON.stringify(output, null, 2));
+
+  const totalWB = output.reduce((s, w) => s + (w.water_bodies as AnalyticalSections["water_bodies"]).current_count, 0);
+  const totalCensus = output.reduce((s, w) => s + (w.water_bodies as AnalyticalSections["water_bodies"]).census_records, 0);
+  const totalDrainage = output.reduce((s, w) => s + (w.drainage as AnalyticalSections["drainage"]).line_count, 0);
+  const totalDrainageKm = output.reduce((s, w) => s + (w.drainage as AnalyticalSections["drainage"]).total_length_km, 0);
+  const totalSewerage = output.reduce(
+    (s, w) => {
+      const sew = w.sewerage as AnalyticalSections["sewerage"];
+      return s + sew.stp_count + sew.pumping_main_count;
+    },
+    0,
+  );
+  const totalFlood = output.reduce((s, w) => s + (w.flood as AnalyticalSections["flood"]).hazard_zone_count, 0);
+  const totalIndustrial = output.reduce((s, w) => s + (w.industrial as AnalyticalSections["industrial"]).zone_count, 0);
+  const wardsWithBlock = output.filter(
+    (w) => (w.groundwater_assessment as GroundwaterAssessment).block != null,
+  ).length;
+  const wardsWithWell = output.filter(
+    (w) => (w.groundwater_assessment as GroundwaterAssessment).nearest_well != null,
+  ).length;
+
+  console.log(`\nWard profiles written to ${outPath}`);
+  console.log(`  ${output.length} wards profiled`);
+  console.log(`  Water bodies (current): ${totalWB} assigned`);
+  console.log(`  Water bodies (census records): ${totalCensus} assigned`);
+  console.log(`  Flood hotspots: ${totalFlood} assigned`);
+  console.log(`  Drainage lines: ${totalDrainage} midpoint assignments, ${Math.round(totalDrainageKm)} km apportioned`);
+  console.log(`  Sewerage features: ${totalSewerage} assigned`);
+  console.log(`  Industrial sources: ${totalIndustrial} assigned`);
+  console.log(`  Groundwater: ${wardsWithBlock}/${output.length} wards with block, ${wardsWithWell}/${output.length} wards with <=5km well`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Reddit reader reported `/bangalore/my-ward?ward=302` was either stalling forever or crashing on `Cannot read properties of undefined (reading 'current_count')`. The bug surface was patched in 951d566 on `main` (notFound state + admin-only fallback gate). This PR closes the data gap underneath.
- Adds `scripts/compute-bangalore-ward-profiles.ts`, a deterministic spatial-join pipeline modelled on the Chennai/Madurai computes. Output is `public/data/bangalore-ward-profiles.json`, schema-identical to Chennai's `ward-profiles.json`.
- All 369 GBA wards now carry the same analytical sections as Chennai: `water_bodies`, `lost_bodies`, `flood`, `drainage`, `sewerage`, `rivers`, `industrial`, `groundwater_assessment`. The admin-only fallback added in 951d566 stays as the safety net for future cities that ship before their compute lands.

## What the compute produces

| Layer | Result |
| --- | --- |
| Water bodies (current, OSM) | 352 / 1,897 polygons assigned (rest fall outside GBA boundary) |
| Water bodies (census points) | 175 / 718 assigned |
| Restoration priority (flagship lakes) | 15 / 17 (Bellandur to ward 6 Yamalur, Varthur to ward 223, Dharmambudhi to ward 307 Nehru Nagar) |
| Flood hotspots (KSNDMC + BBMP Sep 2022) | 396 / 398 across 3 categories |
| SWD primary + secondary | 1,029 / 1,033 lines, 757 km apportioned by length-weighted distribution |
| STPs (BWSSB) | 36 / 39 plants assigned with capacity_mld |
| Sewerage trunk lines (treated as pumping mains) | 14,101 / 14,121 midpoint assignments |
| Industrial sources (KSPCB listed) | 8 / 14 inside GBA |
| Nearest river station | 369 / 369 (Vrishabhavathi, Arkavati, Dakshina Pinakini) |
| Groundwater block (CGWB GEC 2024) | 369 / 369 (6 blocks tile the district) |
| Nearest CGWB well within 5 km | 228 / 369 |

`lost_bodies` stays at zero per ward: `water-bodies-lost-bangalore.json` is name-only (no coordinates), so the 9 documented lost kere cannot be spatially attributed. City-level totals stay surfaced at `/bangalore/water-bodies`.

## Implementation notes

- Admin fields (`ward_name_kn`, `corporation`, `zone`, `assembly_constituency`, `population_*`, `voter_range_*`, `centroid`, `area_sq_km`) are preserved in place. The compute reads existing profiles, enriches each entry with analytical sections, then writes back.
- `groundwater_assessment` uses the Madurai-style block + nearest-well pattern (the WardGroundwaterCard already branches on `liveEmpty && profile.groundwater_assessment`, so Bangalore wards now show the CGWB block class fallback when the live API returns noData).
- Bangalore-specific `sps_count` stays 0 (no public SPS layer for BWSSB) and `hotspot_2015_count` / `hotspot_2020_count` stay 0 (Bangalore has no annual flood snapshot like Chennai's CFLOWS).
- `scripts/compute-bangalore-ward-risk.py` re-runs cleanly against the enriched file (admin fields preserved).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (no new errors; 25 pre-existing warnings)
- [x] `npm test` (67/67 passing)
- [x] `npx tsx scripts/compute-bangalore-ward-profiles.ts` produces 369 wards with full sections
- [x] `python scripts/compute-bangalore-ward-risk.py` still runs against enriched profiles
- [x] Dev probe of `/bangalore/my-ward?ward=302` (the Reddit ward), `?ward=1`, `?ward=6` (Bellandur ward), `?ward=400` (out-of-range) - all return HTTP 200 with no runtime errors
- [ ] Manual browser test of the analytical cards (groundwater block class, water bodies list, flood hotspot categories, drainage km, STPs, river station)