### PR TITLE
Bengaluru gap data: freshen BBMP/Devanahalli + semantic green/red panels

### DIFF
--- a/public/data/basins/arkavathi/fstp.geojson
+++ b/public/data/basins/arkavathi/fstp.geojson
@@ -1,1 +1,81 @@
-{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"name": "Bashettihalli FSTP", "capacityKld": 6, "status": "Not yet functional - tender/planning stage", "agency": "—", "kind": "fstp", "shedId": "C05CAM31", "locationNote": "approximate (no source coordinate)"}, "geometry": {"type": "Point", "coordinates": [77.537, 13.197]}}, {"type": "Feature", "properties": {"name": "Chikkabanavara FSTP", "capacityKld": 9, "status": "Not yet functional - tender/planning stage", "agency": "—", "kind": "fstp", "shedId": "C05CAM32", "locationNote": "approximate (no source coordinate)"}, "geometry": {"type": "Point", "coordinates": [77.512, 13.08]}}, {"type": "Feature", "properties": {"name": "Harohalli FSTP", "capacityKld": 6, "status": "Not yet functional - tender/planning stage", "agency": "—", "kind": "fstp", "shedId": "C05CAM35", "locationNote": "approximate (no source coordinate)"}, "geometry": {"type": "Point", "coordinates": [77.478, 12.608]}}]}
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bashettihalli FSTP",
+        "capacityKld": 6,
+        "status": "Not yet functional - tender/planning stage",
+        "agency": "—",
+        "kind": "fstp",
+        "shedId": "C05CAM31",
+        "locationNote": "approximate (no source coordinate)"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.537,
+          13.197
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Chikkabanavara FSTP",
+        "capacityKld": 9,
+        "status": "Not yet functional - tender/planning stage",
+        "agency": "—",
+        "kind": "fstp",
+        "shedId": "C05CAM32",
+        "locationNote": "approximate (no source coordinate)"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.512,
+          13.08
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Harohalli FSTP",
+        "capacityKld": 6,
+        "status": "Not yet functional - tender/planning stage",
+        "agency": "—",
+        "kind": "fstp",
+        "shedId": "C05CAM35",
+        "locationNote": "approximate (no source coordinate)"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.478,
+          12.608
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Devanahalli FSTP",
+        "capacityKld": 6,
+        "status": "Operational since Nov 2015 - India's first municipal-scale FSTP (CDD Society / BORDA); treats ~100% of collected septage",
+        "agency": "Devanahalli TMC / CDD Society / BORDA",
+        "kind": "fstp",
+        "shedId": "",
+        "locationNote": "approximate (Devanahalli town; no source coordinate)"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.712,
+          13.249
+        ]
+      }
+    }
+  ]
+}

--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -856,6 +856,19 @@
               "emphasis": true
             },
             {
+              "label": "STP network (BWSSB, latest)",
+              "value": "34 STPs, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. Note: DEP 2022 listed 1,522.5 MLD as sanctioned/under-construction.",
+              "emphasis": true
+            },
+            {
+              "label": "Expansion under way, 2026",
+              "value": "+26 STPs / +470 MLD targeted by end-2025 (to ~1,818 MLD); 20 of 34 plants being upgraded to NGT tertiary norms (BOD<=10) by 2026."
+            },
+            {
+              "label": "Monitoring mandate, 2026",
+              "value": "KSPCB OCEMS order (Jan 2026): online continuous effluent monitoring required at every STP outlet >100 KLD across BWSSB + private plants in the Bengaluru Metropolitan Region."
+            },
+            {
               "label": "Sewer-network gap",
               "value": "~20% of area uncovered; 8-10% of sewage untreated (DEP 2022)",
               "emphasis": true
@@ -886,6 +899,12 @@
               "says": "V Valley STP (PRS Arkavathi catchment), Bengaluru Urban: 150 MLD, Operational and Complying, treating 150.36 MLD (2.48 MLD reused to recharge a lake); commissioned Dec 2021 at 70 MLD. A second 150 MLD SBR+ASP STP is under construction (~61%) in place of the existing 180 MLD STP, target 2026.",
               "citation": "Karnataka Monthly Progress Report, February 2026 (NMCG)",
               "url": "https://nmcg.nic.in/writereaddata/fileupload/ngtmpr/7_Karnataka%20-%20February%202026.pdf"
+            },
+            {
+              "source": "BWSSB / KSPCB (2026)",
+              "says": "34 STPs, 1,348.5 MLD installed and ~1,212.7 MLD treated as of Mar 2026; 26 new STPs (+470 MLD) targeted by end-2025; 20 of 34 plants being rehabilitated to NGT tertiary norms; KSPCB Jan 2026 board resolution mandates OCEMS at all STP outlets >100 KLD in the BMR.",
+              "citation": "BWSSB STP rehabilitation programme & KSPCB OCEMS directive, 2026; reported in Water Today / Deccan Herald",
+              "url": "https://www.deccanherald.com/india/karnataka/bengaluru/bengaluru-to-add-26-more-stps-by-june-2026-to-expand-treated-water-capacity-3397653"
             }
           ],
           "medium": "liquid",
