### PR TITLE
Bengaluru water-bodies: legend shows only categories with data

### DIFF
--- a/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
+++ b/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
@@ -308,15 +308,19 @@ export default function WaterBodiesMapClient({
                   return next;
                 })
               }
-              // Bengaluru's V0 data layer is OSM polygons + tabular
-              // lost-kere only - no census-to-OSM polygon spatial join
-              // yet, so the three census_* legend entries would mislead
-              // (no feature on the map is coloured by them). Filter
-              // them out. Chennai/Madurai default to the full legend.
+              // Bengaluru's water-bodies map only renders OSM "current"
+              // polygons, which all read as "existing" (blue). There is no
+              // lost-lakes inventory for the city (so fully_lost /
+              // severely_reduced / encroached have zero features on the
+              // map), and the only survey we hold - the MoWR 6th Minor
+              // Irrigation Census (718 points) - records encroached=No and
+              // in-use=No for every body, so it cannot back a condition
+              // classification either. Show only the one category that
+              // actually appears. Chennai/Madurai default to the full
+              // legend. Revisit if a real lake-condition survey (e.g. a
+              // digitised KTCDA / IISc encroachment inventory) is wired in.
               visibleCategoryIds={
-                cityId === "bangalore"
-                  ? ["existing", "fully_lost", "severely_reduced", "encroached"]
-                  : undefined
+                cityId === "bangalore" ? ["existing"] : undefined
               }
             />
           </div>


### PR DESCRIPTION
Bengaluru's water-bodies map only renders OSM "current" polygons (all read as "existing"). There's no lost-lakes inventory for the city, and the one survey we hold (MoWR 6th Minor Irrigation Census, 718 points) records encroached=No / in-use=No for every body - so the `fully_lost` / `severely_reduced` / `encroached` legend entries colour nothing on the map and mislead. This trims the Bengaluru legend to just "existing"; Chennai/Madurai keep the full legend. A comment notes to revisit if a real lake-condition survey (digitised KTCDA / IISc encroachment inventory) is wired in.