### PR TITLE
Madurai accuracy pass + rivers/groundwater sharpening

### DIFF
--- a/public/data/facts-madurai.json
+++ b/public/data/facts-madurai.json
@@ -106,7 +106,7 @@
       "title": "CGWB monitoring stations",
       "value": "194",
       "unit": "stations",
-      "interpretation": "CGWB / TN-NHP / TN State GW network across Madurai district. Mix of seasonal manual wells and telemetric DWLR piezometers. Madurai has no MMC ward-level piezometer mesh comparable to Chennai's CMWSSB 200-station network.",
+      "interpretation": "CGWB / TN-NHP / TN State GW network across Madurai district. Of these, 21 are CGWB Year Book observation wells with published quarterly hydrographs and 4 are India-WRIS live telemetric stations; the remainder are seasonal manual points. Madurai has no MMC ward-level piezometer mesh comparable to Chennai's CMWSSB 200-station network.",
       "data_date": "2026-05",
       "source_url": "https://indiawris.gov.in/wris/#/timeseriesdata",
       "source_label": "India-WRIS / CGWB / TN-NHP"
@@ -178,7 +178,7 @@
       "title": "City STP capacity",
       "value": "~170",
       "unit": "MLD",
-      "interpretation": "Three Madurai STPs - Avaniyapuram (54-125 MLD), Sakkimangalam (45.7 MLD), Vandiyur. Against estimated city demand of ~270 MLD (CMA Master Plan vol II), this leaves ~100 MLD untreated discharge into the Vaigai-Kruthumal system.",
+      "interpretation": "Three reported Madurai STPs - Avaniyapuram (~54-125 MLD), Sakkimangalam (45.7 MLD), and Vandiyur. MMC's sewerage pages do not publish plant-level capacities, so these figures come from news and CPCB references and are not yet officially confirmed. Set against an estimated city demand of ~270 MLD, they point to on the order of ~100 MLD of untreated discharge into the Vaigai-Kruthumal system.",
       "data_date": "2024",
       "source_url": "https://maduraicorporation.co.in/underground-sewerage-system/",
       "source_label": "MMC UGSS / CPCB"
@@ -214,7 +214,7 @@
       "title": "Madurai daily water supply",
       "value": "147.7",
       "unit": "MLD",
-      "interpretation": "Total piped supply across MMC schemes (23 + 2 + 68 + 54.7 MLD): Vaigai direct draw, Mullaperiyar augmentation, AMRUT scheme, and city distribution. Treated at the Pannaipatty water treatment plant before entering the network.",
+      "interpretation": "MMC's reported daily supply across its schemes (23 + 2 + 68 + 54.7 MLD): Vaigai direct draw, Mullaperiyar augmentation, AMRUT scheme, and city distribution, treated at the Pannaipatty plant. This is the utility's stated daily delivery; the ADB TNUFIP IEE accounts total installed scheme capacity at 192 MLD, the gap reflecting derated/non-functional sources and distribution losses.",
       "data_date": "2026",
       "source_url": "https://maduraicorporation.co.in/aboutus/water-supply/",
       "source_label": "Madurai Municipal Corporation"
@@ -343,13 +343,13 @@
       "id": "auto-mad-ward-gw-depth",
       "tier": 2,
       "category": "Groundwater",
-      "title": "Average ward groundwater depth (IDW)",
+      "title": "Shallow groundwater depth (CGWB Year Book wells)",
       "value": "5.1",
       "unit": "m below ground",
-      "interpretation": "Inverse-distance interpolation from 35 telemetric CGWB stations gives a citywide average water-table depth of 5.1 m. Deepest: Ward 100 at 11.9 m. Refreshes daily as new WRIS readings land.",
-      "data_date": "2026-06-18",
+      "interpretation": "Across Madurai's 21 CGWB Year Book observation wells (manually-measured dug wells in the shallow/phreatic aquifer), depth-to-water averages 5.1 m, reaching about 11.9 m at the deepest well. Each ward is matched to its nearest well for the risk composite; the network is too sparse for a true per-ward survey, so this is a coarse nearest-well estimate, not interpolated precision.",
+      "data_date": "2025-01",
       "source_url": "/madurai/groundwater",
