### PR TITLE
chennai/shoreline: at-a-glance summary overlay

### DIFF
--- a/src/app/shoreline/coastal-client.tsx
+++ b/src/app/shoreline/coastal-client.tsx
@@ -7,6 +7,7 @@ import { BottomSheet } from "@/components/map/bottom-sheet";
 import { MapInfoButton } from "@/components/map/map-info-button";
 import { CoastalLegend } from "@/components/coastal/coastal-legend";
 import { CoastalDetailPanel } from "@/components/coastal/coastal-detail-panel";
+import { ShorelineSummary } from "@/components/coastal/shoreline-summary";
 import { useLockBodyScroll } from "@/lib/hooks/use-lock-body-scroll";
 import type { SelectedCoastal, CoastalSummary } from "@/types/coastal";
 
@@ -29,6 +30,8 @@ export default function CoastalClient() {
   useLockBodyScroll();
   const [selected, setSelected] = useState<SelectedCoastal | null>(null);
   const [summary, setSummary] = useState<CoastalSummary | null>(null);
+  // Bumped by the summary's "zoom to worst spot" button to fly the map there.
+  const [flySignal, setFlySignal] = useState(0);
   // Pre-select the worst-eroding transect once the data loads, so the panel
   // opens with a clear, self-explanatory example. Runs in the map's data-load
   // callback (not an effect), and only the first time; the user is in control
@@ -41,11 +44,6 @@ export default function CoastalClient() {
       setSelected({ kind: "transect", props: s.featured });
     }
   };
