### PR TITLE
docs: Mumbai across every documentation surface (follow-up to #147)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> Technical overview of Neer Vazhvu - Urban Water Intelligence platform (Chennai, Madurai, and Bengaluru live; multi-city by design).
+> Technical overview of Neer Vazhvu - Urban Water Intelligence platform (Chennai, Madurai, Bengaluru and Mumbai live; multi-city by design; Mumbai is the first region place - the 9-corporation MMR).
 
 ## System Overview
 
@@ -95,23 +95,26 @@ graph TB
 
 ## Multi-city architecture
 
-Every page that the user sees is keyed on a `cityId`. Chennai's pages live at the legacy flat routes (`/`, `/groundwater`, `/water-bodies` etc.) for back-compat; Madurai, Bengaluru, and future cities live under `/[cityId]/...`. The `tryGetPlaceConfig(cityId)` resolver loads a `PlaceConfig` from `src/lib/cities/{cityId}.ts` and that config drives:
+Every page that the user sees is keyed on a `cityId`. Chennai's pages live at the legacy flat routes (`/`, `/groundwater`, `/water-bodies` etc.) for back-compat; Madurai, Bengaluru, Mumbai, and future cities live under `/[cityId]/...`. The `tryGetPlaceConfig(cityId)` resolver loads a `PlaceConfig` from `src/lib/cities/{cityId}.ts` and that config drives:
 
 - **`heroMode`** (`days-left` | `allocation` | `cauvery-pumping` | `none`) — picks the dashboard hero variant.
     - Chennai (`days-left`): divides total CMWSSB-reservoir storage by urban demand. Works because Chennai's reservoirs ARE the urban supply.
     - Madurai (`allocation`): anchors on Vaigai live storage + the city's published drinking-water allocation since the dams are irrigation-primary and shared across multiple districts.
     - Bengaluru (`cauvery-pumping`): tracks BWSSB's lift volume from T.K. Halli (~1,400-1,450 MLD) against Stage I-V design capacity (~2,225 MLD post-Stage V). Bangalore drinks 100 km away from the Cauvery so reservoir storage is not the right runway metric; pumping volume vs design is. Pairs with the IISc 80-ward stress overlay (April 2025 Outlook) since all 6 Bangalore Urban CGWB blocks are over-exploited and tap deficits show up as tanker dependency, not as reservoir percent.
+    - Mumbai (`days-left`, region place): BMC's 7 lakes ARE the tap (Chennai-pattern), but the card states two caveats from config - `heroNote` labels the figure an upper bound (storage counts whole-dam water in state-owned dams while capacity is BMC's share), and the rain scenarios collapse to one line because the Pravah feed publishes no inflow data. Desal/inflow sliders hide when a city lacks the underlying data.
 - **`waterSources`** — array of reservoirs/dams the city tracks, with `fullCapacityMcft`, `isPrimaryDrinkingSource`, etc. `isPrimaryDrinkingSource` is true only when the reservoir's storage IS the city's runway. Bangalore tracks 4 upstream Cauvery basin reservoirs (KRS, Hemavathi, Kabini, Harangi) but flags them all false because they're shared with irrigation + Mysuru + Mandya + the inter-state release to TN.
 - **`urbanSupply`** (when `heroMode === 'allocation'`) — annual allocation (mcft/yr), recent draw, WTP capacity, supply chain description for the at-a-glance tile.
 - **`groundwaterViews`** — feature flags for the groundwater page (`exploitation` / `depth` / `risk` / `cgwbStations`). Madurai disables `depth` + `risk` because per-ward IDW interpolation would be dishonest with only 4 live stations across the district; instead it surfaces `cgwbStations` (Year Book point overlay) on top of `exploitation` (block-level classification). Bengaluru disables `depth` for the same reason (13 CGWB telemetric stations across 369 GBA wards is too sparse to honestly IDW); it surfaces `exploitation` (6 blocks all Over-Exploited every year on record), `risk` (ward-risk composite), and `cgwbStations`.
 - **`localGovernment`** — ward count + acronym (GCC 200 / MMC 100 / GBA 369) for help-text and authority labels.
 - **`primaryAuthority`** — utility name (CMWSSB / MMC / TWAD / BWSSB) used in MissingDataCard reasons and About-page citations.
-- **`availableLanguages`** — which UI languages render the language toggle for this city. Chennai: `['en', 'ta']`. Madurai: `['en', 'ta']`. Bengaluru: `['en', 'kn']`.
+- **`availableLanguages`** — which UI languages render the language toggle for this city. Chennai: `['en', 'ta']`. Madurai: `['en', 'ta']`. Bengaluru: `['en', 'kn']`. Mumbai: `['en']` with `upcomingLanguages: ['mr']` - the switcher renders a greyed "coming soon" chip until the Marathi pass lands.
+- **`placeKind` + `corporations[]`** — `'region'` models a metropolitan region rather than one corporation (Mumbai: the 9-corporation MMR). Region places render the `RegionalWaterSystem` dashboard section, and `dashboardScopes` supplies the scope badges ("Greater Mumbai · BMC's 7 lakes" vs "Mumbai Metropolitan Region · 9 corporations") so two geographies never blur on one dashboard.
+- **Capability flags** — `hasCommitments`, `hasAllocationLedger`, `hasShoreline`, `hasCascadeOverlay`, etc. gate whole surfaces; `FEATURE_AVAILABILITY` in `src/lib/cities/routing.ts` is the single source of truth for nav, sitemap AND direct-URL 404s (e.g. Mumbai ships without my-ward until the ward build lands).
 - **`sourceNameAliases`** — case-insensitive maps so the news-search query and reservoir-detail-dialog match a source under any spelling (e.g. "vaigai" / "vaigai dam" / "வைகை" → `vaigai`).
 
 Per-city data files use a `-<cityId>` suffix in `public/data/` and `public/geojson/` (e.g. `madurai-supply-overview.json`, `bangalore-iisc-stress-wards-2025.json`, `imd-rainfall-monthly-bangalore.json`). Chennai keeps legacy unsuffixed paths for back-compat.
 
-To add a new city, see the "Adding a new city" walkthrough in [CONTRIBUTING.md](CONTRIBUTING.md). The Bangalore onboarding (PRs through `bangalore_onboarding` branch) is the most recent worked example; the Madurai onboarding (PR #97) is the canonical reference.
+To add a new city, see the "Adding a new city" walkthrough in [CONTRIBUTING.md](CONTRIBUTING.md). The Mumbai onboarding (PR #147) is the most recent worked example and covers the region pattern; Bangalore (`bangalore_onboarding`) covers `cauvery-pumping` + localization; the Madurai onboarding (PR #97) is the canonical reference.
 
 ## Shared utilities
 
@@ -137,6 +140,14 @@ The dashboard component tree forks where each city's data landscape calls for it
 - **`BangaloreDailyBriefing`** (`src/components/dashboard/bangalore-daily-briefing.tsx`) — template-based daily briefing card. Composes prose from `t()` keys against structured `fields` (returned by `buildBangaloreBriefing()` in `src/lib/insights/bangalore-briefing.ts`) so the briefing is fully localised. Five briefing variants pick by reservoir storage + tanker dependency. Open slot for a Claude-pipeline AI uplift via `aiOverride`.
 - **`IIScStressWardsMap`** (`src/components/dashboard/iisc-stress-wards-{leaflet-,}map.tsx`) — the headline groundwater layer on `/bangalore`. Renders 80 critically-over-extracted BBMP wards (April 2025 IISc Outlook) as a percentile-coloured choropleth (0-100 composite score) over the 198 BBMP polygon set. Click any ward for its severity tier + composite score breakdown.
 - **`TankerExpandedContext`** + **`TankerMarketPanel`** + **`TankerPageChrome`** — the `/bangalore/tanker` page composes longitudinal OpenCity survey data (2015 / 2019 / 2024) on what households actually pay vs BWSSB's official tariff, with tier-by-tier breakdowns and corridor-specific sites. All section headings + body fields read from per-language JSON variants (`_kn`, `_ta`) so the page is fully localised.
+
+### Mumbai (region place, `heroMode: 'days-left'`)
+
+- **`RegionalWaterSystem`** (`src/components/dashboard/regional-water-system.tsx`) — the Metropolitan Water System card, rendered only for `placeKind: 'region'`. LPCD-inequality ranking across the 9 corporations (bar chart against the CPHEEO 135 norm), scoreboard chips, per-corporation cards (supply/demand/deficit verdict chip + live Pravah storage pill), augmentation pipeline, numbered citations. Fed by `mmr-corporations-water.json` + `mmr-dam-storage.json`.
+- **`DaysLeftHero` honesty extensions** (shared component; config-driven) — `heroNote` + `heroNoteSource` (upper-bound caveat + linked attribution), collapsed no-inflow scenarios stating the draw rate, slider gating, `scopeLabel` badge.
+- **`FloodLinesSection`** (`src/components/flood/flood-lines-section.tsx`) — WRD red/blue flood-line sheets per river as collapsed rows; self-hides for cities without a `flood-lines-{cityId}.json`.
+- **Accountability surfaces (all four cities)** — `allocations-client.tsx` (Allocation Ledger: entitled vs received per arrangement, instrument links, confidence + gap verdicts incl. "unreported") and `commitments-client.tsx` (Commitments Register: citation-gated statuses, append-only history). Both follow the verdict-first UX contract (scoreboard, collapsed rows, problems float) and deep-link into each other by entry id (hash scroll + auto-expand + highlight after client-side data load).
+- **Data feeds via GitHub Actions (artifact-commit), not the API runtime** — `pravah-dam-refresh.yml` (daily reservoir storage), `rainfall-recent-refresh.yml` (daily provisional rainfall, all cities), `bmc-floodspots-refresh.yml` (weekly), `imd-rainfall-refresh.yml` (quarterly, all cities incl. Mumbai). One-off: `backfill_cwc_reservoirs.py` (Bhatsa + Upper Vaitarna weekly 2015-2025, insert-only-missing).
 
 ## Daily Pipeline
 
@@ -479,7 +490,7 @@ All chips are pre-loaded into the browser cache via `new Image().src = url` on m
 
 ### Lake Catchment Atlas (`/[city]/water-bodies` → "Catchments" view)
 
-A terrain-derived, clickable area-of-influence layer for every lake/tank, live for Chennai, Madurai, and Bengaluru. Where the cascade reconstruction (90 m HydroSHEDS, tank-to-tank edges) is the district-scale skeleton, the atlas delineates the **contributing area** per lake from a 30 m bare-earth DEM. Full methodology: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md); original spec: [docs/specs/lake-catchment-atlas.md](docs/specs/lake-catchment-atlas.md).
+A terrain-derived, clickable area-of-influence layer for every lake/tank, live for Chennai, Madurai, Bengaluru and Mumbai. Where the cascade reconstruction (90 m HydroSHEDS, tank-to-tank edges) is the district-scale skeleton, the atlas delineates the **contributing area** per lake from a 30 m bare-earth DEM. Full methodology: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md). (Design specs live in local archives; the methodology doc is the maintained record.)
 
 **Build-time pipeline** ([neer-vazhvu-api/app/cascade/catchments.py](neer-vazhvu-api/app/cascade/catchments.py), algorithm `catchments_fabdem_wbt_v1`):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,17 +92,19 @@ The multi-city architecture is config-driven. To add (say) Coimbatore:
    - `"cauvery-pumping"` if the city's drinking water is lifted from a distant source via dedicated pumping infrastructure and the headline constraint is pump capacity vs design (Bengaluru-pattern). Track the upstream reservoirs in `waterSources` but flag all of them `isPrimaryDrinkingSource: false` if they're shared with irrigation / other cities. Provide a `cauveryPumping` block with current lift, Stage design capacity, Stage actual delivery.
    - `"none"` to suppress the hero entirely.
 2. Register it in `src/lib/cities/index.ts`.