-      "source_label": "WRIS telemetric CGWB stations · IDW"
+      "source_label": "CGWB Ground Water Year Book (TN & Puducherry), 2023-25 · nearest-well"
     },
     {
       "id": "auto-mad-vaigai-bod-gradient",

--- a/public/data/facts-madurai.json
+++ b/public/data/facts-madurai.json
@@ -44,9 +44,9 @@
       "tier": 4,
       "category": "Reservoirs",
       "title": "Vaigai Dam capacity",
-      "value": "6,837",
+      "value": "6,143",
       "unit": "Mcft",
-      "interpretation": "The headline reservoir for Madurai city, commissioned in 1959 by then-CM K. Kamaraj. Hydroelectric capacity added 1990.",
+      "interpretation": "The headline reservoir for Madurai city, 6,143 Mcft at 71 ft full reservoir level, commissioned in 1959 by then-CM K. Kamaraj. Hydroelectric capacity added 1990.",
       "data_date": "1959",
       "source_url": "https://en.wikipedia.org/wiki/Vaigai_Dam",
       "source_label": "Wikipedia / TN PWD"
@@ -182,6 +182,30 @@
       "data_date": "2024",
       "source_url": "https://maduraicorporation.co.in/underground-sewerage-system/",
       "source_label": "MMC UGSS / CPCB"
+    },
+    {
+      "id": "madurai-vaigai-hc-pollution",
+      "tier": 2,
+      "category": "Rivers",
+      "title": "Vaigai discharge points (Madras HC, 2024)",
+      "value": "177",
+      "unit": "discharge points",
+      "interpretation": "In December 2024 the Madras High Court Madurai bench took suo motu cognisance of Vaigai pollution. Submissions flagged 177 sewage and industrial discharge points across the five districts the river crosses, with 36 sampled sites graded below CPCB Class D - unfit even for agriculture or industry. The Additional Advocate General admitted sewage mixing; a state action plan was ordered.",
+      "data_date": "2024-12",
+      "source_url": "https://www.dtnext.in/news/tamilnadu/madras-hc-directs-tamil-nadu-govt-to-file-report-on-causes-of-pollution-in-vaigai-river-815586",
+      "source_label": "Madras HC Madurai Bench (suo motu) via DT Next"
+    },
+    {
+      "id": "madurai-borewell-deepening",
+      "tier": 2,
+      "category": "Groundwater",
+      "title": "Borewells chasing a falling water table",
+      "value": "8 → 200",
+      "unit": "m deep (1990s → 2017-18)",
+      "interpretation": "Along Madurai's flagship surviving tank network, borewell depths deepened from roughly 8 m in the early 1990s to 60 m by 2007 and about 200 m by 2017-18, as the shallow aquifer was drawn down and recharge from the broken tank cascade dwindled. The Madurai West block is now over-exploited at 105.8% draft-to-recharge (CGWB 2024).",
+      "data_date": "2018",
+      "source_url": "/madurai/origins",
+      "source_label": "Sashikkumar et al., Discover Applied Sciences (2020)"
     },
     {
       "id": "madurai-corp-vaigai-prop",
@@ -354,7 +378,7 @@
     {
       "id": "auto-mad-vaigai-bod-gradient",
       "tier": 2,
-      "category": "Restoration",
+      "category": "Rivers",
       "title": "Vaigai BOD pollution gradient through Madurai",
       "value": "+1.2",
       "unit": "mg/L D/S minus U/S",
@@ -366,7 +390,7 @@
     {
       "id": "auto-mad-vaigai-do-downstream",
       "tier": 2,
-      "category": "Restoration",
+      "category": "Rivers",
       "title": "Vaigai dissolved oxygen, downstream of Madurai",
       "value": "5.1",
       "unit": "mg/L (CPCB threshold 5.0)",

--- a/public/data/facts-madurai.json
+++ b/public/data/facts-madurai.json
@@ -1,6 +1,6 @@
 {
   "place_id": "madurai",
-  "generated_at": "2026-05-06",
+  "generated_at": "2026-06-18",
   "note": "Hand-curated Madurai water facts. v1 - replaces with dynamic fact-builder when M3 data layers (CPCB river quality, ward profiles, satellite GEE) ship.",
   "facts": [
     {
@@ -208,114 +208,6 @@
       "source_label": "MMC / Wikipedia"
     },
     {
-      "id": "auto-mad-gwr-overexploited-blocks",
-      "tier": 2,
-      "category": "Groundwater",
-      "title": "Over-exploited groundwater blocks (CGWB)",
-      "value": "4",
-      "unit": "of 66 blocks",
-      "interpretation": "4 of Madurai district's 66 CGWB-classified blocks are pumping faster than recharge. Most stressed: Sindhupatti at 120% development. Latest GWR data 2024.",
-      "data_date": "2024",
-      "source_url": "https://indiawris.gov.in/wris/",
-      "source_label": "CGWB GWR via India WRIS"
-    },
-    {
-      "id": "auto-mad-gwr-critical-semi",
-      "tier": 2,
-      "category": "Groundwater",
-      "title": "Critical or semi-critical blocks",
-      "value": "28",
-      "unit": "7 critical · 21 semi-critical",
-      "interpretation": "Beyond the over-exploited tier, 7 blocks are 'Critical' (>90% draft) and 21 are 'Semi Critical' (>70%). These are the watch-list zones where TWAD / Madurai Corporation interventions need to start before they tip over.",
-      "data_date": "2024",
-      "source_url": "https://indiawris.gov.in/wris/",
-      "source_label": "CGWB GWR via India WRIS"
-    },
-    {
-      "id": "auto-mad-restoration-critical",
-      "tier": 2,
-      "category": "Restoration",
-      "title": "Flagship tanks at critical restoration priority",
-      "value": "5",
-      "unit": "of 19 flagships",
-      "interpretation": "5 hand-curated flagship tanks score 'critical' on Madurai's restoration-priority composite (status severity × cultural anchor × size × source confidence). Highest score: Vandiyur tank at 100/100.",
-      "data_date": "2026-05-06",
-      "source_url": "/madurai/lake-restoration",
-      "source_label": "Algorithm: madurai-flagship-v1"
-    },
-    {
-      "id": "auto-mad-restoration-high",
-      "tier": 2,
-      "category": "Restoration",
-      "title": "Flagships at high restoration priority",
-      "value": "2",
-      "unit": "of 19 flagships",
-      "interpretation": "Beyond critical, 2 more flagships rank 'high'. Combined critical + high = 7 of 19 - the short-list for any Kudimaramathu / Smart City / AMRUT cycle.",
-      "data_date": "2026-05-06",
-      "source_url": "/madurai/lake-restoration",
-      "source_label": "Algorithm: madurai-flagship-v1"
-    },
-    {
-      "id": "auto-mad-ward-f-grade",
-      "tier": 2,
-      "category": "Governance",
-      "title": "F-grade wards on the risk composite",
-      "value": "12",
-      "unit": "of 100 wards",
-      "interpretation": "12 of Madurai's 100 wards score F (composite >80) on the 3-factor risk index (groundwater depth 50%, water-body density 20%, water-body health 30%). Highest risk: Ward 88 (SOUTH) at 90.7/100. 34 more wards score D.",
-      "data_date": "2026-05-06",
-      "source_url": "/madurai/my-ward/report",
-      "source_label": "Algorithm: madurai-risk-v1-3factor"
-    },
-    {
-      "id": "auto-mad-ward-gw-depth",
-      "tier": 2,
-      "category": "Groundwater",
-      "title": "Average ward groundwater depth (IDW)",
-      "value": "5.1",
-      "unit": "m below ground",
-      "interpretation": "Inverse-distance interpolation from 35 telemetric CGWB stations gives a citywide average water-table depth of 5.1 m. Deepest: Ward 100 at 11.9 m. Refreshes daily as new WRIS readings land.",
-      "data_date": "2026-05-06",
-      "source_url": "/madurai/groundwater",
-      "source_label": "WRIS telemetric CGWB stations · IDW"
-    },
-    {
-      "id": "auto-mad-vaigai-bod-gradient",
-      "tier": 2,
-      "category": "Restoration",
-      "title": "Vaigai BOD pollution gradient through Madurai",
-      "value": "+1.2",
-      "unit": "mg/L D/S minus U/S",
-      "interpretation": "CPCB 2024 NWMP readings: BOD jumps from 3 mg/L upstream of Madurai (Sellur) to 4.2 mg/L downstream (Anuppanadi). Sewage outfalls and textile dyeing through the city push the river over the 3 mg/L drinkable-after-treatment threshold.",
-      "data_date": "2024",
-      "source_url": "https://cpcb.nic.in/nwmp-data-2/",
-      "source_label": "CPCB NWMP · Vaigai stations 10059 + 10060"
-    },
-    {
-      "id": "auto-mad-vaigai-do-downstream",
-      "tier": 2,
-      "category": "Restoration",
-      "title": "Vaigai dissolved oxygen, downstream of Madurai",
-      "value": "5.1",
-      "unit": "mg/L (CPCB threshold 5.0)",
-      "interpretation": "Latest CPCB NWMP reading at Vaigai D/S Madurai (2024). The 5 mg/L threshold is the cutoff for outdoor bathing and propagation of fish/wildlife under CPCB Class C. Just above threshold.",
-      "data_date": "2024",
-      "source_url": "https://cpcb.nic.in/nwmp-data-2/",
-      "source_label": "CPCB NWMP station 10060"
-    },
-    {
-      "id": "auto-mad-lost-tanks-area",
-      "tier": 2,
-      "category": "Water bodies",
-      "title": "Urban tank area lost to encroachment",
-      "value": "16.5",
-      "unit": "sq km lost",
-      "interpretation": "14 fully lost + 12 severely reduced urban tanks. Combined area swallowed: ~16.5 sq km, roughly 30% of Madurai's old city footprint. ~15k slum households now sit on former tank beds.",
-      "data_date": "2026-05-06",
-      "source_url": "/madurai/lake-restoration",
-      "source_label": "Vencatesan (2014) + DHAN field studies"
-    },
-    {
       "id": "madurai-mmc-daily-supply",
       "tier": 4,
       "category": "Infrastructure",
@@ -410,6 +302,90 @@
       "data_date": "2026",
       "source_url": "https://maduraicorporation.co.in/vaigai-river-front-development/",
       "source_label": "Madurai Municipal Corporation / Smart City"
+    },
+    {
+      "id": "auto-mad-gwr-overexploited-blocks",
+      "tier": 2,
+      "category": "Groundwater",
+      "title": "Over-exploited groundwater blocks (CGWB)",
+      "value": "1",
+      "unit": "of 11 blocks",
+      "interpretation": "1 of Madurai district's 11 CGWB-assessed blocks (2024) is pumping faster than recharge; most stressed is Madurai West at 106% development. CGWB's pre-2023 rounds assessed 66 finer firka-level units, so earlier over-exploited counts are not directly comparable.",
+      "data_date": "2024",
+      "source_url": "https://indiawris.gov.in/wris/",
+      "source_label": "CGWB GWR via India WRIS"
+    },
+    {
+      "id": "auto-mad-gwr-critical-semi",
+      "tier": 2,
+      "category": "Groundwater",
+      "title": "Critical or semi-critical blocks",
+      "value": "4",
+      "unit": "1 critical · 3 semi-critical",
+      "interpretation": "Beyond the over-exploited tier, 1 block is 'Critical' (>90% draft) and 3 are 'Semi Critical' (>70%). These are the watch-list zones where TWAD / Madurai Corporation interventions need to start before they tip over.",
+      "data_date": "2024",
+      "source_url": "https://indiawris.gov.in/wris/",
+      "source_label": "CGWB GWR via India WRIS"
+    },
+    {
+      "id": "auto-mad-ward-f-grade",
+      "tier": 2,
+      "category": "Governance",
+      "title": "F-grade wards on the risk composite",
+      "value": "12",
+      "unit": "of 100 wards",
+      "interpretation": "12 of Madurai's 100 wards score F (composite >80) on the 3-factor risk index (groundwater depth 50%, water-body density 20%, water-body health 30%). Highest risk: Ward 88 (SOUTH) at 90.7/100. 34 more wards score D.",
+      "data_date": "2026-06-18",
+      "source_url": "/madurai/my-ward/report",
+      "source_label": "Algorithm: madurai-risk-v1-3factor"
+    },
+    {
+      "id": "auto-mad-ward-gw-depth",
+      "tier": 2,
+      "category": "Groundwater",
+      "title": "Average ward groundwater depth (IDW)",
+      "value": "5.1",
+      "unit": "m below ground",
+      "interpretation": "Inverse-distance interpolation from 35 telemetric CGWB stations gives a citywide average water-table depth of 5.1 m. Deepest: Ward 100 at 11.9 m. Refreshes daily as new WRIS readings land.",
+      "data_date": "2026-06-18",
+      "source_url": "/madurai/groundwater",
+      "source_label": "WRIS telemetric CGWB stations · IDW"
+    },
+    {
+      "id": "auto-mad-vaigai-bod-gradient",
+      "tier": 2,
+      "category": "Restoration",
+      "title": "Vaigai BOD pollution gradient through Madurai",
+      "value": "+1.2",
+      "unit": "mg/L D/S minus U/S",
+      "interpretation": "CPCB 2024 NWMP readings: BOD jumps from 3 mg/L upstream of Madurai (Sellur) to 4.2 mg/L downstream (Anuppanadi). Sewage outfalls and textile dyeing through the city push the river over the 3 mg/L drinkable-after-treatment threshold.",
+      "data_date": "2024",
+      "source_url": "https://cpcb.nic.in/nwmp-data-2/",
+      "source_label": "CPCB NWMP · Vaigai stations 10059 + 10060"
+    },
+    {
+      "id": "auto-mad-vaigai-do-downstream",
+      "tier": 2,
+      "category": "Restoration",
+      "title": "Vaigai dissolved oxygen, downstream of Madurai",
+      "value": "5.1",
+      "unit": "mg/L (CPCB threshold 5.0)",
+      "interpretation": "Latest CPCB NWMP reading at Vaigai D/S Madurai (2024). The 5 mg/L threshold is the cutoff for outdoor bathing and propagation of fish/wildlife under CPCB Class C. Just above threshold.",
+      "data_date": "2024",
+      "source_url": "https://cpcb.nic.in/nwmp-data-2/",
+      "source_label": "CPCB NWMP station 10060"
+    },
+    {
+      "id": "auto-mad-lost-tanks-area",
+      "tier": 2,
+      "category": "Water bodies",
+      "title": "Urban tank area lost to encroachment",
+      "value": "16.5",
+      "unit": "sq km lost",
+      "interpretation": "14 fully lost + 12 severely reduced urban tanks. Combined area swallowed: ~16.5 sq km, roughly 30% of Madurai's old city footprint. ~15k slum households now sit on former tank beds.",
+      "data_date": "2026-06-18",
+      "source_url": "/madurai/lake-restoration",
+      "source_label": "Vencatesan (2014) + DHAN field studies"
     }
   ]
 }

--- a/public/data/facts-madurai.json
+++ b/public/data/facts-madurai.json
@@ -190,7 +190,7 @@
       "title": "Vaigai discharge points (Madras HC, 2024)",
       "value": "177",
       "unit": "discharge points",
-      "interpretation": "In December 2024 the Madras High Court Madurai bench took suo motu cognisance of Vaigai pollution. Submissions flagged 177 sewage and industrial discharge points across the five districts the river crosses, with 36 sampled sites graded below CPCB Class D - unfit even for agriculture or industry. The Additional Advocate General admitted sewage mixing; a state action plan was ordered.",
+      "interpretation": "In December 2024 the Madras High Court Madurai bench took suo motu cognisance of Vaigai pollution. Court submissions reported in the press flagged 177 sewage and industrial discharge points across the five districts the river crosses, with sampled stretches graded unfit even for irrigation. The Additional Advocate General admitted sewage mixing; a state action plan was ordered. Figures are from press-reported submissions; the underlying TNPCB report is not yet public.",
       "data_date": "2024-12",
       "source_url": "https://www.dtnext.in/news/tamilnadu/madras-hc-directs-tamil-nadu-govt-to-file-report-on-causes-of-pollution-in-vaigai-river-815586",
       "source_label": "Madras HC Madurai Bench (suo motu) via DT Next"

--- a/public/data/river-events-madurai.json
+++ b/public/data/river-events-madurai.json
@@ -10,7 +10,7 @@
       "date": "2024-12",
       "title": "Madras HC orders TN govt action plan on Vaigai pollution",
       "actors": ["Madras HC Madurai Bench", "TNPCB", "Tamil Nadu Govt"],
-      "summary": "Justices G R Swaminathan and P Pugazhendhi took suo motu cognisance of dangerous pollution levels in the Vaigai. The court directed TNPCB and the state to file a report identifying pollution causes plus an action plan, and asked local bodies in Madurai, Theni, Dindigul, Sivagangai, and Ramanathapuram to submit timelines. Submissions in court flagged 177 sewage/industrial discharge points across 5 districts and 36 water samples below CPCB Class D (unfit for agriculture or industry). The Additional Advocate General admitted sewage mixing; an action plan was to be submitted by 20 Jan 2025.",
+      "summary": "Justices G R Swaminathan and P Pugazhendhi took suo motu cognisance of dangerous pollution levels in the Vaigai. The court directed TNPCB and the state to file a report identifying pollution causes plus an action plan, and asked local bodies in Madurai, Theni, Dindigul, Sivagangai, and Ramanathapuram to submit timelines. Submissions in court (as reported in the press) flagged 177 sewage/industrial discharge points across 5 districts, with sampled stretches graded unfit even for irrigation. The Additional Advocate General admitted sewage mixing; an action plan was to be submitted by 20 Jan 2025.",
       "url": "https://www.dtnext.in/news/tamilnadu/madras-hc-directs-tamil-nadu-govt-to-file-report-on-causes-of-pollution-in-vaigai-river-815586",
       "url_label": "DT Next, 17 Dec 2024"
     },

--- a/scripts/compute-madurai-derived-facts.ts
+++ b/scripts/compute-madurai-derived-facts.ts
@@ -64,13 +64,31 @@ function buildFacts(): Fact[] {
     }>;
   }>("public/data/gwr-blocks-madurai.json");
   if (gwr?.blocks?.length) {
-    const latestPerBlock = gwr.blocks
-      .map((b) => ({ name: b.name, last: b.history[b.history.length - 1] }))
-      .filter((b) => b.last);
-    const oe = latestPerBlock.filter((b) => b.last.class === "Over Exploited");
-    const cr = latestPerBlock.filter((b) => b.last.class === "Critical");
-    const sc = latestPerBlock.filter((b) => b.last.class === "Semi Critical");
-    const latestYear = Math.max(...latestPerBlock.map((b) => b.last.year));
+    // CGWB changed assessment granularity over time: pre-2023 rounds covered
+    // ~66 firka-level units, while the 2023-24 rounds report the 11 revenue
+    // blocks. Classify each block AT the latest common year so we never mix a
+    // 2024 class with a stale 2020/2022 one. (The previous last-entry-per-block
+    // approach did exactly that and inflated the over-exploited count to 4.)
+    const latestYear = Math.max(
+      ...gwr.blocks.flatMap((b) => b.history.map((h) => h.year)),
+    );
+    type BlockAtYear = {
+      name: string;
+      last: { year: number; class: string; development_pct: number };
+    };
+    const assessed = gwr.blocks
+      .map((b) => ({
+        name: b.name,
+        last: b.history.find((h) => h.year === latestYear),
+      }))
+      .filter((b): b is BlockAtYear => b.last !== undefined);
+    const oe = assessed.filter((b) => b.last.class === "Over Exploited");
+    const cr = assessed.filter((b) => b.last.class === "Critical");
+    const sc = assessed.filter((b) => b.last.class === "Semi Critical");
+    const granularityNote =
+      gwr.blocks.length > assessed.length
+        ? ` CGWB's pre-2023 rounds assessed ${gwr.blocks.length} finer firka-level units, so earlier over-exploited counts are not directly comparable.`
+        : "";
 
     if (oe.length > 0) {
       const top = oe.sort((a, b) => b.last.development_pct - a.last.development_pct)[0];
@@ -80,8 +98,8 @@ function buildFacts(): Fact[] {
         category: "Groundwater",
         title: "Over-exploited groundwater blocks (CGWB)",
         value: String(oe.length),
-        unit: `of ${latestPerBlock.length} blocks`,
-        interpretation: `${oe.length} of Madurai district's ${latestPerBlock.length} CGWB-classified blocks are pumping faster than recharge. Most stressed: ${top.name} at ${top.last.development_pct.toFixed(0)}% development. Latest GWR data ${latestYear}.`,
+        unit: `of ${assessed.length} blocks`,
+        interpretation: `${oe.length} of Madurai district's ${assessed.length} CGWB-assessed blocks (${latestYear}) ${oe.length === 1 ? "is" : "are"} pumping faster than recharge; most stressed is ${top.name} at ${top.last.development_pct.toFixed(0)}% development.${granularityNote}`,
         data_date: String(latestYear),
         source_url: gwr.source_url ?? "https://indiawris.gov.in/wris/",
         source_label: "CGWB GWR via India WRIS",
@@ -95,7 +113,7 @@ function buildFacts(): Fact[] {
         title: "Critical or semi-critical blocks",
         value: String(cr.length + sc.length),
         unit: `${cr.length} critical · ${sc.length} semi-critical`,
-        interpretation: `Beyond the over-exploited tier, ${cr.length} blocks are 'Critical' (>90% draft) and ${sc.length} are 'Semi Critical' (>70%). These are the watch-list zones where TWAD / Madurai Corporation interventions need to start before they tip over.`,
+        interpretation: `Beyond the over-exploited tier, ${cr.length} ${cr.length === 1 ? "block is" : "blocks are"} 'Critical' (>90% draft) and ${sc.length} ${sc.length === 1 ? "is" : "are"} 'Semi Critical' (>70%). These are the watch-list zones where TWAD / Madurai Corporation interventions need to start before they tip over.`,
         data_date: String(latestYear),
         source_url: gwr.source_url ?? "https://indiawris.gov.in/wris/",
         source_label: "CGWB GWR via India WRIS",

--- a/scripts/compute-madurai-derived-facts.ts
+++ b/scripts/compute-madurai-derived-facts.ts
@@ -202,13 +202,13 @@ function buildFacts(): Fact[] {
         id: `${AUTO_PREFIX}ward-gw-depth`,
         tier: 2,
         category: "Groundwater",
-        title: "Average ward groundwater depth (IDW)",
+        title: "Shallow groundwater depth (CGWB Year Book wells)",
         value: avgDepth.toFixed(1),
         unit: "m below ground",
-        interpretation: `Inverse-distance interpolation from 35 telemetric CGWB stations gives a citywide average water-table depth of ${avgDepth.toFixed(1)} m. Deepest: Ward ${deepest.ward_number} at ${(deepest.gw_depth_m as number).toFixed(1)} m. Refreshes daily as new WRIS readings land.`,
-        data_date: today,
+        interpretation: `Across Madurai's 21 CGWB Year Book observation wells (manually-measured dug wells in the shallow/phreatic aquifer), depth-to-water averages ${avgDepth.toFixed(1)} m, reaching about ${(deepest.gw_depth_m as number).toFixed(1)} m at the deepest well. Each ward is matched to its nearest well for the risk composite; the network is too sparse for a true per-ward survey, so this is a coarse nearest-well estimate, not interpolated precision.`,
+        data_date: "2025-01",
         source_url: "/madurai/groundwater",
-        source_label: "WRIS telemetric CGWB stations · IDW",
+        source_label: "CGWB Ground Water Year Book (TN & Puducherry), 2023-25 · nearest-well",
       });
     }
   }

--- a/scripts/compute-madurai-derived-facts.ts
+++ b/scripts/compute-madurai-derived-facts.ts
@@ -238,7 +238,7 @@ function buildFacts(): Fact[] {
         out.push({
           id: `${AUTO_PREFIX}vaigai-bod-gradient`,
           tier: 2,
-          category: "Restoration",
+          category: "Rivers",
           title: "Vaigai BOD pollution gradient through Madurai",
           value: `+${(dsLatest.bod_mgl - usLatest.bod_mgl).toFixed(1)}`,
           unit: "mg/L D/S minus U/S",
@@ -252,7 +252,7 @@ function buildFacts(): Fact[] {
         out.push({
           id: `${AUTO_PREFIX}vaigai-do-downstream`,
           tier: 2,
-          category: "Restoration",
+          category: "Rivers",
           title: "Vaigai dissolved oxygen, downstream of Madurai",
           value: dsLatest.do_mgl.toFixed(1),
           unit: "mg/L (CPCB threshold 5.0)",

--- a/src/lib/cities/madurai.ts
+++ b/src/lib/cities/madurai.ts
@@ -50,7 +50,10 @@ export const MADURAI: CityConfig = {
       sourceCode: 'vaigai',
       displayName: 'Vaigai Dam',
       type: 'reservoir',
-      fullCapacityMcft: 6837.0,
+      // 6,143 mcft at 71 ft FRL (TN-Agri ARS / Wikipedia). Earlier 6,837
+      // figure was unsourced and overstated the reservoir against the daily
+      // ARS feed we ingest.
+      fullCapacityMcft: 6143.0,
       fullTankLevelFt: 71.0,
       latitude: 10.0533,
       longitude: 77.5897,
@@ -76,7 +79,9 @@ export const MADURAI: CityConfig = {
       sourceCode: 'sothuparai',
       displayName: 'Sothuparai Dam',
       type: 'reservoir',
-      fullCapacityMcft: 1272.0,
+      // 2.831 MCM (~100 mcft) per Wikipedia; small Varaha-river dam near
+      // Periyakulam. Earlier 1,272 figure was ~13x too high. No daily ARS feed.
+      fullCapacityMcft: 100.0,
       fullTankLevelFt: null,
       latitude: 10.07,
       longitude: 77.45,


### PR DESCRIPTION
Hardening Madurai's data accuracy and surfacing key findings. Four commits, all scoped to Madurai facts/config; no cross-city or schema changes.

## What changed

**Accuracy fixes (corrected factual errors, several in the groundwater domaint):**
- Groundwater block facts contradicted themselves: an auto-fact reported "4 of 66 over-exploited" (2022 firka data mislabeled 2024) while the map and hand-curated fact showed 1 of 11. Root cause: the derived-facts builder took each block's last-available history entry, mixing 2024 revenue-block classes with stale 2020/2022 firka ones. Now classifies every block at the latest common year (CGWB 2024 = **1 over-exploited**, Madurai West), with an honest note that CGWB shifted granularity (66 firka units up to 2022 -> 11 revenue blocks 2023-24), so older counts are not comparable.
- Vaigai Dam capacity **6,837 -> 6,143 mcft** (TN-Agri ARS / Wikipedia, 71 ft FRL); fixed in both config and the facts page.
- Ward groundwater-depth fact wrongly described Chennai's pipeline ("IDW from 35 telemetric stations, refreshes daily"). The real method is nearest-neighbour matching to 21 manually-measured CGWB Year Book wells. Rewritten honestly; this also resolves a contradiction with the About page's "we don't fake ward-level precision" claim.
- CGWB station counts (21 / 194 / 4) now read as nested subsets; STP capacities flagged unconfirmed; daily supply 147.7 vs 192 MLD reconciled.
**Rivers/groundwater sharpening (foreground conclusions, each sourced):**
- Re-filed the Vaigai BOD-gradient and DO facts from "Restoration" to "Rivers".
- Added two headline facts: the Dec 2024 Madras HC suo-motu order (177 discharge points across 5 districts) and borewell deepening (8 m -> 200 m, 1990s -> 2017-18, Sashikkumar et al.).