@@ -1774,7 +1793,8 @@
             },
             {
               "label": "Faecal sludge",
-              "value": "Faecal Sludge Treatment Plant recorded in use (DEP 2021, p.57)"
+              "value": "Devanahalli FSTP - CDD Society / BORDA, 6 KLD, operational since Nov 2015. India's first municipal-scale FSTP (625 m2, ~4,000 households); treats ~100% of collected septage via screening, solid-liquid separation, anaerobic baffled reactor, planted gravel filter and co-composting.",
+              "emphasis": true
             },
             {
               "label": "Plan inconsistency",
@@ -1797,6 +1817,12 @@
               "says": "Devanahalli does not appear in the Karnataka existing-STP list - no conventional STP as of Feb 2026.",
               "citation": "Karnataka Monthly Progress Report, February 2026 (NMCG)",
               "url": "https://nmcg.nic.in/writereaddata/fileupload/ngtmpr/7_Karnataka%20-%20February%202026.pdf"
+            },
+            {
+              "source": "FSM Toolbox / CSE / WRI India - Devanahalli FSTP case study",
+              "says": "Devanahalli Town Municipal Council, with CDD Society and BORDA, set up a 6,000 L/day faecal sludge treatment plant operational since Nov 2015 - India's first municipal FSTP - serving ~4,000 households and treating 100% of the town's collected septage.",
+              "citation": "Devanahalli FSTP case study (CDD/BORDA); WRI India, CSE India",
+              "url": "https://wri-india.org/blogs/lessons-devanahalli-urban-faecal-sludge-management"
             }
           ],
           "medium": "liquid",

