### PR TITLE
Mobile layout fixes: header, basin atlas, chrome

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,11 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // Dev-only: let phones/other devices on the LAN load /_next/* dev resources
+  // (Next 16 blocks cross-origin dev requests by default, which leaves the page
+  // server-rendered but non-interactive when opened via a LAN IP). No effect in
+  // production. Add your machine's LAN IP here when testing on a real device.
+  allowedDevOrigins: ["192.168.0.186"],
   async headers() {
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,11 +25,6 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  // Dev-only: let phones/other devices on the LAN load /_next/* dev resources
-  // (Next 16 blocks cross-origin dev requests by default, which leaves the page
-  // server-rendered but non-interactive when opened via a LAN IP). No effect in
-  // production. Add your machine's LAN IP here when testing on a real device.
-  allowedDevOrigins: ["192.168.0.186"],
   async headers() {
     return [
       {

--- a/src/app/[cityId]/rivers/chennai-rivers-client.tsx
+++ b/src/app/[cityId]/rivers/chennai-rivers-client.tsx
@@ -241,7 +241,7 @@ function RiversPageContent({ cityId, cityDisplayName, mapCenter, mapZoom, basin 
 
           {/* Drill-in hint: same affordance as the shared rivers client. */}
           {basin && !coachDismissed && !openBasin && (
-            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[600] max-w-[92%] bg-slate-900/95 text-white text-xs rounded-full px-4 py-2 shadow-lg flex items-center gap-3">
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[600] max-w-[88%] sm:max-w-md bg-slate-900/95 text-white text-xs rounded-xl px-3.5 py-2 shadow-lg flex items-center gap-3">
               <span>Click on a river to drill into the basin - pollution, monitoring &amp; infrastructure</span>
               <button
                 onClick={() => { localStorage.setItem(RIVERS_COACH_KEY, "1"); setCoachDismissed(true); }}

--- a/src/app/[cityId]/rivers/rivers-client.tsx
+++ b/src/app/[cityId]/rivers/rivers-client.tsx
@@ -395,7 +395,7 @@ export default function RiversClient({
 
           {/* Drill-down hint: shown where at least one river opens a basin atlas. */}
           {drillableNames.length > 0 && !coachDismissed && !openBasinRiverId && (
-            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[600] max-w-[92%] bg-slate-900/95 text-white text-xs rounded-full px-4 py-2 shadow-lg flex items-center gap-3">
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[600] max-w-[88%] sm:max-w-md bg-slate-900/95 text-white text-xs rounded-xl px-3.5 py-2 shadow-lg flex items-center gap-3">
               <span>
                 Click on the rivers to drill into the basin - pollution, monitoring &amp; infrastructure
               </span>

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -185,6 +185,13 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     [selectedRiver],
   );
 
+  // Touch devices need bigger hit targets. The atlas renders client-only
+  // (ssr:false), so window is always available here.
+  const coarsePointer =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches;
+
   // URL <-> state (?river= & ?level=), via replaceState (no full navigation).
   // Skipped when embedded as an overlay so we don't clobber the rivers-page URL.
   // Cross-source gap intelligence for the gap layer's click panel (optional).
@@ -547,7 +554,8 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                   interactive={l.family === "rivers"}
                   onEachFeature={(feat: Feature, layer: Layer) => {
                     if (l.family === "rivers") {
-                      const rid = String((feat.properties as Record<string, unknown>)?.riverId ?? "");
+                      const rprops = feat.properties as Record<string, unknown>;
+                      const rid = String(rprops?.riverId ?? rprops?.river_id ?? "");
                       const r = manifest.rivers.find((x) => x.riverId === rid);
                       if (r) {
                         layer.bindTooltip(r.displayName, { sticky: true });
@@ -623,8 +631,8 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                   <CircleMarker
                     key={`gapbadge-${unit}-${idx}-${pi}`}
                     center={p.b.getCenter()}
-                    radius={6}
-                    pathOptions={{ color: "#fecaca", weight: 1, fillColor: "#dc2626", fillOpacity: 0.7 }}
+                    radius={coarsePointer ? 12 : 6}
+                    pathOptions={{ color: "#fecaca", weight: coarsePointer ? 2 : 1, fillColor: "#dc2626", fillOpacity: 0.7 }}
                     eventHandlers={{ click: () => { setSelectedGapUnit(unit); setSelectedFeature(null); } }}
                   >
                     <Tooltip sticky>{name}{pi > 0 ? " (detached part)" : ""} - click for treatment &amp; waste gaps</Tooltip>
@@ -678,8 +686,9 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
             » Layers
           </button>
         )}
-        {/* Legend - reflects what's currently visible. */}
-        <MapLegend layers={visibleLayers} notes={legendNotes} />
+        {/* Legend - reflects what's currently visible. Raised above the mobile
+            bottom sheet when a detail panel is open so it isn't covered. */}
+        <MapLegend layers={visibleLayers} notes={legendNotes} raised={!!(selectedGapUnit || selectedFeature || selectedRiver)} />
       </div>
 
       {/* ── Detail panel: draggable bottom sheet on mobile, sidebar on desktop
@@ -719,7 +728,7 @@ type LegendSym = "box" | "dot" | "ring" | "line" | "dash" | "outline";
 /** Dynamic legend: one entry per symbol actually on the map right now,
  *  expanding pressures into its kinds and showing the monitoring public-domain
  *  cue (filled vs hollow). */
-function MapLegend({ layers, notes }: { layers: BasinLayer[]; notes?: string[] }) {
+function MapLegend({ layers, notes, raised }: { layers: BasinLayer[]; notes?: string[]; raised?: boolean }) {
   const [open, setOpen] = useState(true);
   // Every entry's color comes from the layer's manifest `color` or the shared
   // PRESSURE_KIND_COLOR map - the same sources the map styles read - so the
@@ -752,7 +761,7 @@ function MapLegend({ layers, notes }: { layers: BasinLayer[]; notes?: string[] }
   }
   if (!items.length) return null;
   return (
-    <div className="absolute bottom-3 left-3 z-[800] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow text-[11px] max-w-[230px]">
+    <div className={`absolute ${raised ? "bottom-[156px] md:bottom-3" : "bottom-3"} left-3 z-[800] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow text-[11px] max-w-[230px] transition-[bottom] duration-200`}>
       <button
         onClick={() => setOpen((o) => !o)}
         className="w-full flex items-center justify-between px-2.5 py-1.5 font-semibold text-slate-600 dark:text-slate-300"
@@ -821,7 +830,8 @@ function shedStyle(feat: Feature | undefined, selectedSheds: Set<string>, faded:
 
 function lineStyle(l: BasinLayer, feat: Feature | undefined, manifest: BasinManifest, selectedRiverId: string | null, faded: boolean): PathOptions {
   if (l.family === "rivers") {
-    const rid = String((feat?.properties as Record<string, unknown>)?.riverId ?? "");
+    const rprops = feat?.properties as Record<string, unknown>;
+    const rid = String(rprops?.riverId ?? rprops?.river_id ?? "");
     const r = manifest.rivers.find((x) => x.riverId === rid);
     const sel = rid === selectedRiverId;
     return { color: r?.color ?? l.color, weight: sel ? 5 : 3, opacity: sel || !selectedRiverId ? 1 : 0.75 };

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -6,6 +6,7 @@ import L from "leaflet";
 import type { Feature, FeatureCollection } from "geojson";
 import type { Layer, PathOptions } from "leaflet";
 import { MapResizer } from "@/components/map-resizer";
+import { BottomSheet } from "@/components/map/bottom-sheet";
 import { useMapTiles } from "@/lib/utils/map-tiles";
 import type {
   BasinFloor,
@@ -163,7 +164,6 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
   const [coachDismissed, setCoachDismissed] = useState(true);
   // Either panel can be collapsed to see the map alone.
   const [railOpen, setRailOpen] = useState(true);
-  const [panelOpen, setPanelOpen] = useState(true);
   const fetchedRef = useRef<Set<string>>(new Set());
   const didDefaultGapRef = useRef(false);
 
@@ -360,8 +360,9 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     <div className="h-full w-full flex flex-col md:flex-row">
       {/* ── Elevator rail ── */}
       {railOpen && (
-      <div className="shrink-0 md:w-60 border-b md:border-b-0 md:border-r border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 overflow-y-auto">
+      <div className="shrink-0 md:w-60 border-b md:border-b-0 md:border-r border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 overflow-y-auto max-h-[46vh] md:max-h-none">
         <div className="p-3 border-b border-slate-200 dark:border-slate-700">
+          <div className="text-[10px] uppercase tracking-wide text-slate-400">{cityDisplayName}</div>
           <div className="flex items-start justify-between gap-2">
             <h1 className="font-bold text-slate-900 dark:text-slate-100 leading-tight">{manifest.displayName}</h1>
             <button
@@ -374,6 +375,11 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
           </div>
           {manifest.displayNameLocal && (
             <div className="text-xs text-slate-500 dark:text-slate-400">{manifest.displayNameLocal}</div>
+          )}
+          {/* Basin intro - desktop rail only (mobile rail stays compact). */}
+          <p className="hidden md:block mt-2 text-xs leading-relaxed text-slate-500 dark:text-slate-400">{manifest.blurb}</p>
+          {manifest.areaKm2 && (
+            <p className="hidden md:block mt-1 text-[11px] text-slate-400">Basin area ~{manifest.areaKm2.toLocaleString()} km².</p>
           )}
           {selectedRiver && (
             <button
@@ -437,6 +443,33 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                   </div>
                 )}
               </div>
+            );
+          })}
+        </div>
+
+        {/* Mobile: layer toggles for the focused floor, full-width below the
+            tabs (on desktop the toggles live under each floor above). */}
+        <div className="md:hidden px-3 pb-2 pt-2 space-y-1 border-t border-slate-100 dark:border-slate-800">
+          <div className="text-[10px] uppercase tracking-wide text-slate-400 mb-1">Layers</div>
+          {floorLayers(focusedFloor).map((l) => {
+            const inv = inventory?.families[l.family];
+            return (
+              <label key={l.family} className="flex items-start gap-2 text-xs cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={enabled[l.family] ?? l.defaultOn}
+                  onChange={(e) => setEnabled((s) => ({ ...s, [l.family]: e.target.checked }))}
+                  className="mt-0.5 accent-blue-600"
+                />
+                <span className="flex items-center gap-1.5 leading-tight">
+                  <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: l.color }} />
+                  <span className="text-slate-600 dark:text-slate-300">
+                    {l.label}
+                    {inv && <span className="text-slate-400"> ({inv.featureCount})</span>}
+                    {l.heavy && <span className="block text-[10px] text-slate-400">large layer</span>}
+                  </span>
+                </span>
+              </label>
             );
           })}
         </div>
@@ -635,7 +668,7 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
 
         {/* Coach mark */}
         {!embedded && !coachDismissed && !selectedRiverId && (
-          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[500] bg-slate-900/95 text-white text-xs rounded-full px-4 py-2 shadow-lg flex items-center gap-3">
+          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[500] max-w-[88%] sm:max-w-md bg-slate-900/95 text-white text-xs rounded-xl px-3.5 py-2 shadow-lg flex items-center gap-3">
             <span>Click a river to explore its pollution story</span>
             <button
               onClick={() => { localStorage.setItem(COACH_KEY, "1"); setCoachDismissed(true); }}
@@ -656,55 +689,35 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
             » Layers
           </button>
         )}
-        {!panelOpen && (
-          <button
-            onClick={() => setPanelOpen(true)}
-            title="Show details panel"
-            className="hidden lg:flex absolute right-0 top-1/2 -translate-y-1/2 z-[500] items-center bg-white/95 dark:bg-slate-900/95 border border-r-0 border-slate-200 dark:border-slate-700 rounded-l-md shadow px-1.5 py-3 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
-          >
-            Details «
-          </button>
-        )}
-
         {/* Legend - reflects what's currently visible. */}
         <MapLegend layers={visibleLayers} notes={legendNotes} />
       </div>
 
-      {/* ── Detail panel ── */}
-      {panelOpen && (
-      <aside className="hidden lg:flex h-full w-[400px] xl:w-[460px] shrink-0 border-l border-slate-200 dark:border-slate-700 flex-col overflow-y-auto bg-white dark:bg-slate-900 p-5 text-sm">
-        <div className="flex justify-end -mt-2 -mr-2 mb-1">
-          <button onClick={() => setPanelOpen(false)} title="Hide details panel" className="p-1 text-slate-400 hover:text-slate-700 dark:hover:text-slate-200">»</button>
-        </div>
-        {selectedGapUnit && gapData[selectedGapUnit] ? (
-          <GapPanel unit={gapData[selectedGapUnit]} onClose={() => setSelectedGapUnit(null)} />
-        ) : selectedFeature ? (
-          renderFeatureDetail?.({
-            family: selectedFeature.family,
-            props: selectedFeature.props,
-            onClose: () => setSelectedFeature(null),
-          }) ?? (
-            <FeaturePanel
-              props={selectedFeature.props}
-              label={layerByFamily[selectedFeature.family]?.label ?? selectedFeature.family}
-              onClose={() => setSelectedFeature(null)}
-            />
-          )
-        ) : selectedRiver ? (
-          <RiverPanel river={selectedRiver} onClear={() => selectRiver(null)} />
-        ) : (
-          <div className="space-y-3 text-slate-600 dark:text-slate-400">
-            <h2 className="text-base font-bold text-slate-900 dark:text-slate-100">{cityDisplayName} - {manifest.displayName}</h2>
-            <p className="leading-relaxed">{manifest.blurb}</p>
-            {manifest.areaKm2 && (
-              <p className="text-xs text-slate-500">Basin area ~{manifest.areaKm2.toLocaleString()} km². {manifest.areaNote}</p>
-            )}
-            <p className="text-xs text-slate-500 dark:text-slate-500">
-              Use the floors on the left to move between the river system, its monitoring evidence, the pressures on it, and the response. Click a river to scope everything to its sub-basin.
-            </p>
+      {/* ── Detail panel: draggable bottom sheet on mobile, sidebar on desktop
+           (shared BottomSheet, matching the rivers map). Shown when a river,
+           feature or gap is selected; closing clears the selection. ── */}
+      {(selectedGapUnit || selectedFeature || selectedRiver) && (
+        <BottomSheet onClose={() => { setSelectedGapUnit(null); setSelectedFeature(null); selectRiver(null); }}>
+          <div className="p-5 text-sm">
+            {selectedGapUnit && gapData[selectedGapUnit] ? (
+              <GapPanel unit={gapData[selectedGapUnit]} onClose={() => setSelectedGapUnit(null)} />
+            ) : selectedFeature ? (
+              renderFeatureDetail?.({
+                family: selectedFeature.family,
+                props: selectedFeature.props,
+                onClose: () => setSelectedFeature(null),
+              }) ?? (
+                <FeaturePanel
+                  props={selectedFeature.props}
+                  label={layerByFamily[selectedFeature.family]?.label ?? selectedFeature.family}
+                  onClose={() => setSelectedFeature(null)}
+                />
+              )
+            ) : selectedRiver ? (
+              <RiverPanel river={selectedRiver} onClear={() => selectRiver(null)} />
+            ) : null}
           </div>
-        )}
-      </aside>
+        </BottomSheet>
       )}
     </div>
   );

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -194,6 +194,13 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
       .catch(() => setGapData({}));
   }, [manifest.basinId]);
 
+  // On phones the layers panel is an off-canvas drawer; start it closed so the
+  // map is full-screen, with the "Layers" tab to open it. Desktop keeps the
+  // in-flow sidebar open.
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) setRailOpen(false);
+  }, []);
+
   // When opened straight to the governance floor (the "Treatment & waste gaps"
   // button), auto-select the manifest's default gap unit once the data loads,
   // so the right-hand detail panel is populated and discoverable rather than
@@ -358,9 +365,17 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
 
   return (
     <div className="h-full w-full flex flex-col md:flex-row">
-      {/* ── Elevator rail ── */}
+      {/* ── Elevator rail: off-canvas left drawer on mobile, in-flow sidebar on
+           desktop. ── */}
       {railOpen && (
-      <div className="shrink-0 md:w-60 border-b md:border-b-0 md:border-r border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 overflow-y-auto max-h-[46vh] md:max-h-none">
+        <button
+          aria-label="Close layers"
+          onClick={() => setRailOpen(false)}
+          className="md:hidden fixed inset-0 z-[1190] bg-black/40"
+        />
+      )}
+      {railOpen && (
+      <div className="bg-white dark:bg-slate-900 overflow-y-auto fixed inset-y-0 left-0 z-[1200] w-[84%] max-w-xs shadow-2xl md:static md:z-auto md:w-60 md:max-w-none md:shadow-none md:shrink-0 md:border-r border-slate-200 dark:border-slate-700">
         <div className="p-3 border-b border-slate-200 dark:border-slate-700">
           <div className="text-[10px] uppercase tracking-wide text-slate-400">{cityDisplayName}</div>
           <div className="flex items-start justify-between gap-2">
@@ -368,9 +383,10 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
             <button
               onClick={() => setRailOpen(false)}
               title="Hide layers panel"
-              className="hidden md:block shrink-0 -mt-0.5 p-1 text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+              className="block shrink-0 -mt-0.5 p-1 text-lg leading-none text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
             >
-              «
+              <span className="md:hidden">✕</span>
+              <span className="hidden md:inline">«</span>
             </button>
           </div>
           {manifest.displayNameLocal && (
@@ -391,11 +407,11 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
           )}
         </div>
 
-        <div className="flex md:block">
+        <div className="block">
           {FLOORS.map((f, i) => {
             const active = f.id === focusedFloor;
             return (
-              <div key={f.id} className="flex-1 md:flex-none">
+              <div key={f.id}>
                 <button
                   onClick={() => setFocusedFloor(f.id)}
                   className={`w-full text-left px-3 py-2.5 border-l-4 transition-colors ${
@@ -413,12 +429,12 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                       <span className="text-[10px] tabular-nums text-slate-400">{floorCounts[f.id]}</span>
                     )}
                   </div>
-                  <div className="text-[10px] text-slate-400 dark:text-slate-500 hidden md:block">{f.sub}</div>
+                  <div className="text-[10px] text-slate-400 dark:text-slate-500">{f.sub}</div>
                 </button>
 
                 {/* Per-floor layer toggles, only under the focused floor. */}
                 {active && (
-                  <div className="px-3 pb-2 pt-1 space-y-1 hidden md:block">
+                  <div className="px-3 pb-2 pt-1 space-y-1">
                     {floorLayers(f.id).map((l) => {
                       const inv = inventory?.families[l.family];
                       return (
@@ -443,33 +459,6 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                   </div>
                 )}
               </div>
-            );
-          })}
-        </div>
-
-        {/* Mobile: layer toggles for the focused floor, full-width below the
-            tabs (on desktop the toggles live under each floor above). */}
-        <div className="md:hidden px-3 pb-2 pt-2 space-y-1 border-t border-slate-100 dark:border-slate-800">
-          <div className="text-[10px] uppercase tracking-wide text-slate-400 mb-1">Layers</div>
-          {floorLayers(focusedFloor).map((l) => {
-            const inv = inventory?.families[l.family];
-            return (
-              <label key={l.family} className="flex items-start gap-2 text-xs cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={enabled[l.family] ?? l.defaultOn}
-                  onChange={(e) => setEnabled((s) => ({ ...s, [l.family]: e.target.checked }))}
-                  className="mt-0.5 accent-blue-600"
-                />
-                <span className="flex items-center gap-1.5 leading-tight">
-                  <span className="inline-block w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: l.color }} />
-                  <span className="text-slate-600 dark:text-slate-300">
-                    {l.label}
-                    {inv && <span className="text-slate-400"> ({inv.featureCount})</span>}
-                    {l.heavy && <span className="block text-[10px] text-slate-400">large layer</span>}
-                  </span>
-                </span>
-              </label>
             );
           })}
         </div>
@@ -679,12 +668,12 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
           </div>
         )}
 
-        {/* Reopen tabs when a panel is collapsed (md+). */}
+        {/* Reopen the layers drawer/sidebar when collapsed (left-edge tab). */}
         {!railOpen && (
           <button
             onClick={() => setRailOpen(true)}
             title="Show layers panel"
-            className="hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 z-[500] items-center bg-white/95 dark:bg-slate-900/95 border border-l-0 border-slate-200 dark:border-slate-700 rounded-r-md shadow px-1.5 py-3 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
+            className="flex absolute left-0 top-1/2 -translate-y-1/2 z-[500] items-center bg-white/95 dark:bg-slate-900/95 border border-l-0 border-slate-200 dark:border-slate-700 rounded-r-md shadow px-1.5 py-3 text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
           >
             » Layers
           </button>
@@ -763,7 +752,7 @@ function MapLegend({ layers, notes }: { layers: BasinLayer[]; notes?: string[] }
   }
   if (!items.length) return null;
   return (
-    <div className="absolute bottom-3 left-3 z-[500] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow text-[11px] max-w-[230px]">
+    <div className="absolute bottom-3 left-3 z-[800] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow text-[11px] max-w-[230px]">
       <button
         onClick={() => setOpen((o) => !o)}
         className="w-full flex items-center justify-between px-2.5 py-1.5 font-semibold text-slate-600 dark:text-slate-300"

--- a/src/components/layout/city-switcher.tsx
+++ b/src/components/layout/city-switcher.tsx
@@ -45,18 +45,18 @@ export function CitySwitcher() {
       <button
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          "flex items-center gap-1.5 px-3 py-2.5 rounded-md text-sm font-medium transition-colors",
+          "flex items-center gap-1 px-2.5 py-2 sm:gap-1.5 sm:px-3 sm:py-2.5 rounded-md text-sm font-medium transition-colors shrink-0",
           "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800",
           "border border-slate-200 dark:border-slate-700",
         )}
         aria-label={`Current city: ${currentPlace.displayName}. Switch city.`}
         aria-expanded={open}
       >
-        <svg className="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg className="hidden sm:block w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
-        <span>{currentPlace.displayName}</span>
+        <span className="whitespace-nowrap">{currentPlace.displayName}</span>
         <svg className={cn("w-3.5 h-3.5 text-slate-400 transition-transform", open && "rotate-180")} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>

--- a/src/components/layout/city-switcher.tsx
+++ b/src/components/layout/city-switcher.tsx
@@ -63,7 +63,7 @@ export function CitySwitcher() {
       </button>
 
       {open && (
-        <div className="absolute top-full right-0 mt-1 min-w-[180px] bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
+        <div className="absolute top-full right-0 mt-1 min-w-[180px] max-w-[calc(100vw-1rem)] bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
           {places.map((p) => {
             const supported = FEATURE_AVAILABILITY[p.cityId];
             const featureSupported = supported ? supported.has(feature) : false;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -274,9 +274,10 @@ export function Header() {
                 </span>
               </div>
             </Link>
-            {/* Mobile: show current page name instead of app title */}
+            {/* Mobile: show current page name instead of app title. Truncates
+                so a long label can never push into the city switcher. */}
             {currentPageLabel && (
-              <span className="sm:hidden text-sm font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">
+              <span className="sm:hidden text-sm font-semibold text-slate-700 dark:text-slate-300 truncate min-w-0">
                 {currentPageLabel}
               </span>
             )}
@@ -303,7 +304,7 @@ export function Header() {
           </nav>
 
           {/* Mobile: toggles + hamburger */}
-          <div className="flex sm:hidden items-center gap-1">
+          <div className="flex sm:hidden items-center gap-1 shrink-0 pl-2">
             <CitySwitcher />
             <LanguageToggle />
             <ThemeToggle />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -268,7 +268,7 @@ export function Header() {
                 </svg>
               </div>
               <div>
-                <span className={cn("font-bold text-lg text-slate-900 dark:text-slate-100", currentPageLabel && "hidden sm:inline")}>{t("header.title")}</span>
+                <span className="font-bold text-lg text-slate-900 dark:text-slate-100 hidden sm:inline">{t("header.title")}</span>
                 <span className="hidden sm:inline text-xs text-slate-500 dark:text-slate-400 ml-2">
                   {t("header.subtitle")}
                 </span>

--- a/src/components/layout/language-toggle.tsx
+++ b/src/components/layout/language-toggle.tsx
@@ -59,7 +59,7 @@ export function LanguageToggle() {
     return (
       <button
         onClick={() => setLanguage(other)}
-        className="px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
+        className="px-2.5 h-9 inline-flex items-center justify-center rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
         aria-label={`Switch to ${otherLabel.english}`}
         title={`Switch to ${otherLabel.native}`}
       >
@@ -76,12 +76,12 @@ export function LanguageToggle() {
         onClick={() => setOpen((v) => !v)}
         aria-label={t("lang.choose_language") || `Choose language - currently ${currentLabel.english}`}
         aria-expanded={open}
-        className="px-2.5 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
+        className="px-2.5 h-9 inline-flex items-center justify-center rounded-md border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 bg-white dark:bg-slate-900 transition-colors leading-none"
       >
         {currentLabel.toggle}
       </button>
       {open && (
-        <div className="absolute right-0 top-10 z-50 min-w-[160px] rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg py-1">
+        <div className="absolute right-0 top-full mt-1 z-50 min-w-[160px] max-w-[calc(100vw-1rem)] rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg py-1">
           {availableLanguages.map((code: LanguageCode) => {
             const label = LANGUAGE_LABELS[code];
             const isActive = code === language;
@@ -92,7 +92,7 @@ export function LanguageToggle() {
                   setLanguage(code);
                   setOpen(false);
                 }}
-                className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between gap-3 ${
+                className={`w-full text-left px-3 py-2.5 text-sm flex items-center justify-between gap-3 ${
                   isActive
                     ? "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100"
                     : "text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"

--- a/src/components/map/bottom-sheet.tsx
+++ b/src/components/map/bottom-sheet.tsx
@@ -159,7 +159,7 @@ export function BottomSheet({ children, onClose }: BottomSheetProps) {
       </div>
 
       {/* Desktop: normal sidebar panel */}
-      <div className="hidden md:flex h-full md:w-80 lg:w-96 border-l border-slate-200 dark:border-slate-700 flex-col">
+      <div className="hidden md:flex h-full md:w-80 lg:w-96 border-l border-slate-200 dark:border-slate-700 flex-col overflow-y-auto">
         {children}
       </div>
     </>

--- a/src/components/rivers/rivers-legend.tsx
+++ b/src/components/rivers/rivers-legend.tsx
@@ -54,7 +54,7 @@ export function RiversLegend({ hiddenCategories, onToggleCategory }: RiversLegen
         </svg>
       </button>
 
-      <div className={`${expanded ? "block" : "hidden"} mt-1.5 space-y-2`}>
+      <div className={`${expanded ? "block" : "hidden"} mt-1.5 space-y-2 max-h-[52vh] overflow-y-auto pr-1`}>
         {/* Water quality section */}
         <div className="flex flex-col gap-1">
           {QUALITY_ITEMS.map((status) => {


### PR DESCRIPTION
First pass of mobile-layout fixes found while testing on a phone. More will follow in separate PRs as we find them.

## Header
- The "Neer Vazhvu" wordmark no longer overlaps the city switcher on mobile (hidden on small screens; logo + switcher carry identity).
- The current-page label (e.g. "Groundwater") now `truncate`s instead of `whitespace-nowrap`, and the control cluster is `shrink-0`, so a long page name can never push into the city switcher.

## Basin atlas (rivers drill-down / treatment & waste gaps) - was desktop-only on mobile
- **Detail panel** now uses the shared `BottomSheet` (draggable sheet on mobile, sidebar on desktop) instead of `hidden lg:flex`. Tapping a river / feature / gap opens it; closing clears the selection.
- **Layers panel is an off-canvas left drawer** on mobile (map full-screen by default; "Layers" tab opens it, backdrop/X closes). Floors render vertically with inline toggles. Desktop keeps the in-flow sidebar.
- **River lines are clickable for all basins** - the click handler now accepts both `riverId` (Arkavathi) and `river_id` (Chennai); Adyar's line was previously unclickable.
- **Gap badge** ("red box") tap target doubled on touch devices (radius 6→12).
- **Legend** scrolls instead of clipping, and lifts above the bottom sheet when a panel is open (was hidden behind it); keeps its own minimise.
- Coach mark `rounded-full` → `rounded-xl` so it doesn't balloon when wrapping.

## Shared chrome
- City-switcher & language dropdowns clamp to the viewport (`max-w-[calc(100vw-1rem)]`).
- Language toggle buttons sized to `h-9` to meet tap-target size and align with siblings; compact city switcher on mobile (pin icon hidden, tighter padding).
- `BottomSheet` desktop variant gets `overflow-y-auto`; rivers coach marks de-ballooned.

## Note
- The "data not loading / menu unclickable" symptom seen while testing over a LAN IP was a Next 16 dev-server cross-origin block (`allowedDevOrigins`), **not** a code bug - production is unaffected. That config is kept local, not in this PR.