-3. If the city has a regional language other than EN, set `availableLanguages: ['en', '<iso>']` and add translations for every key in `src/lib/i18n/translations.ts` (validated by `npm run i18n:check`).
+3. If the city has a regional language other than EN, set `availableLanguages: ['en', '<iso>']` and add translations for every key in `src/lib/i18n/translations.ts` (validated by `npm run i18n:check`). If the translation pass will follow later, declare it in `upcomingLanguages` instead - the switcher renders a greyed "coming soon" chip (the Mumbai launch pattern).
 4. Drop city-specific files into `public/data/coimbatore-*.json` and `public/geojson/coimbatore-*.geojson` matching the existing naming convention.
 5. Mirror `compute-ward-profiles.ts` for the new city's ward count + data layers. Emit `_data_status: "not_available"` for sections you don't yet have data for — the UI cards branch on this and render honest "data not yet sourced" disclaimers.
 6. For long-term IMD rainfall, add the city's grid intersection to `CITY_DEFAULTS` in `neer-vazhvu-api/scripts/generate_imd_rainfall.py` and run `python generate_imd_rainfall.py --city coimbatore`.
 7. The routes at `src/app/[cityId]/...` will pick up the new city automatically once `tryGetPlaceConfig(cityId)` resolves it.
 
-Worked examples: Madurai onboarding (`madurai_onboarding`, PR #97) is the canonical reference for the `allocation` pattern; Bengaluru onboarding (`bangalore_onboarding`) is the most recent and covers the `cauvery-pumping` pattern + Kannada localization + 13-body rich-data deep-zoom batch.
+For a **metropolitan region** rather than a single corporation, set `placeKind: 'region'` and a `corporations[]` array (the Mumbai pattern: 9 MMR corporations). The regional dashboard section (`RegionalWaterSystem`), scope badges (`dashboardScopes`) and per-corporation data file (`mmr-corporations-water.json`-style) hang off that structure. Gate any page that is not ready by omitting its feature from `FEATURE_AVAILABILITY` in `src/lib/cities/routing.ts` - nav, sitemap and direct URLs all respect it (the Mumbai my-ward launch pattern).
+
+Worked examples: Madurai onboarding (`madurai_onboarding`, PR #97) is the canonical reference for the `allocation` pattern; Bengaluru onboarding (`bangalore_onboarding`) covers the `cauvery-pumping` pattern + Kannada localization + 13-body rich-data deep-zoom batch; Mumbai onboarding (`mumbai_onboarding`, PR #147) is the most recent and covers the region pattern, the days-left-with-caveats hero, the Allocation Ledger + Commitments Register data files, and workflow-based (GitHub Actions artifact-commit) data feeds.
 
 ## Earth Engine Phase 1
 
-If you are working on the satellite summary layer, also read [GEE_PHASE1_METHODS.md](GEE_PHASE1_METHODS.md).
+If you are working on the satellite summary layer, also read [GEE_PHASE2_3_PLAN.md](GEE_PHASE2_3_PLAN.md) and the shipped-method write-ups under [docs/methodology/](docs/methodology/).
 
 Local prerequisites for GEE work:
 
@@ -123,7 +125,7 @@ python scripts/run_gee_phase1.py run-water-body-summaries --write
 Current workflow note:
 
 - `.github/workflows/gee-phase1.yml` is wired for manual dispatch in this branch
-- if you change the GEE data model or methodology, update both [README.md](README.md) and [GEE_PHASE1_METHODS.md](GEE_PHASE1_METHODS.md) in the same PR
+- if you change the GEE data model or methodology, update both [README.md](README.md) and [GEE_PHASE2_3_PLAN.md](GEE_PHASE2_3_PLAN.md) and the shipped-method write-ups under [docs/methodology/](docs/methodology/) in the same PR
 
 ## Development Workflow
 
@@ -182,7 +184,7 @@ Current workflow note:
 - **Kannada prose review** - `src/app/[cityId]/about/bangalore-page-descriptions.tsx`, the BangaloreDailyBriefing variants in `translations.ts`, and the long-form story (`src/content/story-bangalore-kn.tsx`). Native-speaker review wanted.
 - **Localization (UI)** - ~1,500 i18n keys covering EN + TA + KN; `npm run i18n:check` enforces parity.
 - **Testing** - Unit tests for scrapers, calculator, intelligence modules, and the shared `src/lib/utils/river-classification.ts` (CPCB Best-Use classifier).
-- **Adding a fourth city** - see the "Adding a new city" subsection above.
+- **Adding a fifth city** - see the "Adding a new city" subsection above.
 
 ## Submitting a Pull Request
 

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -9,10 +9,11 @@ The detailed source-by-source breakdown lives in per-city files. Each file docum
 - [docs/cities/chennai/data-sources.md](docs/cities/chennai/data-sources.md) - Chennai (CMWSSB reservoirs, OpenCity groundwater, CFLOWS flood, CRRT, etc.)
 - [docs/cities/madurai/data-sources.md](docs/cities/madurai/data-sources.md) - Madurai (TN Agriculture ARS, ADB TNUFIP IEE, CGWB Year Book, Vencatesan/DHAN water bodies, CPCB NWMP Vaigai, etc.)
 - [docs/cities/bangalore/data-sources.md](docs/cities/bangalore/data-sources.md) - Bengaluru (4 upstream Cauvery reservoirs via TN Agriculture / WRIS, IISc Groundwater Outlook 2025, CGWB block GWR via WRIS GEC 2024, OpenCity tanker surveys, IMD gridded rainfall, 13 flagship water bodies, etc.)
+- [docs/cities/mumbai/data-sources.md](docs/cities/mumbai/data-sources.md) - Mumbai/MMR (Maharashtra WRD Pravah daily reservoir bulletin, CWC weekly bulletins 2015-2025 backfill, BMC ESR/Climate Budget/RTI manuals, Praja Foundation RTI ward tables, MPCB water-quality series, WRD red/blue flood-line sheets, allocation instruments incl. WRD GRs + STEM board minutes, etc.)
 
-Per-city *features* live alongside in the same folder: [docs/cities/chennai/features.md](docs/cities/chennai/features.md), [docs/cities/madurai/features.md](docs/cities/madurai/features.md), and [docs/cities/bangalore/features.md](docs/cities/bangalore/features.md).
+Per-city *features* live alongside in the same folder: [docs/cities/chennai/features.md](docs/cities/chennai/features.md), [docs/cities/madurai/features.md](docs/cities/madurai/features.md), [docs/cities/bangalore/features.md](docs/cities/bangalore/features.md), and [docs/cities/mumbai/features.md](docs/cities/mumbai/features.md).
 
-When adding a fourth city, copy the Bengaluru or Madurai folder as a template - those docs reflect the multi-city naming convention (per-city `-<cityId>` suffix on data files). Chennai's docs predate that and use unsuffixed legacy paths for back-compat.
+When adding a fifth city, copy the Mumbai or Bengaluru folder as a template - those docs reflect the multi-city naming convention (per-city `-<cityId>` suffix on data files). Chennai's docs predate that and use unsuffixed legacy paths for back-compat.
 
 ## Documentation principle: avoid absolute-absence claims
 
@@ -22,36 +23,38 @@ The Madurai documents follow this principle throughout. The Chennai documents pr
 
 ## Cross-city parity matrix
 
-A contributor cheat-sheet for what each city has covered. If you're adding a third city, this is your checklist - replicate the green column items first, then file the red column as known gaps to track.
+A contributor cheat-sheet for what each city has covered. If you're adding a new city, this is your checklist - replicate the green column items first, then file the red column as known gaps to track.
 
-| Domain | Chennai | Madurai | Bengaluru |
-|---|---|---|---|
-| Hero pattern | days-left (reservoirs ARE supply) | allocation (irrigation-primary dams) | cauvery-pumping (lift vs Stage design) |
-| Reservoir daily | CMWSSB scrape | TN Agriculture ARS scrape | TN Agriculture ARS scrape (4 upstream Cauvery: KRS, Hemavathi, Kabini, Harangi; all isPrimaryDrinkingSource=false) |
-| Weather daily | Open-Meteo + NASA POWER | Same | Same |
-| Long-term rainfall | IMD gridded (Chennai grid 13.0/80.0) | IMD gridded (Madurai grid 9.9/78.0) | IMD gridded (Bangalore grid 13.0/77.5; 1970-2025; 843 mm long-term annual mean) |
-| Groundwater wards | OpenCity ward-monthly choropleth | (Not surfaced - too sparse to interpolate) | (Not surfaced - 13 stations across 369 wards too sparse to IDW) |
-| Groundwater stations | India WRIS GWL API daily scrape | India WRIS GWL API daily scrape (Madurai district) | India WRIS GWL API daily scrape (Bangalore Urban + Rural districts; 13 CGWB telemetric stations) |
-| Groundwater blocks | India WRIS / CGWB block GWR | CGWB block GWR (11 MMC blocks of 66 district-wide) | CGWB block GWR via WRIS GEC 2024 (6 Bangalore Urban blocks; ALL Over-Exploited every year on record; Bangalore-East 306% draft/recharge, Yelahanka 140%→260% in 4 yrs) |
-| Headline GW layer | OpenCity ward choropleth | CGWB Year Book + block exploitation | IISc Groundwater Outlook for Bengaluru (April 2025) - 80 critically-over-extracted BBMP wards rendered as a percentile choropleth |
-| Rivers (CPCB NWMP) | Cooum (7 stations) + Adyar (5) + Buckingham (1) | Vaigai (2 stations) | Vrishabhavathi + Arkavathy + Dakshina Pinakini (partial coverage; KSPCB cross-check pending) |
-| Water bodies | OSM (1,635) + Census (305) + Lost (15) | OSM (715, 638 named) + Flagship (19) + Lost (26) | OSM (~900) + Flagship-curated + Lost-tank inventory (T.V. Ramachandra et al.) |
-| Restoration priority | 6-component spatial scoring | 4-component (different algorithm) | Composite incl. encroachment + sewage stress (Bangalore-specific) |
-| Flood hazard | CFLOWS 1.0 (Nov 2019) + 2015/2020 hotspots | Not sourced (narrative-only) | KSNDMC flood-prone zones + BBMP Sept 2022 hotspots (custom flood-risk-bangalore-leaflet-map) |
-| Drainage | GCC 10,308-segment survey | Not sourced (RTI follow-up) | BBMP SWM master plan partial - RTI follow-up for full RWD network |
-| Sewerage | CMWSSB 13 STPs / 745 MLD | Not sourced (RTI follow-up) | BWSSB 33 STPs / ~1,440 MLD design (per Stage V program docs) - RTI for actual treatment volumes |
-| Industrial sources | NGT/TNPCB/CPCB curated | TNPCB + HC PIL curated | KSPCB + The Hindu BlueLine curated (Bellandur/Varthur foam cluster, Peenya cluster) |
-| Tanker market | (Not surfaced) | Not yet sourced | OpenCity longitudinal household survey 2015 / 2019 / 2024 - what households actually pay vs BWSSB tariff |
-| Cauvery pumping | n/a | n/a | BWSSB Stage I-V design capacity (~2,225 MLD) vs current lift (~1,450 MLD); Stage V actual ~400 MLD per The Ken Feb 2026 |
-| Urban supply structure | (Implicit in CMWSSB reservoirs) | ADB TNUFIP Tranche 2 IEE structural extract | BWSSB Stage I-V infrastructure + cauvery-pumping-hero callouts |
-| Ward representatives | GCC councillors / MLAs / MPs | Not yet sourced | BBMP councillors (partial pre-GBA reorganization) |
-| AI narratives | Daily city + monthly per-ward | Not yet wired | Template-based daily briefing (BangaloreDailyBriefing); Claude AI uplift slot |
-| Localities for search | OSM (~500) | OSM (51, Wikidata fallback queued) | OSM + Wikidata SPARQL (Bangalore neighbourhoods + suburbs) |
-| Ward profiles | 200 GCC wards, 5-factor composite | 100 MMC wards, 3-factor composite (reduced) | 198 BBMP wards (pre-GBA), 3-factor reduced composite (no public flood/drainage layer); GBA 369-ward migration pending |
-| Languages | EN + TA | EN + TA | EN + KN |
-| Long-form story | `/origins` (EN + TA) | `/madurai/origins` (EN + TA) | `/bangalore/origins` (EN + KN; 4-chapter, ~4,000 words) |
-| Rich-data deep-zoom (flagship bodies) | 8 onboarded: Pallikaranai (TNSWA gazette) + Sholavaram + Red Hills + Chembarambakkam + Porur + Velachery + Perumbakkam + Chitlapakkam (all OSM). Yearly chips (Landsat 5/7/8 + Sentinel-2), JRC water trend + DW splice 2022+, DW built trend, Overture buildings (monthly) | Not yet wired (flagship candidates: Vandiyur, Anaipatti tanks) | 13 onboarded: Bellandur, Varthur, Hesaraghatta, Hebbal, Ulsoor, Sankey, Madivala, Agara, Jakkur, Rachenahalli, Iblur, Kempambudhi, Puttenahalli, Yelahanka. Same pipeline + JRC/DW splice |
-| Catchment atlas (every lake) | FABDEM 30 m + WhiteboxTools; own/received/total catchment, feeder streams, downstream flow path, rooftop harvest (Overture + IMD normals). River names from `chennai-rivers.geojson`. Lake names: OSM + OpenCity 2019 polygons (~101 recoverable; deferred) | Same pipeline; Vaigai/Varaha/Manjalar river names | Same pipeline; lake names backfilled from the ATREE/CSEI named-lake census (OpenCity, 446 toponyms); rivers Arkavati/Vrishabhavathi/Dakshina Pinakini |
+| Domain | Chennai | Madurai | Bengaluru | Mumbai |
+|---|---|---|---|---|
+| Hero pattern | days-left (reservoirs ARE supply) | allocation (irrigation-primary dams) | cauvery-pumping (lift vs Stage design) | days-left, labelled an upper bound (whole-dam storage vs BMC share); rain scenarios collapsed (no public inflow data) |
+| Reservoir daily | CMWSSB scrape | TN Agriculture ARS scrape | TN Agriculture ARS scrape (4 upstream Cauvery: KRS, Hemavathi, Kabini, Harangi; all isPrimaryDrinkingSource=false) | WRD Pravah daily bulletin (5 of 7 BMC lakes; Vihar/Tulsi have no public feed) + CWC weekly 2015-2025 backfill |
+| Weather daily | Open-Meteo + NASA POWER | Same | Same | Same |
+| Long-term rainfall | IMD gridded (Chennai grid 13.0/80.0) | IMD gridded (Madurai grid 9.9/78.0) | IMD gridded (Bangalore grid 13.0/77.5; 1970-2025; 843 mm long-term annual mean) | IMD gridded (grid 19.0/73.0) + all cities now carry the daily Open-Meteo provisional layer |
+| Groundwater wards | OpenCity ward-monthly choropleth | (Not surfaced - too sparse to interpolate) | (Not surfaced - 13 stations across 369 wards too sparse to IDW) | (Not surfaced - excluded from CGWB assessment; Year Book wells only) |
+| Groundwater stations | India WRIS GWL API daily scrape | India WRIS GWL API daily scrape (Madurai district) | India WRIS GWL API daily scrape (Bangalore Urban + Rural districts; 13 CGWB telemetric stations) | CGWB Year Book transcription (~53 wells, Mumbai/Thane/Palghar/Raigad, incl. chemistry; WRIS wells stale, ending May 2023) |
+| Groundwater blocks | India WRIS / CGWB block GWR | CGWB block GWR (11 MMC blocks of 66 district-wide) | CGWB block GWR via WRIS GEC 2024 (6 Bangalore Urban blocks; ALL Over-Exploited every year on record; Bangalore-East 306% draft/recharge, Yelahanka 140%→260% in 4 yrs) | n/a - Mumbai City + Suburban are the only 2 of Maharashtra's 35 districts excluded from the assessment (stated on-page) |
+| Headline GW layer | OpenCity ward choropleth | CGWB Year Book + block exploitation | IISc Groundwater Outlook for Bengaluru (April 2025) - 80 critically-over-extracted BBMP wards rendered as a percentile choropleth | CGWB Year Book well points (monitored-not-assessed framing) |
+| Rivers (CPCB NWMP) | Cooum (7 stations) + Adyar (5) + Buckingham (1) | Vaigai (2 stations) | Vrishabhavathi + Arkavathy + Dakshina Pinakini (partial coverage; KSPCB cross-check pending) | MPCB annual WQR series (Mithi stn 2168, Ulhas stations; 2019-20 edition never published) + CPCB PRS 2025 (Mithi = India's worst stretch, 210 mg/l) |
+| Water bodies | OSM (1,635) + Census (305) + Lost (15) | OSM (715, 638 named) + Flagship (19) + Lost (26) | OSM (~900) + Flagship-curated + Lost-tank inventory (T.V. Ramachandra et al.) | OSM + flagship + lost-tank inventory (Powai/Vihar/Tulsi + talao record) |
+| Restoration priority | 6-component spatial scoring | 4-component (different algorithm) | Composite incl. encroachment + sewage stress (Bangalore-specific) | Priority scoring + flagship + projects (NGT Powai record) |
+| Flood hazard | CFLOWS 1.0 (Nov 2019) + 2015/2020 hotspots | Not sourced (narrative-only) | KSNDMC flood-prone zones + BBMP Sept 2022 hotspots (custom flood-risk-bangalore-leaflet-map) | BMC chronic-flooding register (weekly scrape) + 26/7/2005 layer + WRD red/blue flood-line sheets (41, six MMR rivers); iFLOWS documented as not public |
+| Drainage | GCC 10,308-segment survey | Not sourced (RTI follow-up) | BBMP SWM master plan partial - RTI follow-up for full RWD network | OSM-traced (labelled community-traced; BRIMSTOWAD as-builts not public) |
+| Sewerage | CMWSSB 13 STPs / 745 MLD | Not sourced (RTI follow-up) | BWSSB 33 STPs / ~1,440 MLD design (per Stage V program docs) - RTI for actual treatment volumes | BMC ESR Table 11.5 (2,723 MLD installed vs 1,313 reaching plants) + WwTF upgrade %s in the Commitments Register |
+| Industrial sources | NGT/TNPCB/CPCB curated | TNPCB + HC PIL curated | KSPCB + The Hindu BlueLine curated (Bellandur/Varthur foam cluster, Peenya cluster) | Curated (Mahul refinery ring, Taloja MIDC) |
+| Tanker market | (Not surfaced) | Not yet sourced | OpenCity longitudinal household survey 2015 / 2019 / 2024 - what households actually pay vs BWSSB tariff | Not surfaced (RTI-gated; Rs 729 vs 25 per-person-month fact from Praja) |
+| Cauvery pumping | n/a | n/a | BWSSB Stage I-V design capacity (~2,225 MLD) vs current lift (~1,450 MLD); Stage V actual ~400 MLD per The Ken Feb 2026 | n/a (gravity-fed lakes) |
+| Urban supply structure | (Implicit in CMWSSB reservoirs) | ADB TNUFIP Tranche 2 IEE structural extract | BWSSB Stage I-V infrastructure + cauvery-pumping-hero callouts | BMC HE RTI manuals + ESR (3 MBRs → 27 service reservoirs → 109 zones; connections with denominator note) |
+| Ward representatives | GCC councillors / MLAs / MPs | Not yet sourced | BBMP councillors (partial pre-GBA reorganization) | Not yet sourced (my-ward withheld at launch) |
+| AI narratives | Daily city + monthly per-ward | Not yet wired | Template-based daily briefing (BangaloreDailyBriefing); Claude AI uplift slot | Not yet wired |
+| Localities for search | OSM (~500) | OSM (51, Wikidata fallback queued) | OSM + Wikidata SPARQL (Bangalore neighbourhoods + suburbs) | OSM |
+| Ward profiles | 200 GCC wards, 5-factor composite | 100 MMC wards, 3-factor composite (reduced) | 198 BBMP wards (pre-GBA), 3-factor reduced composite (no public flood/drainage layer); GBA 369-ward migration pending | 24 BMC wards, equity-first risk model on real Praja supply-hours (my-ward page withheld until ward build completes) |
+| Languages | EN + TA | EN + TA | EN + KN | EN (MR advertised as coming soon) |
+| Long-form story | `/origins` (EN + TA) | `/madurai/origins` (EN + TA) | `/bangalore/origins` (EN + KN; 4-chapter, ~4,000 words) | `/mumbai/origins` (EN; 4-chapter + 5 licensed Wikimedia images with provenance manifest) |
+| Allocation Ledger | Krishna/Telugu Ganga chain + Veeranam + desal contracts | 1,500 mcft/yr PWD-letter entitlement + 1886 Periyar lease ancestry | CWDT award chain (1.75 → +4.75 TMC SC 2018 → 19+10 TMC GoK-BWSSB) | 15 arrangements incl. STEM/MIDC/MMRDA middlemen; 10 of 15 'unreported' (quota on paper, delivery unpublished) |
+| Commitments Register | 16 (metering policy, desal trio, ring main, NGT sewage, Cooum/Adyar/Buckingham) | 7 (Manibharathi HC order, Mullaiperiyar 125 MLD, 24x7, UGSS, Vaigai riverfront/cleanup) | 10 (Bellandur/Varthur NGT, Cauvery Stage V/VI, K-100, reuse, Mekedatu) | 19 (WwTFs, BRIMSTOWAD, Gargai/Kalu/Manori, flood spots, climate budget) |
+| Rich-data deep-zoom (flagship bodies) | 8 onboarded: Pallikaranai (TNSWA gazette) + Sholavaram + Red Hills + Chembarambakkam + Porur + Velachery + Perumbakkam + Chitlapakkam (all OSM). Yearly chips (Landsat 5/7/8 + Sentinel-2), JRC water trend + DW splice 2022+, DW built trend, Overture buildings (monthly) | Not yet wired (flagship candidates: Vandiyur, Anaipatti tanks) | 13 onboarded: Bellandur, Varthur, Hesaraghatta, Hebbal, Ulsoor, Sankey, Madivala, Agara, Jakkur, Rachenahalli, Iblur, Kempambudhi, Puttenahalli, Yelahanka. Same pipeline + JRC/DW splice | Not yet wired (flagship candidates: Powai, Vihar) |
+| Catchment atlas (every lake) | FABDEM 30 m + WhiteboxTools; own/received/total catchment, feeder streams, downstream flow path, rooftop harvest (Overture + IMD normals). River names from `chennai-rivers.geojson`. Lake names: OSM + OpenCity 2019 polygons (~101 recoverable; deferred) | Same pipeline; Vaigai/Varaha/Manjalar river names | Same pipeline; lake names backfilled from the ATREE/CSEI named-lake census (OpenCity, 446 toponyms); rivers Arkavati/Vrishabhavathi/Dakshina Pinakini | Same pipeline; Mithi/Dahisar/Poisar/Oshiwara + supply-lake catchments |
 
 ## Shared utilities (city-agnostic)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Neer Vazhvu
 
-**Urban Water Intelligence** - An open-source platform that turns public water data into actionable intelligence for Indian cities. Live for Chennai, Madurai, and Bengaluru today, with more cities on the way.
+**Urban Water Intelligence** - An open-source platform that turns public water data into actionable intelligence for Indian cities. Live for Chennai, Madurai, Bengaluru and Mumbai today, with more cities on the way.
 
 **Live:** [neervazhvu.org](https://neervazhvu.org)
 
-Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks reservoir levels, groundwater health, river water quality, flood risk, sewerage infrastructure, and water body loss across Indian cities. Each city's dashboard reflects what's actually knowable for that city - so Chennai surfaces CMWSSB-fed days-of-water-left + 5-factor ward risk, Madurai surfaces a Vaigai allocation hero + 3-factor ward risk because its dams are irrigation-primary, and Bengaluru surfaces a Cauvery-pumping hero (BWSSB lifts treated water 100 km from T.K. Halli, so reservoir storage is not the right runway metric) layered on the IISc 80-ward stress overlay since all 6 Bangalore Urban CGWB blocks are over-exploited.
+Neer Vazhvu (நீர் வாழ்வு, Tamil for "Water Life") tracks reservoir levels, groundwater health, river water quality, flood risk, sewerage infrastructure, and water body loss across Indian cities. Each city's dashboard reflects what's actually knowable for that city - so Chennai surfaces CMWSSB-fed days-of-water-left + 5-factor ward risk, Madurai surfaces a Vaigai allocation hero + 3-factor ward risk because its dams are irrigation-primary, Bengaluru surfaces a Cauvery-pumping hero (BWSSB lifts treated water 100 km from T.K. Halli, so reservoir storage is not the right runway metric) layered on the IISc 80-ward stress overlay since all 6 Bangalore Urban CGWB blocks are over-exploited, and Mumbai - the first *region* place, modelled as the full Metropolitan Region's 9 corporations - surfaces a days-of-water-left hero over BMC's 7 lakes (explicitly labelled an upper bound) alongside a Metropolitan Water System view of the region's 3.6x per-capita inequality.
 
 ## What we track (city-agnostic)
 
@@ -16,8 +16,11 @@ Every city dashboard, where the data exists, surfaces:
 - **Water bodies** - OSM polygons, lost-tank inventory, restoration priority scoring (algorithm varies per city)
 - **Rich-data deep-zoom panel** - 21 flagship bodies onboarded (8 in Chennai + 13 in Bangalore). A click opens a full-screen panel with yearly satellite imagery 1984-present, cumulative water-loss and built-gain tints over the polygon and 1 km halo, per-year stats (water surface, built share, building counts in body vs halo), a play/pause timeline with event stamps, and a sources & methodology modal. Water-fraction series splices JRC GSW v1.4 (1984-2021) with Dynamic World V1 (2022-present) so the chart doesn't truncate at JRC's cutoff
 - **Flood risk** - Hazard zones / drainage / sewerage where layers are public; narrative-only stub where they're not
-- **Shoreline change** (`/shoreline`, Chennai only today) - Erosion/accretion along the Chennai coast, Mahabalipuram to Pulicat. The primary layer is our own MNDWI/DSAS satellite measurement (Landsat 5/7/8 + Sentinel-2 via Earth Engine, ~1,200 transects, **1990-2026** - extending past the study's 2024 cutoff), with a per-transect movement-over-time chart, an early-vs-recent acceleration check (≈72% of the eroding coast is eroding faster than before), and a per-transect confidence flag. The six study zones + named port hotspots from Anagha, Singh & Frappart (2026, *Environmental Challenges*) are drawn as faint context that validates the measurement
-- **My Ward** - Per-ward report aggregating every layer above with comparison + uplift planner
+- **Shoreline change** (`/shoreline`, Chennai + Mumbai today) - Erosion/accretion along the Chennai coast, Mahabalipuram to Pulicat. The primary layer is our own MNDWI/DSAS satellite measurement (Landsat 5/7/8 + Sentinel-2 via Earth Engine, ~1,200 transects, **1990-2026** - extending past the study's 2024 cutoff), with a per-transect movement-over-time chart, an early-vs-recent acceleration check (≈72% of the eroding coast is eroding faster than before), and a per-transect confidence flag. The six study zones + named port hotspots from Anagha, Singh & Frappart (2026, *Environmental Challenges*) are drawn as faint context that validates the measurement
+- **My Ward** - Per-ward report aggregating every layer above with comparison + uplift planner (Chennai, Madurai, Bengaluru; deliberately withheld for Mumbai until the ward build lands)
+- **Allocation Ledger** (`/[cityId]/allocations`, all 4 cities) - Who is owed what water: every arrangement (source → authority → recipient) with entitled vs received, the legal/administrative instrument it rests on, and a confidence grade - including the honest "unreported" class for quotas whose deliveries nobody publishes
+- **Commitments Register** (`/[cityId]/commitments`, all 4 cities) - 52 dated commitments by named institutions (commissioning dates, court deadlines, mitigation claims) checked against time; statuses change only with a dated citation and history appends, never overwrites
+- **Rainfall** - IMD gridded history + normals (quarterly-refreshed backbone) plus a daily provisional layer (Open-Meteo archive fill) so monsoon bursts appear as they happen, asterisked until IMD's authoritative series supersedes them
 - **About** - Per-city methodology, data-source index, transparency-gap inventory
 - **Tanker market** (Bengaluru only today) - Longitudinal OpenCity household-survey data (2015 / 2019 / 2024) on what households actually pay vs BWSSB's official tariff
 - **IISc 80-ward stress overlay** (Bengaluru only today) - 80 critically-over-extracted BBMP wards from the April 2025 IISc Groundwater Outlook layered as a choropleth on /bangalore
@@ -27,7 +30,8 @@ Per-city deep-dives:
 - [docs/cities/chennai/features.md](docs/cities/chennai/features.md) - Chennai feature inventory + risk-score, ward-report-card, uplift-planner, and restoration-priority methodologies
 - [docs/cities/madurai/features.md](docs/cities/madurai/features.md) - Madurai-specific surfaces (allocation hero, supply-overview tile, transparency-gap panel, missing-data card) and how Madurai differs from Chennai
 - [docs/cities/bangalore/features.md](docs/cities/bangalore/features.md) - Bengaluru-specific surfaces (cauvery-pumping hero, daily briefing, IISc stress overlay, tanker market, 13 rich-body lakes) and Kannada localization
-- City-specific long-form water stories: [`/origins`](https://neervazhvu.org/origins) (Chennai), [`/madurai/origins`](https://neervazhvu.org/madurai/origins), [`/bangalore/origins`](https://neervazhvu.org/bangalore/origins) (EN + KN)
+- [docs/cities/mumbai/features.md](docs/cities/mumbai/features.md) - Mumbai/MMR-specific surfaces (region model + scope badges, upper-bound days-left hero, Metropolitan Water System, WRD flood lines, Pravah/CWC reservoir feeds) and what is deliberately absent at launch
+- City-specific long-form water stories: [`/origins`](https://neervazhvu.org/origins) (Chennai), [`/madurai/origins`](https://neervazhvu.org/madurai/origins), [`/bangalore/origins`](https://neervazhvu.org/bangalore/origins) (EN + KN), [`/mumbai/origins`](https://neervazhvu.org/mumbai/origins)
 
 ## Architecture
 
@@ -44,6 +48,11 @@ Per-city deep-dives:
 │  ├─ tn_pwd_reservoirs.py (Madurai: TN Agriculture ARS daily)       │
 │  └─ openmeteo_basin_rainfall.py                                    │
 │                                                                    │
+│  Mumbai feeds run as GitHub Actions (artifact-commit), not in the  │
+│  API runtime: scrape_pravah_dams.py (WRD daily), backfill_cwc_     │
+│  reservoirs.py (2015-25 one-off), fetch_recent_rainfall.py (daily  │
+│  provisional rainfall, all cities), scrape_bmc_flood_spots.py      │
+│                                                                    │
 │  Writes computed results to Supabase ────┐                         │
 └──────────────────────────────────────────┘                         │
                                                                      │
@@ -56,26 +65,29 @@ Per-city deep-dives:
 │  • /[cityId]/* (Madurai, Bangalore,      │
 │    future cities)                         │
 │  • src/lib/cities/{chennai,madurai,      │
-│    bangalore}.ts drives heroMode,        │
+│    bangalore,mumbai}.ts drives heroMode, │
 │    water sources, ward count,            │
-│    allocation config                     │
+│    allocation config, placeKind          │
+│    ('city' | 'region' - Mumbai is the    │
+│    MMR: 9 corporations)                  │
 │                                          │
 │  Static GeoJSON + JSON served from       │
 │  /public (per-city -<cityId> suffix)     │
 └──────────────────────────────────────────┘
 ```
 
-**Place-config-driven multi-city.** Adding a city = adding a `CityConfig` in `src/lib/cities/`. The routes at `src/app/[cityId]/...` resolve it via `tryGetPlaceConfig(cityId)`. `heroMode` (`days-left` | `allocation` | `cauvery-pumping` | `none`) picks the dashboard hero variant. Per-city water sources, ward counts, and `urbanSupply` allocation context flow from the same config. See [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-city) for the full walkthrough.
+**Place-config-driven multi-city.** Adding a city = adding a `CityConfig` in `src/lib/cities/`. The routes at `src/app/[cityId]/...` resolve it via `tryGetPlaceConfig(cityId)`. `heroMode` (`days-left` | `allocation` | `cauvery-pumping` | `none`) picks the dashboard hero variant. Per-city water sources, ward counts, `urbanSupply` allocation context, capability flags (`hasCommitments`, `hasAllocationLedger`, `hasShoreline`, ...), language state (`availableLanguages` + `upcomingLanguages` for greyed coming-soon toggles), and region structure (`placeKind: 'region'` + `corporations[]` for the MMR) all flow from the same config. See [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-city) for the full walkthrough.
 
 Earth Engine Phase 1 jobs live under `neer-vazhvu-api/app/gee/` and write small summary tables into Supabase instead of serving raster layers directly to the frontend.
 
 ## Data Sources
 
-We integrate roughly 40 distinct sources across the cities we cover - from utility-published reservoir feeds (CMWSSB for Chennai, TN Agriculture ARS for Madurai, KSNDMC + Karnataka WRD for Bengaluru), to CGWB groundwater telemetry, to CPCB river quality, to IISc research outputs (Bengaluru stress wards), to OpenCity household-survey panels (Bengaluru tanker market), to OSM/Wikidata for spatial geometry. The full breakdown lives in per-city documents:
+We integrate 50+ distinct sources across the cities we cover - from utility-published reservoir feeds (CMWSSB for Chennai, TN Agriculture ARS for Madurai, KSNDMC + Karnataka WRD for Bengaluru, Maharashtra WRD's Pravah bulletin + CWC weekly bulletins for Mumbai), to CGWB groundwater telemetry, to CPCB/MPCB river quality, to IISc research outputs (Bengaluru stress wards), to OpenCity household-survey panels (Bengaluru tanker market), to Praja Foundation RTI tables (Mumbai ward equity), to legal/administrative instruments (WRD GRs, board minutes, NGT and High Court records backing the Allocation Ledger and Commitments Register), to OSM/Wikidata for spatial geometry. The full breakdown lives in per-city documents:
 
 - [docs/cities/chennai/data-sources.md](docs/cities/chennai/data-sources.md)
 - [docs/cities/madurai/data-sources.md](docs/cities/madurai/data-sources.md)
 - [docs/cities/bangalore/data-sources.md](docs/cities/bangalore/data-sources.md)
+- [docs/cities/mumbai/data-sources.md](docs/cities/mumbai/data-sources.md)
 - [DATA_SOURCES.md](DATA_SOURCES.md) - top-level index with a cross-city parity matrix (the contributor cheat-sheet for what each city has covered)
 
 ## Tech Stack
@@ -95,9 +107,9 @@ We integrate roughly 40 distinct sources across the cities we cover - from utili
 
 Earth Engine is used as a summary layer (catchment rainfall context, water-body NDWI seasonality) and as the build-time source for the rich-data deep-zoom panel's yearly chips and zonal stats — not a raster explorer. Methodology, guardrails, and operations live in dedicated docs:
 
-- [GEE_PHASE1_METHODS.md](GEE_PHASE1_METHODS.md), [GEE_PHASE1_PLAN.md](GEE_PHASE1_PLAN.md), [GEE_CATCHMENT_DERIVATION_PLAN.md](GEE_CATCHMENT_DERIVATION_PLAN.md)
 - [GEE_PHASE2_3_PLAN.md](GEE_PHASE2_3_PLAN.md), [GEE_PHASE2_CHECKLIST.md](GEE_PHASE2_CHECKLIST.md)
-- [GEE_RESEARCH.md](GEE_RESEARCH.md)
+- Shipped-method write-ups: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md), [docs/methodology/coastal-shoreline-change-v1.md](docs/methodology/coastal-shoreline-change-v1.md), [docs/methodology/cascade-reconstruction-v1.md](docs/methodology/cascade-reconstruction-v1.md)
+- (The phase-1 planning documents were retired to local archives once the work shipped; the methodology folder is the maintained record.)
 
 ## Rich-Data Deep-Zoom Panel
 
@@ -319,8 +331,8 @@ neer-vazhvu/
 ├── src/                # Next.js frontend (App Router)
 │   ├── app/            # / (Chennai legacy flat routes), /[cityId]/* (Madurai, Bangalore, future cities)
 │   ├── components/     # City-agnostic where possible; per-city forks live in dashboard/, my-ward/, water-bodies/
-│   ├── lib/cities/     # Place-config registry (chennai.ts, madurai.ts, bangalore.ts, types.ts)
-│   ├── lib/i18n/       # ~1,500 EN/TA/KN translation keys
+│   ├── lib/cities/     # Place-config registry (chennai.ts, madurai.ts, bangalore.ts, mumbai.ts, types.ts)
+│   ├── lib/i18n/       # ~1,500 EN/TA/KN translation keys (MR declared as upcoming)
 │   └── lib/utils/      # Shared utilities incl. river-classification.ts (CPCB Best-Use)
 ├── neer-vazhvu-api/    # Python FastAPI service: scrapers, ETL, intelligence, GEE
 ├── public/
@@ -331,12 +343,13 @@ neer-vazhvu/
 │   ├── cities/         # Per-city documentation (features, data sources)
 │   │   ├── chennai/
 │   │   ├── madurai/
-│   │   └── bangalore/
+│   │   ├── bangalore/
+│   │   └── mumbai/
 │   └── research/       # Authoritative source PDFs (CGWB, ADB IEE, IISc Outlook)
 └── supabase/migrations/ # SQL schema
 ```
 
-For the full per-city file inventory, see [docs/cities/chennai/data-sources.md](docs/cities/chennai/data-sources.md), [docs/cities/madurai/data-sources.md](docs/cities/madurai/data-sources.md), and [docs/cities/bangalore/data-sources.md](docs/cities/bangalore/data-sources.md).
+For the full per-city file inventory, see [docs/cities/chennai/data-sources.md](docs/cities/chennai/data-sources.md), [docs/cities/madurai/data-sources.md](docs/cities/madurai/data-sources.md), [docs/cities/bangalore/data-sources.md](docs/cities/bangalore/data-sources.md), and [docs/cities/mumbai/data-sources.md](docs/cities/mumbai/data-sources.md).
 
 ## Limitations
 
@@ -347,6 +360,7 @@ For the full per-city file inventory, see [docs/cities/chennai/data-sources.md](
 - Forecasts use AutoARIMA which works best with 90+ days of history.
 - Lost water body coordinates and historical areas are approximate, sourced from academic and civic studies.
 - Restoration priority scores use spatial proximity as a proxy; they do not account for population density, land ownership, or restoration cost -factors that require non-public data.
+- Mumbai's days-of-water-left is an upper bound (storage counts full live water in state-owned dams, part of which serves users beyond BMC) and the card says so. Vihar + Tulsi (~3% of capacity) have no public feed. Rain scenarios are not computed for Mumbai because the Pravah feed publishes no inflow data.
 
 ## Contributing
 
@@ -359,7 +373,7 @@ Areas where help is needed:
 - **Data quality** -Improving scraper resilience, handling CMWSSB / BWSSB / TN Agriculture page format changes
 - **Models** -Better forecasting (Prophet, LSTM), improved evaporation integration
 - **Water bodies data** -Adding more documented lost water bodies with verified coordinates and sources
-- **Localization** -Translating the UI for local accessibility. Today: ~1,500 keys covering EN + TA (Chennai/Madurai) + KN (Bangalore). Native-speaker review wanted for TA prose review and KN long-form story (`src/content/story-bangalore-kn.tsx`)
+- **Localization** -Translating the UI for local accessibility. Today: ~1,500 keys covering EN + TA (Chennai/Madurai) + KN (Bangalore). **Marathi (Mumbai) is the biggest open item** - declared as coming-soon in the UI, 0 of ~1,509 keys translated. Native-speaker review wanted for TA prose review and KN long-form story (`src/content/story-bangalore-kn.tsx`)
 - **Testing** -Unit tests for scrapers, calculator, and intelligence modules
 
 Please open an issue first to discuss significant changes.
@@ -394,5 +408,12 @@ Please open an issue first to discuss significant changes.
 - **Indian Institute of Science (IISc)** for the Groundwater Outlook for Bengaluru (April 2025) - 80 critically-over-extracted BBMP wards used as the headline stress layer on `/bangalore`
 - **OpenCity Bengaluru** for longitudinal household water-tariff surveys (2015 / 2019 / 2024) powering the `/bangalore/tanker` market view
 - **BWSSB** for Cauvery pumping disclosures used in the cauvery-pumping hero
+- **Maharashtra Water Resources Department** for the daily Pravah dam-safety bulletin (Mumbai's live reservoir feed) and the red/blue flood-line map sheets
+- **Central Water Commission (CWC)** for the weekly Reservoir Storage Bulletins that provide Mumbai's 2015-2025 reservoir history
+- **Praja Foundation** for RTI-sourced ward-level water data (connections, supply hours, quality samples) in its Status of Civic Issues reports
+- **BMC / MCGM** for the Environment Status Report, Climate Budget and Hydraulic Engineer RTI manuals mined for Mumbai's supply structure
+- **MPCB** for the annual Water Quality Status reports behind the Mithi/Ulhas river series
+- **DataMeet** for Mumbai's 24-ward boundary geometry
+- **Wikimedia Commons contributors** (Alexey Komarov, Planemad, Sailee5, Rakesh) for the licensed images in Mumbai's Origins story
 - **[Anthropic](https://www.anthropic.com/)** for Claude API powering city and ward AI narratives
-- Chennai's, Madurai's, and Bengaluru's civic data communities for making public data accessible
+- Chennai's, Madurai's, Bengaluru's, and Mumbai's civic data communities for making public data accessible

--- a/docs/cities/mumbai/data-sources.md
+++ b/docs/cities/mumbai/data-sources.md
@@ -1,0 +1,85 @@
+# Data Sources - Mumbai
+
+> Where each Mumbai dataset comes from, how often it refreshes, and what to watch out for.
+
+Mumbai is the fourth onboarded city, modelled as the full Metropolitan Region (9 corporations). Its data landscape has a defining quirk: **the official BMC lake-level page is a SAP portal iView that renders only inside a browser session** - it cannot be scraped and shows nothing to a curl. Every live number therefore comes from state-level feeds (Maharashtra WRD) and document mining (BMC's own reports via RTI manuals, ESR, climate budget; Praja Foundation's RTI-sourced tables). The hedging principle from the Madurai docs applies throughout: absence claims are "no known public X".
+
+## Reservoir storage - WRD Pravah (daily, 5 of 7 BMC lakes)
+
+| | |
+|---|---|
+| **Source** | Maharashtra WRD "Pravah" dam-safety bulletin - a daily all-Maharashtra PDF (139 dams). Stable human entry: `mwrdpravah.in/damsafety/control/main`; the PDF endpoint (`.../pdfLatestReportEng`) is what the scraper parses |
+| **Method** | `neer-vazhvu-api/scripts/scrape_pravah_dams.py`, daily via `.github/workflows/pravah-dam-refresh.yml` (09:30 IST) |
+| **Coverage** | Bhatsa, Upper/Middle Vaitarna, Modak Sagar, Tansa (~97% of BMC system capacity). **Vihar + Tulsi have no public feed at all** |
+| **Gotchas** | Cert chain incomplete (fetch with verification off); dated URLs 404 - only "latest" works; per-dam timestamps stagger, so rows are stamped with the report date; the bulletin's same-date-last-year column is harvested too, so every run grows the history at both ends; the PDF endpoint intermittently serves an OFBiz error page (the workflow tolerates failed runs) |
+| **Table** | `reservoir_daily_v2` (city_id='mumbai'), upsert on (city_id, source_code, date) |
+
+Also parsed but not written as city rows: Barvi (eastern-corridor corporations) and the Surya scheme's Dhamni/Kawdas (western corridor) - these feed the regional corporation cards via `public/data/mmr-dam-storage.json`.
+
+## Reservoir history - CWC weekly bulletins (2015-2025 backfill, one-off)
+
+| | |
+|---|---|
+| **Source** | Central Water Commission weekly Reservoir Storage Bulletin PDFs (`cwc.gov.in/reservoirs-storage-bulletin`, 527 bulletins, 16-Apr-2015 → 08-May-2025 where the archive ends) |
+| **Method** | `neer-vazhvu-api/scripts/backfill_cwc_reservoirs.py` - listing-page scrape (URL naming drifts across eras), pdftotext, four table-format eras handled, FRL sanity anchors against misparses |
+| **Result** | 996 rows: Bhatsa 498 weekly dates + Upper Vaitarna 502, 2015-2025. Insert-only-missing - the backfill never overwrites the live feed |
+| **Gotchas** | ~20 weeks of 2022 are 404 on CWC's own server (unrecoverable); bulletin titles contain typos, so the per-dam row date is the date of record; old-era dates are US-style M/D/YYYY |
+
+## Supply structure - BMC's own documents
+
+| | |
+|---|---|
+| **Sources** | BMC Hydraulic Engineer RTI manuals (Dec 2024), BMC Environment Status Report 2024-25 (first mined here: supply pair 4,000 vs 4,505 MLD; per-source yield Table 9.1; sewage Table 11.5 - 2,723 MLD installed vs 1,313 reaching plants), MCGM O&M handbook, 2018 24x7 White Paper, BMC Climate Budget 2025-26 (via OpenCity) |
+| **Feeds** | `public/data/mumbai-supply-overview.json` (structural tile), facts, commitments entries |
+| **Refresh** | Annual/on-publication (document calendar, not a cron) |
+
+## Ward-level equity feedstock - Praja Foundation
+
+| | |
+|---|---|
+| **Source** | Praja Foundation, *Status of Civic Issues in Mumbai* (May 2025; RTI-sourced tables). praja.org is poorly indexed - the OpenCity mirror is the reliable fetch |
+| **Data** | Connections 5,51,459 as on Mar-2025 per ward (building-level - one connection often serves a whole society or chawl); 24-ward supply hours (city 5.37 h/day; T ward 24 h; C ward 1.5 h); yield→losses→supply reconciliation (4,370 − 395 = 3,975 MLD); per-ward %-unfit samples 2020-24; shortage complaints +64% |
+| **Feeds** | `public/data/mumbai-ward-water-praja.json` (ward-equity build feedstock - no UI yet), supply overview, facts |
+| **Refresh** | Annual (the 2026 edition launched 30-Jun-2026; PDF lands on praja.org ~late July) |
+
+## Rainfall - IMD gridded + Open-Meteo provisional (two layers)
+
+| | |
+|---|---|
+| **Backbone** | IMD 0.25° gridded rainfall via imdlib (1970-present, grid point 19.0/73.0) - authoritative history + normals; refreshed quarterly (`imd-rainfall-refresh.yml`, Mumbai included); publishes with weeks-to-a-year lag |
+| **Provisional layer** | Open-Meteo archive API (ERA5-family reanalysis, CC BY 4.0), daily precipitation from IMD's last published month through yesterday; `fetch_recent_rainfall.py`, daily via `rainfall-recent-refresh.yml` (08:15 IST). Rendered as asterisked provisional months; IMD wins wherever both cover a month |
+
+## Groundwater - CGWB (static, honest gaps)
+
+Mumbai City + Mumbai Suburban are the only 2 of Maharashtra's 35 districts **excluded from the CGWB Dynamic Ground Water Resources Assessment** - no safe/critical/over-exploited categories exist. What we surface instead: CGWB National Hydrograph Network wells transcribed from the Ground Water Year Book of Maharashtra (~53 wells across Mumbai/Thane/Palghar/Raigad, to Jan-2025, with water chemistry), via `public/data/mumbai-cgwb-stations.json`. WRIS has ~24 stale manual wells (ending May 2023) - documented, not used as a live layer.
+
+## Rivers - MPCB + CPCB
+
+| | |
+|---|---|
+| **MPCB** | Annual Water Quality Status reports (5 editions mined; **2019-20 was never published**): Mithi station 2168 annual-avg BOD series 45.3 → 18.3 → 28.2 → 37.3 → 53.0 (2023-24, WQI 32); Ulhas mainstem consistently clean; **Waldhuni is not an MPCB station** - no public series exists. FC units are inconsistent across editions (directional only) |
+| **CPCB** | Polluted River Stretches for Restoration of Water Quality - 2025 (Oct 2025, on 2022-23 data): the Mithi at Mahim is **India's worst stretch** (Priority I, max BOD 210 mg/l); the Ulhas is Priority V (least severe); Dahisar/Poisar/Oshiwara/Waldhuni are not in the national list at all |
+| **Feeds** | `public/data/river-quality-mumbai.json` (`mpcb_wqr_series` blocks; note the rivers `notes` field is a STRING, not a list), facts |
+
+## Flood - BMC register + WRD flood lines
+
+| | |
+|---|---|
+| **BMC flood spots** | Chronic-flooding register scraped weekly (`bmc-floodspots-refresh.yml`, Mondays); the list grew 386 → 453 → 496 across recent years while the climate budget tracks mitigation as a KPI |
+| **WRD flood lines** | The legal red/blue flood-boundary map sheets (blue = 25-yr level, construction prohibited; red = 100-yr, restricted): 41 sheets for 6 MMR rivers from WRD's 494-sheet statewide list (`wrd.maharashtra.gov.in/Site/1315/Flood-Line-Maps`). Scanned A0 plots, not georeferenced - linked as cited documents (`public/data/flood-lines-mumbai.json`); georeferencing into an overlay is a logged follow-up. **Named gap**: BMC publishes no equivalent for the city's own rivers |
+| **26/7/2005** | Reference layer from the Chitale Fact-Finding Committee record + curated hotspot geojson |
+| **iFLOWS** | Built with public money, briefs officials only - documented as a transparency gap |
+
+## Allocation instruments (the Ledger's paper)
+
+WRD Government Resolutions via the orgpedia mahGRs mirror (the way to full-text-search Maharashtra GRs; e.g. BMC's Bhatsa share, GR 11-Sep-2019, 427.93 Mm³/yr), STEM Water's own board minutes (8-Dec-2016, on environmentclearance.nic.in: 285 MLD sanctioned), MBMC's official supply page (211 = STEM 86 + MIDC 125), MMRDA Annual Report 2021-22 (Surya allocation 146.33 Mm³/yr), EC compliance tables. **Not public**: STEM's Thane/Bhiwandi split, MIDC per-buyer quantities, the MWRRA entitlement register (page literally "Under Construction"), Barvi sharing GR 18-Sep-2017 (number known, PDF unretrievable), BMC→Thane 90 MLD instrument - all named in the Ledger's gaps section.
+
+## Spatial
+
+DataMeet Mumbai 24-ward boundaries (`public/geojson/mumbai-wards-2023.geojson`), corporation boundaries 2024, OSM water bodies/rivers/drainage, FABDEM-derived lake catchments (`public/data/cascade/mumbai-*`), GEE MNDWI shoreline transects (`public/geojson/mumbai-coastal-transects.geojson`).
+
+## Retired / rejected sources
+
+- **numerical.co.in** (a third-party mirror of the BMC lake feed): died with 500s in 2026 and appears SEO-gamed; scraper, workflow step and all citations removed. The DB never held rows from it.
+- **India-WRIS reservoir module**: unreachable in repeated probes; CWC PDFs used instead.
+- **IMD AWS city endpoints**: 403 to non-browser clients.

--- a/docs/cities/mumbai/features.md
+++ b/docs/cities/mumbai/features.md
@@ -1,0 +1,44 @@
+# Mumbai - features and methodology
+
+> Detailed feature inventory for Mumbai, including how it differs from Chennai, Madurai and Bengaluru. The high-level overview lives in [README.md](../../../README.md); the data-source breakdown in [data-sources.md](data-sources.md).
+
+Mumbai is the fourth onboarded city and the first **region place** (`placeKind: 'region'`): it is modelled as the full Mumbai Metropolitan Region - nine municipal corporations (Greater Mumbai/BMC, Thane, Navi Mumbai, Kalyan-Dombivli, Mira-Bhayandar, Vasai-Virar, Bhiwandi-Nizampur, Ulhasnagar, Panvel) drawing on one contested source pool with no regional utility above them. The dashboard therefore carries **two geographies at once**, and every card names which one it covers via a scope badge: "Greater Mumbai · BMC's 7 lakes" or "Mumbai Metropolitan Region · 9 corporations".
+
+The supply model is Chennai-like, not Bengaluru-like: BMC's seven impounded lakes ARE the city's tap (Bhatsa alone ~48%), so a days-of-water-left hero is honest - with two caveats the card itself states (see below).
+
+### Dashboard (Mumbai-specific surfaces)
+
+- **Days-Left Hero** (`DaysLeftHero`, `heroMode: 'days-left'`) with three honesty features that other cities inherit where applicable:
+  - **Upper-bound caveat** (`heroNote`): storage counts the full live water in the five state-owned dams, part of which serves users beyond BMC (Bhatsa's BMC share is ~76% per WRD GR 11-Sep-2019). The figure is labelled an upper bound; the share-adjusted computation is a logged follow-up.
+  - **Collapsed rain scenarios**: the Pravah feed publishes storage only - no inflow data - so the worst-case / current-trend / seasonal scenarios would be three identical numbers. The hero collapses them to one line that states its divisor ("At a draw of 3,850 MLD") and says why rain scenarios can't be computed. The inflow and desalination sliders are hidden (Mumbai has no operating desal plant - Manori's 200 MLD is a proposal, tracked in the Commitments Register).
+  - **Linked attribution**: storage data attributed to the Maharashtra WRD Pravah portal (the stable `damsafety/control/main` entry, not the flaky PDF endpoint).
+- **The Metropolitan Water System** (`RegionalWaterSystem`, region places only) - the MMR view: LPCD-inequality ranking (~252 LPCD in Mumbai to ~70 in Vasai-Virar, against the CPHEEO 135 norm), scoreboard chips (below-norm / at-norm / unverified counts), per-corporation cards with deficit verdict chips + live source-storage pills (Pravah), the augmentation pipeline (Gargai, Kalu, Surya phases), and numbered scholarly citations with a collapsed source list.
+- **Supply-overview tile** (`UrbanSupplyOverview`) - BMC's engineering chain dam-to-tap: 3 Master Balancing Reservoirs → 27 service reservoirs → 109 supply zones; connections shown with the denominator explained (5.5 lakh **building-level** connections, ~23 people per connection - not comparable across cities).
+- **Reservoir history chart** - opens on **All time** by default (`reservoirHistoryDefaultRange: 'all'`): the recent windows hold only the young daily feed, while All-time spans a decade (CWC weekly 2015-2025 + Pravah daily from Jul 2026). A config-driven coverage note states exactly which dams have history and which never had a public archive (Vihar + Tulsi have no feed at all).
+- **Rainfall** - two-layer model (all cities): IMD gridded history + normals as the authoritative backbone, plus a daily provisional layer (Open-Meteo archive fill from IMD's last published month through yesterday) rendered as asterisked months. IMD supersedes the fill automatically as its quarterly series catches up.
+
+### Accountability surfaces (all four cities; Mumbai-first design)
+
+- **Allocation Ledger** (`/mumbai/allocations`) - who is owed what water: 15 arrangements (source → authority → recipient) with entitled vs received, the instrument each rests on (WRD GRs, STEM board minutes, MMRDA Annual Report), and a confidence grade. The honest verdict classes include **"unreported"** - a quota exists on paper but no delivery figure is published - which covers 10 of Mumbai's 15 rows and is the ledger's central finding.
+- **Commitments Register** (`/mumbai/commitments`) - 19 dated commitments (WwTF commissioning dates, Gargai/Kalu/Manori, BRIMSTOWAD, flood-spot mitigation, climate-budget delivery) with citation-gated status changes and append-only history. Cross-linked with the Ledger in both directions, landing on the exact entry (hash deep-links with auto-expand + highlight).
+
+### Flood risk (`/mumbai/flood-risk`)
+
+- Interactive map: BMC's chronic-flooding register (weekly refresh workflow), the 26/7/2005 reference layer, OSM drainage (labelled as community-traced, not BRIMSTOWAD as-builts).
+- **WRD flood-line sheets** (`FloodLinesSection`, shared component, data-file driven): the legal red/blue flood-boundary maps for 6 MMR rivers - 41 sheets, including the Ulhas 0-84 km (the Badlapur-Ulhasnagar-Kalyan flood corridor) - with the named gap that BMC publishes no equivalent for the city's own rivers (Mithi, Dahisar, Poisar, Oshiwara).
+- iFLOWS-Mumbai (the public-money flood model) briefs officials only; documented as a transparency gap, not silently omitted.
+
+### Other pages
+
+- **Groundwater** - Mumbai City + Suburban are excluded from CGWB's Dynamic Ground Water Resources Assessment (the only 2 of Maharashtra's 35 districts), so exploitation/depth/risk views are off; the page surfaces CGWB National Hydrograph Network wells (Year Book transcription, ~53 wells across Mumbai/Thane/Palghar/Raigad) as the honest signal.
+- **Water bodies + Catchments** - OSM bodies + lost-tank inventory + the FABDEM-derived lake-catchment atlas (same WhiteboxTools pipeline as the other cities).
+- **Rivers** - Mithi/Dahisar/Poisar/Oshiwara + regional Ulhas, with the MPCB annual Water Quality Status series where it exists (Mithi station 2168 BOD series; the 2019-20 edition was never published) and named reading gaps where it doesn't. Facts carry CPCB's Oct-2025 finding that the Mithi at Mahim is now **India's worst river stretch** (max BOD 210 mg/l).
+- **Shoreline** (`/mumbai/shoreline`) - same GEE MNDWI transect pipeline as Chennai, west-coast orientation, corroborated against the published record (NCCR 1990-2016 district table + MSMP 2017 risk grades) because no rate-publishing paper exists for Mumbai. Copy is config-driven per city (`ShorelineSummaryCopy`).
+- **Facts** (21 curated, each with a source URL) and **Origins** - the four-chapter water history (seven islands → Vihar 1860 → hydraulic citizenship → 26/7 and the forty-five litres) with five licensed Wikimedia images; provenance in `public/images/story/mumbai/MANIFEST.json`.
+
+### Deliberately absent at launch
+
+- **My Ward** - the ward panels are still in build (non-BMC corporation ward geometry has no public source). Removed from `FEATURE_AVAILABILITY`, so nav, sitemap and direct URLs all 404 for Mumbai. Returns with the ward-equity build (the per-ward Praja feedstock - supply hours, unfit samples, metering - is already in `public/data/mumbai-ward-water-praja.json`).
+- **Marathi** - declared as upcoming (`upcomingLanguages: ['mr']`): the language switcher shows a greyed "coming soon" chip. The translation pass is a dedicated follow-up PR; ~1,509 keys.
+- **Forecasts** - shipped without AutoARIMA forecasts (Chennai-only today); the Pravah history is too young.
+- **Cascades / tanker** - not applicable (reservoir-pumped geography; tanker data is RTI-gated).

--- a/docs/methodology/catchment-atlas-v1.md
+++ b/docs/methodology/catchment-atlas-v1.md
@@ -2,7 +2,7 @@
 
 **neer-vazhvu catchment delineation v1**
 **Algorithm: `catchments_fabdem_wbt_v1`**
-**Status: as-built, shipped for Chennai, Madurai, Bengaluru**
+**Status: as-built, shipped for Chennai, Madurai, Bengaluru, Mumbai**
 
 ## Abstract
 

--- a/docs/methodology/coastal-shoreline-change-v1.md
+++ b/docs/methodology/coastal-shoreline-change-v1.md
@@ -1,5 +1,13 @@
 # Mapping shoreline change on the Chennai coast with open satellite data
 
+> **Multi-city note (Jul 2026):** the same pipeline now also runs for Mumbai
+> (west-coast orientation, `public/geojson/mumbai-coastal-transects.geojson`),
+> corroborated against the published record (NCCR 1990-2016 district table +
+> MSMP 2017 risk grades) since no rate-publishing study exists for Mumbai.
+> The annual refresh workflow (`coastal-shoreline-refresh.yml`) is still
+> Chennai-hardcoded - parameterising it for Mumbai is a logged follow-up.
+> The methodology below is written against the Chennai build.
+
 **An independent, transparent reproduction and 2026 extension of a published shoreline-change study**
 
 Version 1 - Neer Vazhvu - June 2026

--- a/src/app/[cityId]/about/mumbai-page-descriptions.tsx
+++ b/src/app/[cityId]/about/mumbai-page-descriptions.tsx
@@ -57,14 +57,23 @@ export function MumbaiPageDescriptions({ cityId, cityName }: Props) {
           CMWSSB-style bulletin - its Hydraulic Engineer page is a closed portal applet. The lakes
           sit 30-130 km outside the city; they render as source cards, not map pins.
         </p>
+        <p className="text-slate-600 dark:text-slate-400">
+          The headline figure is labelled an <strong>upper bound</strong>: storage counts the full
+          live water in the five state-owned dams, part of which serves users beyond BMC. And
+          because the Pravah bulletin publishes storage only (no inflows), the rain scenarios other
+          cities carry collapse here to a single at-current-draw figure that states its divisor.
+        </p>
         <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 p-4 bg-amber-50/50 dark:bg-amber-950/20 space-y-2">
-          <h4 className="text-sm font-semibold text-amber-900 dark:text-amber-200">No history chart or forecast yet</h4>
+          <h4 className="text-sm font-semibold text-amber-900 dark:text-amber-200">A decade of history; no forecast yet</h4>
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            The BMC publishes no pre-2020 lake-level archive, so the 9-year history chart and the
-            AutoARIMA forecast that Chennai and Madurai carry are not available at launch. The daily
-            Pravah scrape accumulates a forward record - and harvests the bulletin&apos;s
-            same-date-last-year column, so each day adds two years of context; forecasts follow
-            once enough history banks up.
+            The history chart spans February 2015 to the present for Bhatsa and Upper Vaitarna -
+            weekly readings recovered from the Central Water Commission&apos;s bulletin archive
+            (discontinued May 2025) - and opens on the All-time view. The other three fed lakes have
+            no public archive before July 2026; their record accumulates from the daily Pravah
+            scrape, which also harvests the bulletin&apos;s same-date-last-year column so each run
+            adds two years of context. AutoARIMA forecasts (Chennai-style) follow once the daily
+            history banks up. Rainfall pairs IMD&apos;s gridded history with a daily provisional
+            layer so the current monsoon appears as it happens, asterisked until IMD confirms it.
           </p>
         </div>
       </SubSection>
@@ -99,10 +108,13 @@ export function MumbaiPageDescriptions({ cityId, cityName }: Props) {
 
       <SubSection id="page-rivers" title="Rivers">
         <p className="text-slate-600 dark:text-slate-400">
-          Four rivers - the Mithi, Dahisar, Poisar and Oshiwara - all CPCB Priority-I (most-polluted)
-          stretches, drawn from OpenStreetMap with their monitoring points. The Mithi, an 18 km open
-          drain from the Powai/Vihar overflows to Mahim Creek, is the river that overflowed in the 26
-          July 2005 deluge.
+          Four rivers - the Mithi, Dahisar, Poisar and Oshiwara - drawn from OpenStreetMap with
+          their monitoring points. In CPCB&apos;s October 2025 assessment the Mithi at Mahim is
+          <strong> India&apos;s single worst polluted river stretch</strong> (Priority I, max BOD
+          210 mg/l); the other three do not appear in the national list at all - they are barely
+          monitored as rivers, which is its own finding. The Mithi, an 18 km open drain from the
+          Powai/Vihar overflows to Mahim Creek, is the river that overflowed in the 26 July 2005
+          deluge.
         </p>
         <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200 pt-2">Mithi water quality (2018-2023)</h4>
         <p className="text-slate-600 dark:text-slate-400">
@@ -206,19 +218,69 @@ export function MumbaiPageDescriptions({ cityId, cityName }: Props) {
       <SubSection id="page-facts" title="Water facts">
         <p className="text-slate-600 dark:text-slate-400">
           Journalist-ready, sourced facts grouped by category - supply, water equity, groundwater,
-          rivers, floods, and coast &amp; wetlands. Today {cityName} ships 15 hand-curated facts: the
-          supply-demand gap, 34% non-revenue water (BMC audit, 2024), the slum/non-slum LPCD gap and the one ward in 24
-          with 24x7 supply, the groundwater-assessment exclusion, the four Priority-I rivers and
-          Powai&apos;s sewage load, the 26/7/2005 deluge and the locked iFLOWS model, and the
-          mangrove / salt-pan / Mahul / Gargai signature stories.
+          rivers, floods, and coast &amp; wetlands. Today {cityName} ships 21 hand-curated facts,
+          each with a source URL: the supply-demand gap, 34% non-revenue water (BMC audit, 2024),
+          the building-level connections denominator, the slum/non-slum LPCD gap and the one ward
+          in 24 with 24x7 supply, the groundwater-assessment exclusion, the Mithi as India&apos;s
+          worst river stretch (CPCB, Oct 2025) and Powai&apos;s sewage load, the 26/7/2005 deluge,
+          the locked iFLOWS model, the climate budget&apos;s flood bill, and the mangrove /
+          salt-pan / Mahul / Gargai signature stories.
+        </p>
+      </SubSection>
+
+      <SubSection id="page-water-bodies" title="Water bodies & catchments">
+        <p className="text-slate-600 dark:text-slate-400">
+          OSM water-body polygons plus a lost-tank inventory and restoration priority scoring, with
+          the Catchments view (FABDEM terrain-derived) making every lake clickable for its
+          contributing area, feeder streams and downstream flow path - the same pipeline as the
+          other cities. Powai&apos;s NGT record anchors the restoration entries.
+        </p>
+      </SubSection>
+
+      <SubSection id="page-shoreline" title="Shoreline">
+        <p className="text-slate-600 dark:text-slate-400">
+          The same satellite shoreline-change measurement as Chennai (MNDWI transects, Landsat +
+          Sentinel-2), west-coast orientation. No rate-publishing study exists for {cityName}, so
+          the measurement is corroborated against the official record instead: NCCR&apos;s 1990-2016
+          district table and the 2017 Shoreline Management Plan risk grades.
+        </p>
+      </SubSection>
+
+      <SubSection id="page-allocations" title="Allocation Ledger">
+        <p className="text-slate-600 dark:text-slate-400">
+          Who is owed what water: 15 arrangements (source &rarr; authority &rarr; recipient) across
+          the metropolitan region with entitled vs received, the instrument each rests on (WRD
+          Government Resolutions, STEM board minutes, the MMRDA Annual Report) and a confidence
+          grade. Ten of the fifteen carry the &quot;unreported&quot; verdict - a quota exists on
+          paper but nobody publishes what actually flows - which is the ledger&apos;s central
+          finding about how the region&apos;s water is governed.
+        </p>
+      </SubSection>
+
+      <SubSection id="page-commitments" title="Commitments Register">
+        <p className="text-slate-600 dark:text-slate-400">
+          Nineteen dated commitments by named institutions - wastewater-facility commissioning dates
+          from BMC&apos;s own climate budget and ESR, the Gargai / Kalu / Manori source projects,
+          BRIMSTOWAD, flood-spot mitigation - each checked against time. Statuses change only with a
+          dated citation; when a date slips, the old one stays on the record. Cross-linked with the
+          Allocation Ledger entry-to-entry.
+        </p>
+      </SubSection>
+
+      <SubSection id="page-origins" title="Origins">
+        <p className="text-slate-600 dark:text-slate-400">
+          The four-chapter water history - seven islands with no river, the first pipe at Vihar
+          (1860), hydraulic citizenship, and 26/7 with the forty-five litres - with five licensed
+          archival and contemporary images whose provenance is recorded file-by-file in the
+          repository manifest.
         </p>
         <p className="text-xs text-slate-500 dark:text-slate-400 italic">
           See also the dedicated Chennai about page (
           <Link href="/about" className="text-blue-600 dark:text-blue-400 hover:underline">
             /about
           </Link>
-          ) for the canonical methodology pattern this follows. Pages not yet shipped for {cityName}
-          (water bodies, lake restoration) will be documented here as their data layers land. Linked
+          ) for the canonical methodology pattern this follows. My Ward is the one page still in
+          build for {cityName}; it will be documented here when it ships. Linked
           from <Link href={`/${cityId}/facts`} className="text-blue-600 dark:text-blue-400 hover:underline">{`/${cityId}/facts`}</Link>.
         </p>
       </SubSection>


### PR DESCRIPTION
Follow-up to #147. Documents the Mumbai launch everywhere documentation lives - and fixes the staleness/bugs the pass uncovered.

- **New**: `docs/cities/mumbai/{features,data-sources}.md` (the per-city pair, incl. feed gotchas, launch absences, retired sources)
- **README / DATA_SOURCES / ARCHITECTURE / CONTRIBUTING**: Mumbai + the region-place pattern + the cross-city Allocation Ledger / Commitments Register / two-layer rainfall; full Mumbai column in the parity matrix; PR #147 as the newest worked example
- **Methodology**: catchment atlas +Mumbai; shoreline write-up gains a multi-city note (refresh workflow still Chennai-hardcoded - logged follow-up)
- **User-facing About page** (`mumbai-page-descriptions`): corrected the stale "no history chart yet" box (CWC gave it a 2015-present decade), the "all four rivers Priority-I" claim (CPCB Oct 2025: the Mithi is India's worst stretch; the other three aren't nationally listed), the 15→21 facts count, and the footer claiming water-bodies/lake-restoration weren't shipped; new sections for shoreline, Ledger, Register, Origins
- **Link hygiene**: fixed 7 pre-existing dead links (parked GEE phase-1 docs, local-only specs); relative-link check now clean across all touched files

Validation: tsc + eslint + 67/67 tests; `/mumbai/about` renders.