--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -856,16 +856,16 @@
               "emphasis": true
             },
             {
-              "label": "STP network (BWSSB, latest)",
-              "value": "34 STPs, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. Note: DEP 2022 listed 1,522.5 MLD as sanctioned/under-construction.",
+              "label": "STP network (BBMP city-wide)",
+              "value": "34 STPs across all three valleys, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. City-wide; only the Vrishabhavathi valley drains into the Arkavathi (see below). DEP 2022's 1,522.5 MLD was sanctioned/under-construction.",
               "emphasis": true
             },
             {
-              "label": "Expansion under way, 2026",
+              "label": "Expansion, 2026 (city-wide)",
               "value": "+26 STPs / +470 MLD targeted by end-2025 (to ~1,818 MLD); 20 of 34 plants being upgraded to NGT tertiary norms (BOD<=10) by 2026."
             },
             {
-              "label": "Monitoring mandate, 2026",
+              "label": "Monitoring mandate, 2026 (city-wide)",
               "value": "KSPCB OCEMS order (Jan 2026): online continuous effluent monitoring required at every STP outlet >100 KLD across BWSSB + private plants in the Bengaluru Metropolitan Region."
             },
             {
@@ -876,6 +876,10 @@
             {
               "label": "Fix plan",
               "value": "124 MLD via 14 new WWTPs by 2024 (DEP 2022)"
+            },
+            {
+              "label": "In-basin share",
+              "value": "Of BBMP's 3 sewage valleys only the Vrishabhavathi valley drains into the Arkavathi; the Koramangala-Challaghatta (Bellandur/Varthur -> Ponnaiyar) and Hebbal (-> Pennar) valleys leave this basin. So the city-wide totals above are ~3x the catchment that reaches the Arkavathi."
             },
             {
               "label": "V-Valley STP (Arkavathi stretch), 2026",

--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -25,15 +25,17 @@
             {
               "label": "Treatment gap",
               "value": "4.0 MLD (2021-2025)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "STP compliance",
-              "value": "Non-complying (every year 2021-2025)"
+              "value": "Non-complying (every year 2021-2025)",
+              "emphasis": "bad"
             },
             {
               "label": "Rs 220.17 cr upgrade DPR",
-              "value": "\"No Work Progress\" (2021-2025)"
+              "value": "\"No Work Progress\" (2021-2025)",
+              "emphasis": "bad"
             }
           ],
           "trend": {
@@ -101,7 +103,7 @@
             {
               "label": "Common ETPs in catchment",
               "value": "0 (NMCG, 2022-2026)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Industrial areas mapped (basin)",
@@ -113,7 +115,8 @@
             },
             {
               "label": "CAG finding",
-              "value": "38 of 66 sampled KIADB areas had no CETP; ~2,571 ML/yr untreated (CAG 2017)"
+              "value": "38 of 66 sampled KIADB areas had no CETP; ~2,571 ML/yr untreated (CAG 2017)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -150,12 +153,12 @@
             },
             {
               "label": "Processed",
-              "value": "20 TPD (NMCG 2025)",
-              "emphasis": true
+              "value": "20 TPD (NMCG 2025)"
             },
             {
               "label": "Sanitary-landfill gap (district)",
-              "value": "3 of 5 sites short; 2 under litigation (DEP 2021)"
+              "value": "3 of 5 sites short; 2 under litigation (DEP 2021)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -194,8 +197,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -229,8 +231,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
             }
           ],
           "sources": [
@@ -255,8 +256,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "1.0 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "1.0 TPD (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -303,7 +303,7 @@
             {
               "label": "Treatment gap",
               "value": "0.6 MLD (NMCG, 2025)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -339,11 +339,12 @@
             {
               "label": "With a CETP nearby",
               "value": "0 - both >5 km from the nearest CETP (Neer Vazhvu estimate, 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "District CETPs",
-              "value": "0 - \"no CETPs in the Ramanagara district\" (DEP 2021)"
+              "value": "0 - \"no CETPs in the Ramanagara district\" (DEP 2021)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -407,8 +408,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -442,8 +442,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
             }
           ],
           "sources": [
@@ -468,8 +467,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "2.0 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "2.0 TPD (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -503,12 +501,13 @@
             },
             {
               "label": "STP capacity",
-              "value": "None operational (11.5 MLD proposed, 2026)"
+              "value": "None operational (11.5 MLD proposed, 2026)",
+              "emphasis": "bad"
             },
             {
               "label": "Treatment gap",
               "value": "~8.8 MLD, whole load (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -572,8 +571,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -607,8 +605,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
             }
           ],
           "sources": [
@@ -633,8 +630,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "1.0 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "1.0 TPD (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -680,7 +676,7 @@
             {
               "label": "STP compliance",
               "value": "Non-complying (NMCG, 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -716,7 +712,7 @@
             {
               "label": "Legacy waste",
               "value": "46,000 t, largest in district (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -749,8 +745,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -784,8 +779,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
             }
           ],
           "sources": [
@@ -810,8 +804,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "0.5 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "0.5 TPD (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -852,13 +845,11 @@
             },
             {
               "label": "Actually treated",
-              "value": "1,050 MLD (DEP 2022)",
-              "emphasis": true
+              "value": "1,050 MLD (DEP 2022)"
             },
             {
               "label": "STP network (BBMP city-wide)",
-              "value": "34 STPs across all three valleys, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. City-wide; only the Vrishabhavathi valley drains into the Arkavathi (see below). DEP 2022's 1,522.5 MLD was sanctioned/under-construction.",
-              "emphasis": true
+              "value": "34 STPs across all three valleys, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. City-wide; only the Vrishabhavathi valley drains into the Arkavathi (see below). DEP 2022's 1,522.5 MLD was sanctioned/under-construction."
             },
             {
               "label": "Expansion, 2026 (city-wide)",
@@ -871,7 +862,7 @@
             {
               "label": "Sewer-network gap",
               "value": "~20% of area uncovered; 8-10% of sewage untreated (DEP 2022)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Fix plan",
@@ -884,7 +875,7 @@
             {
               "label": "V-Valley STP (Arkavathi stretch), 2026",
               "value": "150 MLD operational & complying; treating 150.36 MLD (NMCG 2026)",
-              "emphasis": true
+              "emphasis": "good"
             },
             {
               "label": "V-Valley STP-2 (under construction), 2026",
@@ -934,7 +925,7 @@
             {
               "label": "Peenya cluster (V-Valley)",
               "value": "CPCB Critically Polluted Area, CEPI 78.12; NGT OA 1038/2018 (DEP 2022)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -964,11 +955,12 @@
             {
               "label": "Legacy waste",
               "value": "~5,000,000 t at 4 dumpsites (DEP 2022)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Sanitary landfill",
-              "value": "None functional - SLF Nil (DEP 2022)"
+              "value": "None functional - SLF Nil (DEP 2022)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -1001,8 +993,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)",
-              "emphasis": true
+              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -1014,7 +1005,8 @@
             },
             {
               "label": "Disposal facilities",
-              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)"
+              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -1040,8 +1032,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)",
-              "emphasis": true
+              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",
@@ -1074,8 +1065,7 @@
           "metrics": [
             {
               "label": "C&D waste generated (BBMP)",
-              "value": "2,500 TPD (DEP 2022)",
-              "emphasis": true
+              "value": "2,500 TPD (DEP 2022)"
             },
             {
               "label": "Recycling capacity",
@@ -1114,7 +1104,7 @@
             {
               "label": "CAG audit finding",
               "value": "38 of 66 sampled KIADB areas had no CETP/CSTP (CAG 2017)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Nearest common ETP",
@@ -1154,12 +1144,12 @@
             {
               "label": "Status",
               "value": "Newly declared town; DPR yet to be prepared (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "STP status, 2026",
               "value": "DPR yet to be prepared - land issue, not finalised (NMCG 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Faecal sludge, 2026",
@@ -1190,7 +1180,8 @@
           "metrics": [
             {
               "label": "Processing",
-              "value": "DPR yet to be prepared (DEP 2021)"
+              "value": "DPR yet to be prepared (DEP 2021)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -1219,8 +1210,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -1254,8 +1244,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
             }
           ],
           "sources": [
@@ -1281,8 +1270,7 @@
           "metrics": [
             {
               "label": "Wastewater generated",
-              "value": "5.0 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "5.0 MLD (DEP 2021)"
             },
             {
               "label": "Existing STP capacity",
@@ -1298,13 +1286,12 @@
             },
             {
               "label": "UGD (sewer) network coverage",
-              "value": "80% provided, 20% yet to be completed (DEP 2021)",
-              "emphasis": true
+              "value": "80% provided, 20% yet to be completed (DEP 2021)"
             },
             {
               "label": "Compliance / treatment gap",
               "value": "Incomplete UGD -> sewage bypasses STP via missing links (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Treated (utilisation), 2026",
@@ -1313,7 +1300,7 @@
             {
               "label": "STP compliance, 2026",
               "value": "Directed to upgrade STP to meet PCB standards (NMCG 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -1355,7 +1342,7 @@
             {
               "label": "CETP status, 2026",
               "value": "NOT operating - defunct machinery; dyeing-unit trade effluent presently untreated (NMCG 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "District industries discharging",
@@ -1394,8 +1381,7 @@
           "metrics": [
             {
               "label": "Solid waste generated",
-              "value": "35 tons/day (DEP 2021)",
-              "emphasis": true
+              "value": "35 tons/day (DEP 2021)"
             },
             {
               "label": "Wards / population (Doddaballapura CMC)",
@@ -1440,8 +1426,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -1479,8 +1464,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",
@@ -1509,8 +1493,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)",
-              "emphasis": true
+              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -1548,11 +1531,12 @@
             {
               "label": "STP capacity",
               "value": "0 MLD - no STP (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "UGD network",
-              "value": "Nominally 'provided' but 0% laid; 100% of UGD work yet to be completed (DEP 2021, p.57)"
+              "value": "Nominally 'provided' but 0% laid; 100% of UGD work yet to be completed (DEP 2021, p.57)",
+              "emphasis": "bad"
             },
             {
               "label": "Action plan",
@@ -1561,7 +1545,7 @@
             {
               "label": "STP status, 2026",
               "value": "Still no STP - not in the NMCG Feb 2026 STP list (NMCG 2026)",
-              "emphasis": true
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -1596,8 +1580,7 @@
             },
             {
               "label": "Industrial wastewater generated (district-wide, not taluk-level)",
-              "value": "14.354 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "14.354 MLD (DEP 2021)"
             },
             {
               "label": "Common Effluent Treatment Facilities (district-wide)",
@@ -1606,7 +1589,7 @@
             {
               "label": "Industries NOT meeting discharge standards (district-wide)",
               "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Operating industries by KSPCB category (district-wide)",
@@ -1635,8 +1618,7 @@
           "metrics": [
             {
               "label": "Solid waste generated",
-              "value": "30 tons/day (DEP 2021)",
-              "emphasis": true
+              "value": "30 tons/day (DEP 2021)"
             },
             {
               "label": "Wards / population (Nelamangala CMC)",
@@ -1681,8 +1663,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -1720,8 +1701,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",
@@ -1750,8 +1730,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)",
-              "emphasis": true
+              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -1789,7 +1768,7 @@
             {
               "label": "Conventional STP",
               "value": "0 MLD - no STP (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "UGD network",
@@ -1798,7 +1777,7 @@
             {
               "label": "Faecal sludge",
               "value": "Devanahalli FSTP - CDD Society / BORDA, 6 KLD, operational since Nov 2015. India's first municipal-scale FSTP (625 m2, ~4,000 households); treats ~100% of collected septage via screening, solid-liquid separation, anaerobic baffled reactor, planted gravel filter and co-composting.",
-              "emphasis": true
+              "emphasis": "good"
             },
             {
               "label": "Plan inconsistency",
@@ -1847,8 +1826,7 @@
             },
             {
               "label": "Industrial wastewater generated (district-wide, not taluk-level)",
-              "value": "14.354 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "14.354 MLD (DEP 2021)"
             },
             {
               "label": "Common Effluent Treatment Facilities (district-wide)",
@@ -1857,7 +1835,7 @@
             {
               "label": "Industries NOT meeting discharge standards (district-wide)",
               "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Operating industries by KSPCB category (district-wide)",
@@ -1886,8 +1864,7 @@
           "metrics": [
             {
               "label": "Solid waste generated",
-              "value": "17 tons/day (DEP 2021)",
-              "emphasis": true
+              "value": "17 tons/day (DEP 2021)"
             },
             {
               "label": "Wards / population (Devanahalli Town MC)",
@@ -1932,8 +1909,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -1971,8 +1947,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",
@@ -2001,8 +1976,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)",
-              "emphasis": true
+              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -2049,33 +2023,28 @@
           "metrics": [
             {
               "label": "Sewage generated, CMC Chikkaballapura",
-              "value": "3.5 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "3.5 MLD (DEP 2021)"
             },
             {
               "label": "Existing STP capacity, CMC Chikkaballapura",
-              "value": "10 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "10 MLD (DEP 2021)"
             },
             {
               "label": "Underground sewerage network coverage / gap, CMC Chikkaballapura",
               "value": "91% covered, 9% gap (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "District urban sewage generated (6 ULBs, Class-II towns and above)",
-              "value": "13.01 MLD (DEP 2021)",
-              "emphasis": false
+              "value": "13.01 MLD (DEP 2021)"
             },
             {
               "label": "District total available STP treatment capacity (3 of 6 towns have STPs)",
-              "value": "15.10 MLD (DEP 2021)",
-              "emphasis": false
+              "value": "15.10 MLD (DEP 2021)"
             },
             {
               "label": "Treated/untreated sewage flowing to rivers or lakes (district)",
-              "value": "Nil reported (DEP 2021)",
-              "emphasis": false
+              "value": "Nil reported (DEP 2021)"
             },
             {
               "label": "Treated (utilisation), 2026",
@@ -2083,7 +2052,8 @@
             },
             {
               "label": "STP compliance, 2026",
-              "value": "Complying (NMCG 2026)"
+              "value": "Complying (NMCG 2026)",
+              "emphasis": "good"
             }
           ],
           "sources": [
@@ -2132,33 +2102,29 @@
           "metrics": [
             {
               "label": "Operating industries in district (Red/Orange/Green/White)",
-              "value": "196 total - 16 Red, 59 Orange, 113 Green, 8 White (DEP 2021)",
-              "emphasis": false
+              "value": "196 total - 16 Red, 59 Orange, 113 Green, 8 White (DEP 2021)"
             },
             {
               "label": "Industries discharging waste water (district)",
-              "value": "39 (DEP 2021)",
-              "emphasis": false
+              "value": "39 (DEP 2021)"
             },
             {
               "label": "Industrial trade effluent generated (district)",
-              "value": "2.15 MLD (DEP 2021)",
-              "emphasis": true
+              "value": "2.15 MLD (DEP 2021)"
             },
             {
               "label": "Industrial waste water treated (district)",
-              "value": "1.61 MLD (DEP 2021)",
-              "emphasis": false
+              "value": "1.61 MLD (DEP 2021)"
             },
             {
               "label": "CETP status (district)",
               "value": "No CETP established in Chikkaballapura district (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "ETP status (district)",
               "value": "Effluent treated in in-premises ETPs; 39 of 39 discharging industries meeting standards, 0 not meeting (DEP 2021)",
-              "emphasis": false
+              "emphasis": "good"
             }
           ],
           "sources": [
@@ -2189,33 +2155,30 @@
           "metrics": [
             {
               "label": "MSW generated, CMC Chikkaballapura",
-              "value": "26 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "26 TPD (DEP 2021)"
             },
             {
               "label": "Door-to-door collection, CMC Chikkaballapura",
               "value": "100% of 31 wards (DEP 2021)",
-              "emphasis": false
+              "emphasis": "good"
             },
             {
               "label": "Legacy / historic dumpsite waste, CMC Chikkaballapura",
               "value": "40,000 tonnes (DEP 2021)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "District legacy waste total (6 ULBs)",
               "value": "1,46,250 tonnes (DEP 2021)",
-              "emphasis": false
+              "emphasis": "bad"
             },
             {
               "label": "District urban MSW generated (6 ULBs)",
-              "value": "112.5 TPD (DEP 2021)",
-              "emphasis": false
+              "value": "112.5 TPD (DEP 2021)"
             },
             {
               "label": "Processing / disposal status (district)",
-              "value": "100% collection; composting in all ULBs; no separate processed-tonnage printed; legacy remediation by screening machine targeted 31/12/2025 (DEP 2021)",
-              "emphasis": false
+              "value": "100% collection; composting in all ULBs; no separate processed-tonnage printed; legacy remediation by screening machine targeted 31/12/2025 (DEP 2021)"
             }
           ],
           "sources": [
@@ -2266,8 +2229,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "398.82 MT/yr ≈ 1.1 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "398.82 MT/yr ≈ 1.1 t/day (DEP 2021)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -2279,7 +2241,8 @@
             },
             {
               "label": "Disposal facilities",
-              "value": "No TSDF, no SLF, no standalone incinerator in the district; HW sent off-district under MoU. One in-district used-oil recycler (Gowribidanur). (DEP 2021)"
+              "value": "No TSDF, no SLF, no standalone incinerator in the district; HW sent off-district under MoU. One in-district used-oil recycler (Gowribidanur). (DEP 2021)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -2305,8 +2268,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "378.221 kg/day ≈ 0.38 t/day (DEP 2021)",
-              "emphasis": true
+              "value": "378.221 kg/day ≈ 0.38 t/day (DEP 2021)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",
@@ -2339,8 +2301,7 @@
           "metrics": [
             {
               "label": "C&D waste generated",
-              "value": "3.0 TPD (DEP 2021)",
-              "emphasis": true
+              "value": "3.0 TPD (DEP 2021)"
             },
             {
               "label": "Recycling facility",
@@ -2373,7 +2334,8 @@
           "metrics": [
             {
               "label": "STP (Yelahanka), 2026",
-              "value": "10 MLD operational, 5.83 MLD treated, complying (NMCG 2026)"
+              "value": "10 MLD operational, 5.83 MLD treated, complying (NMCG 2026)",
+              "emphasis": "good"
             },
             {
               "label": "New STP under construction, 2026",
@@ -2410,8 +2372,7 @@
           "metrics": [
             {
               "label": "Hazardous waste generated (district)",
-              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)",
-              "emphasis": true
+              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
             },
             {
               "label": "Incinerable / land-fillable / recyclable",
@@ -2423,7 +2384,8 @@
             },
             {
               "label": "Disposal facilities",
-              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)"
+              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
+              "emphasis": "bad"
             }
           ],
           "sources": [
@@ -2449,8 +2411,7 @@
           "metrics": [
             {
               "label": "Biomedical waste generated (district)",
-              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)",
-              "emphasis": true
+              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
             },
             {
               "label": "Treatment facilities (CBMWTF)",

--- a/public/data/basins/chennai-rivers/gaps.json
+++ b/public/data/basins/chennai-rivers/gaps.json
@@ -17,11 +17,12 @@
             {
               "label": "Located discharge into the Cooum",
               "value": "~30.5 MLD via 31 surveyed inlets (survey)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Worst CPCB station",
-              "value": "BOD 16 mg/L, DO 1.4 (Cooum at Poonamalle, 2024) - below Class E"
+              "value": "BOD 16 mg/L, DO 1.4 (Cooum at Poonamalle, 2024) - below Class E",
+              "emphasis": "bad"
             },
             {
               "label": "STPs in this catchment",
@@ -29,12 +30,12 @@
             },
             {
               "label": "City-wide raw bypass into rivers",
-              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river"
+              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river",
+              "emphasis": "bad"
             },
             {
               "label": "Contested estimate (citizens' audit)",
-              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies",
-              "emphasis": true
+              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies"
             },
             {
               "label": "City STP capacity (latest)",
@@ -77,11 +78,12 @@
             {
               "label": "Unsewered suburbs (-> septic tanks)",
               "value": "Ambattur 23.79, Avadi 4.66 MLD generated, uncollected by sewer (CAG App. 2.6, 2019)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Septage co-treatment (city-wide)",
-              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines."
+              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines.",
+              "emphasis": "good"
             },
             {
               "label": "Fate",
@@ -124,8 +126,7 @@
           "metrics": [
             {
               "label": "Located discharge into the Adyar",
-              "value": "Not surveyed - no published inlet/outfall flow for the Adyar (RTI gap)",
-              "emphasis": true
+              "value": "Not surveyed - no published inlet/outfall flow for the Adyar (RTI gap)"
             },
             {
               "label": "Worst CPCB station",
@@ -137,12 +138,12 @@
             },
             {
               "label": "City-wide raw bypass into rivers",
-              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river"
+              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river",
+              "emphasis": "bad"
             },
             {
               "label": "Contested estimate (citizens' audit)",
-              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies",
-              "emphasis": true
+              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies"
             },
             {
               "label": "City STP capacity (latest)",
@@ -180,11 +181,12 @@
             {
               "label": "Unsewered suburbs (-> septic tanks)",
               "value": "Tambaram 13.18, Porur 5.04, Ramapuram 4.18, Perungudi 3.30, Sholinganallur-Karapakkam 3.05, Pallikaranai 1.32 MLD (CAG App. 2.6, 2019)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Septage co-treatment (city-wide)",
-              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines."
+              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines.",
+              "emphasis": "good"
             },
             {
               "label": "Fate",
@@ -227,8 +229,7 @@
           "metrics": [
             {
               "label": "Located discharge into the Kosasthalaiyar",
-              "value": "Not surveyed - no published inlet/outfall flow (RTI gap)",
-              "emphasis": true
+              "value": "Not surveyed - no published inlet/outfall flow (RTI gap)"
             },
             {
               "label": "STPs in this catchment",
@@ -240,12 +241,12 @@
             },
             {
               "label": "City-wide raw bypass into rivers",
-              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river"
+              "value": "242.73 MLD into Cooum + Adyar + Buckingham (CAG, Apr 2019); not split by river",
+              "emphasis": "bad"
             },
             {
               "label": "Contested estimate (citizens' audit)",
-              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies",
-              "emphasis": true
+              "value": "Arappor's 2018 RTI social audit puts city generation at 1,500-2,000 MLD and ~1,073 MLD into waterbodies - 2-4x the official figures; 10 of 27 audited pumping stations discharge untreated sewage directly into water bodies"
             },
             {
               "label": "City STP capacity (latest)",
@@ -283,11 +284,12 @@
             {
               "label": "Unsewered suburbs (-> septic tanks)",
               "value": "Thiruvottiyur 16.17 MLD generated, uncollected by sewer (CAG App. 2.6, 2019)",
-              "emphasis": true
+              "emphasis": "bad"
             },
             {
               "label": "Septage co-treatment (city-wide)",
-              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines."
+              "value": "Chennai co-treats septic-tank septage at 3 STPs - Nesapakkam (~200 truck-trips/day), Perungudi (~300), Kodungaiyur (~50), ~5 MLD total (9 kL/truck) - under GoTN's Septage Management Guidelines.",
+              "emphasis": "good"
             },
             {
               "label": "Fate",

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -65,7 +65,9 @@ interface GapStream {
    *  liquid, TPD for solid), for the composition bar. Absent = no defensible
    *  generation figure (stream still shows as a card). */
   magnitude?: { perDay: number; unit: string; estimated?: boolean };
-  metrics: { label: string; value: string; emphasis?: boolean }[];
+  // emphasis tone: "bad" (red - a gap/deficit/non-compliance) or "good" (green
+  // - a positive outcome). Legacy `true` is treated as "bad". Absent = neutral.
+  metrics: { label: string; value: string; emphasis?: boolean | "good" | "bad" }[];
   trend?: { label: string; unit?: string; points: { year: number; value: number | null; url?: string; note?: string }[] };
   sources: GapSource[];
 }
@@ -1186,7 +1188,7 @@ function StreamCard({ s }: { s: GapStream }) {
         {s.metrics.map((m, j) => (
           <div key={j} className="flex items-baseline justify-between gap-3">
             <dt className="text-[13px] text-slate-500 dark:text-slate-400">{m.label}</dt>
-            <dd className={`text-[13px] tabular-nums text-right ${m.emphasis ? "font-bold text-rose-600 dark:text-rose-400" : "text-slate-700 dark:text-slate-300"}`}>{m.value}</dd>
+            <dd className={`text-[13px] tabular-nums text-right ${m.emphasis === "good" ? "font-bold text-emerald-600 dark:text-emerald-400" : m.emphasis ? "font-bold text-rose-600 dark:text-rose-400" : "text-slate-700 dark:text-slate-300"}`}>{m.value}</dd>
           </div>
         ))}
       </dl>


### PR DESCRIPTION
Builds on the just-merged Chennai gaps PR (#134), now applied to the Bengaluru side.

## Bengaluru data (Arkavathi basin)
- **BBMP sewage** - layer BWSSB/KSPCB **2026** figures over the DEP-2022 numbers: 34 STPs / 1,348.5 MLD installed / ~1,212.7 MLD treated (~90% util); +26 STPs / +470 MLD expansion by end-2025; 20 of 34 plants upgrading to NGT tertiary norms; KSPCB Jan-2026 OCEMS mandate.
- **Scope-labelled** those as `(city-wide)` and added an `In-basin share` caveat - only the Vrishabhavathi valley drains into the Arkavathi; the Koramangala-Challaghatta (-> Ponnaiyar) and Hebbal (-> Pennar) valleys leave the basin, so the city-wide totals are ~3x the in-basin catchment.
- **Devanahalli** - replaced the bare "FSTP recorded in use" line with the documented case study (CDD/BORDA, 6 KLD, operational since Nov 2015, India's first municipal FSTP, ~4,000 HH, ~100% of collected septage). Added the operational Devanahalli pin to `fstp.geojson` alongside the 3 tender-stage plants.

## Semantic green/red coloring (Arkavathi + Chennai)
The gap panel only knew red (`emphasis:true`), so good news rendered red and many neutral facts were red too. Extended `emphasis` to **good (green) | bad (red) | neutral (plain)** and re-tagged both basins' gap data:
- **green**: operational/complying STPs, the Devanahalli FSTP, Chennai septage co-treatment, 100% door-to-door collection.
- **red**: treatment gaps, non-compliance, 0/no STP-CETP-TSDF, legacy waste, raw-sewage bypass, CPCB exceedance, stalled DPRs.
- **neutral**: generated volumes, capacities, counts, contested estimates, data gaps ("not surveyed"/"not tabulated").

## Honest framing
Chennai = under-utilised STPs but a formal septage co-treatment system; Bengaluru = ~90%-utilised STPs with Devanahalli as the lone FSM exemplar and city-scale FSM governance still nascent.