-
-  const accelPct =
-    summary && summary.erodingWithSplit > 0
-      ? Math.round((100 * summary.acceleratingErosion) / summary.erodingWithSplit)
-      : null;
 
   return (
     <div className="h-[calc(100vh-64px)] flex flex-col">
@@ -62,15 +60,6 @@ export default function CoastalClient() {
             <span className="font-semibold text-slate-900 dark:text-slate-100">{summary?.total ?? 905}</span> transects
           </span>
         </div>
-        {accelPct != null && (
-          <div className="flex items-center gap-2 whitespace-nowrap shrink-0">
-            <span className="w-3 h-3 rounded-sm bg-red-700 opacity-80" />
-            <span className="text-xs text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-900 dark:text-slate-100">{accelPct}%</span> eroding{" "}
-              <span className="font-semibold">faster</span> than before
-            </span>
-          </div>
-        )}
         <div className="ml-auto flex items-center gap-3">
           <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap hidden sm:inline">
             Corroborated by{" "}
@@ -89,7 +78,23 @@ export default function CoastalClient() {
 
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
         <div className="relative flex-1 h-full">
-          <CoastalMap selected={selected} onSelect={setSelected} onSummary={handleSummary} />
+          <CoastalMap
+            selected={selected}
+            onSelect={setSelected}
+            onSummary={handleSummary}
+            flyToFeaturedSignal={flySignal}
+          />
+
+          {/* "At a glance" summary - semi-transparent overlay, top-right. */}
+          <div className="absolute top-2 right-2 sm:top-4 sm:right-4 z-[1000]">
+            <ShorelineSummary
+              summary={summary}
+              onShowWorst={() => {
+                if (summary?.featured) setSelected({ kind: "transect", props: summary.featured });
+                setFlySignal((s) => s + 1);
+              }}
+            />
+          </div>
 
           {/* Legend overlay */}
           <div

--- a/src/components/coastal/coastal-map.tsx
+++ b/src/components/coastal/coastal-map.tsx
@@ -22,6 +22,8 @@ interface CoastalMapProps {
   selected: SelectedCoastal | null;
   onSelect: (sel: SelectedCoastal | null) => void;
   onSummary?: (s: CoastalSummary) => void;
+  /** Increment to zoom the map to the showcase ("Highest erosion") transect. */
+  flyToFeaturedSignal?: number;
   mapCenter?: [number, number];
   mapZoom?: number;
 }
@@ -47,6 +49,18 @@ function FlyTo({ target }: { target: [number, number] | null }) {
   return null;
 }
 
+/** Zooms to `target` whenever `signal` increments - lets a parent (e.g. the
+ *  summary's "zoom to worst spot" button) trigger a fly without a map click. */
+function FlyOnSignal({ signal, target }: { signal: number; target: [number, number] | null }) {
+  const map = useMap();
+  useEffect(() => {
+    if (signal > 0 && target) map.setView(target, Math.max(map.getZoom(), 13), { animate: true });
+    // Fire only when the signal changes, not on target/map identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signal]);
+  return null;
+}
+
 /**
  * Single shoreline-change view. The rate-coloured transects (our own
  * measurement) are the primary layer; the study's six zones are drawn as faint
@@ -60,6 +74,7 @@ export function CoastalMap({
   onSummary,
   mapCenter = [13.15, 80.32],
   mapZoom = 11,
+  flyToFeaturedSignal = 0,
 }: CoastalMapProps) {
   const tiles = useMapTiles();
   const [zones, setZones] = useState<FeatureCollection | null>(null);
@@ -87,6 +102,8 @@ export function CoastalMap({
           const all = t.features.map((f) => f.properties as unknown as CoastalTransectProperties);
           const hi = all.filter((p) => p.confidence === "high");
           const eroding = hi.filter((p) => p.trend === "erosion");
+          const accreting = hi.filter((p) => p.trend === "accretion");
+          const stable = hi.filter((p) => p.trend === "stable");
           const withSplit = eroding.filter((p) => p.early_rate_m_yr != null && p.recent_rate_m_yr != null);
           const accel = withSplit.filter((p) => (p.recent_rate_m_yr as number) - (p.early_rate_m_yr as number) < -1);
           const featured =
@@ -104,7 +121,10 @@ export function CoastalMap({
           }
           onSummary?.({
             total: all.length,
+            highConf: hi.length,
             eroding: eroding.length,
+            accreting: accreting.length,
+            stable: stable.length,
             erodingWithSplit: withSplit.length,
             acceleratingErosion: accel.length,
             period: all[0]?.period ?? "1990-2026",
@@ -142,6 +162,7 @@ export function CoastalMap({
       {/* Default load frames the entire coastline; clicks zoom in via FlyTo. */}
       <FitToBounds bounds={geoJsonBounds(zones)} resetKey="coastal-full" maxZoom={12} />
       <FlyTo target={flyTarget} />
+      <FlyOnSignal signal={flyToFeaturedSignal} target={featuredLatLng} />
 
       {/* Study zones: faint neutral context bands, clickable for the study's
           per-zone figures. Highlighted when selected. */}

--- a/src/components/coastal/shoreline-summary.tsx
+++ b/src/components/coastal/shoreline-summary.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import type { CoastalSummary } from "@/types/coastal";
+
+/**
+ * "At a glance" overview for the shoreline page - a semi-transparent card
+ * overlaid top-right of the map, open by default and collapsible to a pill.
+ * Gives the Chennai-wide conclusion on arrival without changing the map.
+ */
+export function ShorelineSummary({
+  summary,
+  onShowWorst,
+}: {
+  summary: CoastalSummary | null;
+  onShowWorst: () => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="bg-white/85 dark:bg-slate-900/85 backdrop-blur-sm rounded-lg shadow-md border border-slate-200 dark:border-slate-700 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-200 flex items-center gap-1.5 hover:bg-white dark:hover:bg-slate-900"
+      >
+        <span className="w-2 h-2 rounded-full bg-red-600" />
+        Coastline summary
+        <svg className="w-3.5 h-3.5 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M9 18l6-6-6-6" />
+        </svg>
+      </button>
+    );
+  }
+
+  const hc = summary?.highConf ?? 0;
+  const pct = (n: number) => (hc ? Math.round((100 * n) / hc) : 0);
+  const erodingPct = pct(summary?.eroding ?? 0);
+  const accretingPct = pct(summary?.accreting ?? 0);
+  const stablePct = Math.max(0, 100 - erodingPct - accretingPct);
+  const accelPct =
+    summary && summary.erodingWithSplit > 0
+      ? Math.round((100 * summary.acceleratingErosion) / summary.erodingWithSplit)
+      : null;
+  const period = summary?.period ?? "1990-2026";
+
+  return (
+    <div className="w-[260px] sm:w-[288px] bg-white/85 dark:bg-slate-900/85 backdrop-blur-sm rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 p-3.5 text-sm">
+      <div className="flex items-start justify-between mb-2">
+        <h2 className="font-bold text-slate-900 dark:text-slate-100 leading-tight">
+          Chennai coastline
+          <span className="block text-[11px] font-normal text-slate-500">
+            at a glance - {period}, Mahabalipuram to Pulicat
+          </span>
+        </h2>
+        <button
+          onClick={() => setOpen(false)}
+          className="p-1 -m-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 shrink-0"
+          aria-label="Collapse summary"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M5 12h14" />
+          </svg>
+        </button>
+      </div>
+
+      <p className="text-slate-700 dark:text-slate-200 font-medium leading-snug mb-3">
+        Most of the coast is eroding - and the erosion is speeding up.
+      </p>
+
+      {!summary ? (
+        <p className="text-xs text-slate-400">Calculating from the satellite measurement…</p>
+      ) : (
+        <>
+      {/* erosion / stable / accretion split */}
+      <div className="mb-1.5">
+        <div className="flex h-2.5 rounded-full overflow-hidden">
+          <div style={{ width: `${erodingPct}%`, backgroundColor: "#dc2626" }} />
+          <div style={{ width: `${stablePct}%`, backgroundColor: "#94a3b8" }} />
+          <div style={{ width: `${accretingPct}%`, backgroundColor: "#2563eb" }} />
+        </div>
+        <div className="flex justify-between text-[11px] mt-1">
+          <span className="text-red-600 dark:text-red-400 font-semibold">{erodingPct}% eroding</span>
+          <span className="text-slate-500">{stablePct}% stable</span>
+          <span className="text-blue-600 dark:text-blue-400 font-semibold">{accretingPct}% accreting</span>
+        </div>
+      </div>
+
+      {accelPct != null && (
+        <p className="text-xs text-slate-600 dark:text-slate-300 mt-2.5">
+          <span className="font-bold text-slate-900 dark:text-slate-100">{accelPct}%</span> of the eroding
+          coast is eroding <span className="font-semibold">faster</span> now (2015-2026) than before.
+        </p>
+      )}
+
+      <p className="text-xs text-slate-600 dark:text-slate-300 mt-2 leading-snug">
+        <span className="font-semibold">Why:</span> the <span className="font-semibold">Ennore &amp; Kattupalli</span>{" "}
+        ports interrupt the coast&apos;s natural south-to-north sand drift - trapping sand at the breakwaters,
+        but starving and eroding the beaches further north (down-drift). The coast gains land where the{" "}
+        <span className="font-semibold">Adyar &amp; Cooum</span> rivers drop silt at their mouths.
+      </p>
+
+      <button
+        onClick={onShowWorst}
+        className="mt-3 w-full text-xs font-semibold text-white bg-red-600 hover:bg-red-700 rounded-md py-1.5"
+      >
+        Zoom to the worst-eroding spot →
+      </button>
+
+      <p className="text-[10px] text-slate-400 mt-2.5 leading-snug">
+        Our satellite measurement ({summary.total.toLocaleString()}{" "}transects), corroborated by
+        Anagha, Singh &amp; Frappart (2026).
+      </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/types/coastal.ts
+++ b/src/types/coastal.ts
@@ -151,7 +151,11 @@ export function rateColor(rate: number): string {
 /** Aggregate the map computes from the computed-transect layer for the header. */
 export interface CoastalSummary {
   total: number;
+  /** Counts below are over HIGH-confidence transects only. */
+  highConf: number;
   eroding: number;
+  accreting: number;
+  stable: number;
   erodingWithSplit: number;
   acceleratingErosion: number;
   period: string;


### PR DESCRIPTION
Follow-up to #131. Adds a collapsible, semi-transparent **"Chennai coastline at a glance"** card overlaid top-right of the `/shoreline` map (open by default, reduces to a pill), so a visitor gets the coast-wide conclusion on arrival instead of having to work the map.

- Verdict + eroding/stable/accreting split bar + acceleration %, all over high-confidence transects.
- Plain-language **why**: the Ennore/Kattupalli ports interrupt the south-to-north sand drift (eroding the down-drift beaches); the Adyar/Cooum river mouths gain land from trapped silt.
- **"Zoom to the worst-eroding spot"** button flies the map to the showcase transect.
- Credits the study.
- Removed the now-duplicated "% eroding faster" from the top stats bar (the box owns it).

Map behaviour is unchanged - this is purely an additive overlay. Frontend-only, no GEE re-run.