### PR TITLE
Cross-city leak audit + map zoom fix + About-page data layer + workflow hardening

### DIFF
--- a/.github/workflows/bmc-floodspots-refresh.yml
+++ b/.github/workflows/bmc-floodspots-refresh.yml
@@ -57,4 +57,5 @@ jobs:
             exit 0
           fi
           git commit -m "BMC flood-spot register refresh ($(date -u +%Y-%m-%d))"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/imd-rainfall-refresh.yml
+++ b/.github/workflows/imd-rainfall-refresh.yml
@@ -65,4 +65,5 @@ jobs:
             exit 0
           fi
           git commit -m "IMD rainfall refresh ($(date -u +%Y-%m-%d))"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/overture-buildings-refresh.yml
+++ b/.github/workflows/overture-buildings-refresh.yml
@@ -92,8 +92,8 @@ jobs:
             exit 0
           fi
           git commit -m "Overture buildings refresh ($(date -u +%Y-%m-%d))"
+          git pull --rebase origin main
           git push
-
       - name: Open PR with candidate (anomaly detected)
         if: steps.refresh.outputs.anomaly_found == '1'
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/pravah-dam-refresh.yml
+++ b/.github/workflows/pravah-dam-refresh.yml
@@ -69,4 +69,5 @@ jobs:
             exit 0
           fi
           git commit -m "Pravah dam storage refresh ($(date -u +%Y-%m-%d))"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/rainfall-recent-refresh.yml
+++ b/.github/workflows/rainfall-recent-refresh.yml
@@ -46,5 +46,6 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "data: daily provisional rainfall refresh (Open-Meteo fill after IMD's last month)"
+            git pull --rebase origin main
             git push
           fi

--- a/public/data/restoration-projects-mumbai.json
+++ b/public/data/restoration-projects-mumbai.json
@@ -11,7 +11,9 @@
       "amount_cr": 53.36,
       "sanctioned_year": 2023,
       "status": "In progress (target ~2024). The beautification model itself is contested - citizens at Kavesar, Upvan and Railadevi argue hardscaping degrades living wetlands.",
-      "sources": ["https://www.freepressjournal.in/mumbai/thane-tmc-to-beautify-25-lakes-in-city-under-amrit-2-scheme"]
+      "sources": [
+        "https://www.freepressjournal.in/mumbai/thane-tmc-to-beautify-25-lakes-in-city-under-amrit-2-scheme"
+      ]
     },
     {
       "scheme_name": "Powai Lake Restoration",
@@ -21,7 +23,10 @@
       "amount_cr": 66,
       "sanctioned_year": 2025,
       "status": "Underway; the STP is not to be commissioned until 11 December 2027, so ~18 MLD of sewage continues meanwhile.",
-      "sources": ["https://www.freepressjournal.in/mumbai/mumbai-news-bmc-launches-66-crore-powai-lake-restoration-project-with-new-stp-sewage-diversion-and-hyacinth-removal", "https://www.freepressjournal.in/mumbai/mumbai-ngt-told-powai-lake-will-continue-getting-18-mld-sewage-till-2027-due-to-stp-delay"]
+      "sources": [
+        "https://www.freepressjournal.in/mumbai/mumbai-news-bmc-launches-66-crore-powai-lake-restoration-project-with-new-stp-sewage-diversion-and-hyacinth-removal",
+        "https://www.freepressjournal.in/mumbai/mumbai-ngt-told-powai-lake-will-continue-getting-18-mld-sewage-till-2027-due-to-stp-delay"
+      ]
     },
     {
       "scheme_name": "Bandra Talao Heritage Restoration",
@@ -31,7 +36,9 @@
       "amount_cr": 20,
       "sanctioned_year": 2026,
       "status": "Consultant appointed; tank dewatered May 2026. Activists question the cost and approach.",
-      "sources": ["https://www.theweek.in/news/india/2026/05/21/mumbais-famous-bandra-talao-completely-dewatered-as-part-of-restoration-work.html"]
+      "sources": [
+        "https://www.theweek.in/news/india/2026/05/21/mumbais-famous-bandra-talao-completely-dewatered-as-part-of-restoration-work.html"
+      ]
     },
     {
       "scheme_name": "Vadale Lake Nature-Based Restoration",
@@ -41,7 +48,9 @@
       "amount_cr": 13,
       "sanctioned_year": 2021,
       "status": "Weevil campaign running Apr 2026 - Oct 2027; the cleanest nature-based arc in the outer MMR.",
-      "sources": ["https://www.freepressjournal.in/mumbai/panvel-municipal-corporation-launches-biological-campaign-to-remove-invasive-weed-from-vadale-lake"]
+      "sources": [
+        "https://www.freepressjournal.in/mumbai/panvel-municipal-corporation-launches-biological-campaign-to-remove-invasive-weed-from-vadale-lake"
+      ]
     },
     {
       "scheme_name": "DPS Flamingo Lake Conservation Reserve",
@@ -50,7 +59,9 @@
       "funding_summary": "Protection status (no rupee line)",
       "sanctioned_year": 2025,
       "status": "Approved 17 Apr 2025 - but a CIDCO de-reservation resolution followed within weeks; protection contested.",
-      "sources": ["https://india.mongabay.com/2025/04/flamingo-lake-in-navi-mumbai-faces-a-threat-as-citizens-fight-for-conservation/"]
+      "sources": [
+        "https://india.mongabay.com/2025/04/flamingo-lake-in-navi-mumbai-faces-a-threat-as-citizens-fight-for-conservation/"
+      ]
     }
   ],
   "court_orders": [
@@ -59,60 +70,70 @@
       "writ_petition": "NGT OA No. 150 of 2025",
       "court": "National Green Tribunal, Western Zone (Pune)",
       "date": "2025-12",
-      "directive": "A joint committee (CPCB/MPCB/State Wetland Authority) RECOMMENDED a Rs 5 lakh-per-inlet monthly penalty on BMC for Powai's sewage inflow (recommended, not imposed); the 8 MLD STP is not due until Dec 2027.",
-      "specific_tanks": ["Powai Lake"],
+      "specific_tanks": [
+        "Powai Lake"
+      ],
       "concern": "~18 MLD untreated sewage inflow (BMC affidavit ~10.9 MLD); eutrophication and hyacinth.",
-      "source": "https://www.deccanherald.com/india/maharashtra/ngt-panel-moots-rs-5-lakh-per-inlet-penalty-to-bmc-for-powai-lake-lapses-3820577"
+      "source": "https://www.deccanherald.com/india/maharashtra/ngt-panel-moots-rs-5-lakh-per-inlet-penalty-to-bmc-for-powai-lake-lapses-3820577",
+      "ruling": "A joint committee (CPCB/MPCB/State Wetland Authority) RECOMMENDED a Rs 5 lakh-per-inlet monthly penalty on BMC for Powai's sewage inflow (recommended, not imposed); the 8 MLD STP is not due until Dec 2027."
     },
     {
       "case": "Malabar Hill residents' immersion plea (Banganga)",
       "writ_petition": "Bombay HC order, 4 Sept 2025",
       "court": "Bombay High Court",
       "date": "2025-09-04",
-      "directive": "Refused immersion of even eco-friendly idols in Banganga Talao - 'Right to Clean Water Prevails'.",
-      "specific_tanks": ["Banganga Talao"],
+      "specific_tanks": [
+        "Banganga Talao"
+      ],
       "concern": "Idol-immersion pollution of a sacred heritage tank.",
-      "source": "https://www.livelaw.in/high-court/bombay-high-court/malabar-hill-residents-plea-to-immerse-ganesh-idol-in-banganga-lake-declined-302961"
+      "source": "https://www.livelaw.in/high-court/bombay-high-court/malabar-hill-residents-plea-to-immerse-ganesh-idol-in-banganga-lake-declined-302961",
+      "ruling": "Refused immersion of even eco-friendly idols in Banganga Talao - 'Right to Clean Water Prevails'."
     },
     {
       "case": "Ganesh idol immersion - artificial ponds (statewide)",
       "writ_petition": "Bombay HC order, ~25 Jul 2025",
       "court": "Bombay High Court",
       "date": "2025-07-25",
-      "directive": "All Ganesh idols up to 6 ft (clay or PoP) must be immersed in artificial ponds provided by civic bodies statewide; PoP not in natural water bodies without leave of court (2025 season / to March 2026).",
       "specific_tanks": [],
       "concern": "Plaster-of-Paris and immersion pollution across all MMR lakes and creeks.",
-      "source": "https://lawtrend.in/bombay-high-court-mandates-artificial-immersion-for-ganesh-idols-up-to-6-feet-expands-eco-friendly-festival-norms/"
+      "source": "https://lawtrend.in/bombay-high-court-mandates-artificial-immersion-for-ganesh-idols-up-to-6-feet-expands-eco-friendly-festival-norms/",
+      "ruling": "All Ganesh idols up to 6 ft (clay or PoP) must be immersed in artificial ponds provided by civic bodies statewide; PoP not in natural water bodies without leave of court (2025 season / to March 2026)."
     },
     {
       "case": "Lotus Lake protection (Nerul)",
       "writ_petition": "Bombay HC PIL, 15 Apr 2025",
       "court": "Bombay High Court",
       "date": "2025-04-15",
-      "directive": "Directed NMMC to protect Lotus Lake (Nerul, Sector 27) and report by 29 Apr 2025; lake cleared and fenced.",
-      "specific_tanks": ["Lotus Lake, Nerul"],
+      "specific_tanks": [
+        "Lotus Lake, Nerul"
+      ],
       "concern": "Repeated illegal construction-debris dumping linked to Navi Mumbai airport works.",
-      "source": "https://sandrp.in/2026/02/08/2025-mumbais-wetlands-mangroves-need-urgent-proactive-governance/"
+      "source": "https://sandrp.in/2026/02/08/2025-mumbais-wetlands-mangroves-need-urgent-proactive-governance/",
+      "ruling": "Directed NMMC to protect Lotus Lake (Nerul, Sector 27) and report by 29 Apr 2025; lake cleared and fenced."
     },
     {
       "case": "NRI wetland golf course (Navi Mumbai)",
       "writ_petition": "Bombay HC (2018); SLP pending in Supreme Court",
       "court": "Bombay High Court / Supreme Court",
       "date": "2018",
-      "directive": "Struck down a proposed golf course with a total ban on reclamation of NWIA wetlands; the developer's Special Leave Petition is still pending in the Supreme Court.",
-      "specific_tanks": ["NRI Wetland"],
+      "specific_tanks": [
+        "NRI Wetland"
+      ],
       "concern": "Reclamation of a flamingo-bearing tidal wetland.",
-      "source": "https://science.thewire.in/environment/navi-mumbai-wetlands-flamigos-golf-course-bombay-high-court/"
+      "source": "https://science.thewire.in/environment/navi-mumbai-wetlands-flamigos-golf-course-bombay-high-court/",
+      "ruling": "Struck down a proposed golf course with a total ban on reclamation of NWIA wetlands; the developer's Special Leave Petition is still pending in the Supreme Court."
     },
     {
       "case": "Goregaon wetland landfilling (Zoru Bhathena PIL)",
       "writ_petition": "Bombay HC PIL, 24 Apr 2025",
       "court": "Bombay High Court",
       "date": "2025-04-24",
-      "directive": "Notices to BMC/MCZMA/Konkan Wetland Committee over alleged illegal landfilling of a 191.39 ha wetland; matter pending.",
-      "specific_tanks": ["Goregaon (West) wetland"],
+      "specific_tanks": [
+        "Goregaon (West) wetland"
+      ],
       "concern": "Illegal landfilling of a mapped wetland.",
-      "source": "https://sandrp.in/2026/02/08/2025-mumbais-wetlands-mangroves-need-urgent-proactive-governance/"
+      "source": "https://sandrp.in/2026/02/08/2025-mumbais-wetlands-mangroves-need-urgent-proactive-governance/",
+      "ruling": "Notices to BMC/MCZMA/Konkan Wetland Committee over alleged illegal landfilling of a 191.39 ha wetland; matter pending."
     }
   ]
 }

--- a/src/app/[cityId]/about/about-content.tsx
+++ b/src/app/[cityId]/about/about-content.tsx
@@ -641,7 +641,7 @@ export function CityAboutContent({
             id="catchment-methodology"
             title={`Lake catchment atlas methodology - ${cityName}`}
           >
-            <CatchmentMethodologySection cityDisplayName={cityName} />
+            <CatchmentMethodologySection cityDisplayName={cityName} cityId={config.cityId} />
           </Section>
         )}
 
@@ -922,10 +922,26 @@ export function CityAboutContent({
               />
             </>
           )}
+          {isMumbai && (
+            <>
+              <DataSource
+                name="Maharashtra WRD Pravah - daily dam-safety bulletin"
+                url="https://mwrdpravah.in/damsafety/control/main"
+                description="The state Water Resources Department's daily all-Maharashtra bulletin (139 dams). We parse Bhatsa, Upper and Middle Vaitarna, Modak Sagar and Tansa - about 97% of the BMC lake system's capacity. Vihar and Tulsi (BMC-owned) appear in no public feed anywhere, a named gap the dashboard states. The bulletin's same-date-last-year column is harvested too, so the history grows at both ends every day."
+                frequency="daily (morning bulletin)"
+              />
+              <DataSource
+                name="CWC weekly Reservoir Storage Bulletins (2015-2025 backfill)"
+                url="https://cwc.gov.in/reservoirs-storage-bulletin"
+                description="527 Central Water Commission weekly bulletin PDFs mined one-off for the decade of history the daily feed is too young to hold: ~1,000 weekly readings for Bhatsa and Upper Vaitarna, April 2015 to May 2025 where the archive ends. Insert-only - the backfill never overwrites the live feed. Roughly 20 weeks of 2022 are missing on CWC's own server."
+                frequency="one-off backfill (archive ended May 2025)"
+              />
+            </>
+          )}
           <DataSource
             name="Open-Meteo"
             url="https://open-meteo.com/"
-            description="Free, no-auth daily weather data: precipitation, temperature, humidity, ET0, wind. ECMWF / ERA5-Land base."
+            description="Free, no-auth daily weather data: precipitation, temperature, humidity, ET0, wind. ECMWF / ERA5-Land base. For cities with the provisional-rainfall layer, its archive API also fills the months IMD's gridded series hasn't published yet - rendered as asterisked provisional months that IMD supersedes automatically."
             frequency="daily"
           />
           <DataSource
@@ -935,14 +951,16 @@ export function CityAboutContent({
               ? "India Meteorological Department 0.25-degree gridded rainfall, 1970-2025. Madurai grid cell at 9.9 deg N, 78.0 deg E, 862.6 mm long-term mean. Same imdlib pipeline as Chennai's IMD generator."
               : isBangalore
                 ? "India Meteorological Department 0.25-degree gridded rainfall, 1970-present. Bengaluru grid cell at 12.97 deg N, 77.6 deg E. Used for monsoon-context overlays (Bengaluru is south-west monsoon dominant with a smaller north-east monsoon tail through Oct-Nov; Cauvery basin recharge depends on both)."
-                : "India Meteorological Department 0.25-degree gridded rainfall, 1970-present. Used for monsoon-context overlays."}
+                : isMumbai
+                  ? "India Meteorological Department 0.25-degree gridded rainfall, 1970-present. Mumbai grid cell at 19.0 deg N, 73.0 deg E. The authoritative backbone and normals for the rainfall chart; publishes with a weeks-to-a-year lag, so a daily Open-Meteo provisional layer fills the gap through yesterday."
+                  : "India Meteorological Department 0.25-degree gridded rainfall, 1970-present. Used for monsoon-context overlays."}
             frequency="monthly archive"
           />
           {isMadurai && (
             <DataSource
               name="OSM Nominatim + Overpass - locality search points"
               url="https://overpass-api.de/"
-              description="51 Madurai neighbourhood points (Anna Nagar, Pasumalai, Mattuthavani, KK Nagar, Sellur, Vandiyur, etc.) extracted via scripts/fetch-localities-osm-madurai.ts for the my-ward search box. 49/51 carry Tamil names. Powers locality-name -> ward resolution."
+              description="51 Madurai neighbourhood points (Anna Nagar, Pasumalai, Mattuthavani, KK Nagar, Sellur, Vandiyur, etc.) extracted from OpenStreetMap for the my-ward search box. 49/51 carry Tamil names. Powers locality-name -> ward resolution."
               frequency="periodic (one-off refresh today)"
             />
           )}
@@ -950,7 +968,7 @@ export function CityAboutContent({
             <DataSource
               name="OSM Nominatim + Overpass - locality search points"
               url="https://overpass-api.de/"
-              description="369 Bengaluru neighbourhood points (Whitefield, Indiranagar, Koramangala, HSR Layout, JP Nagar, Yelahanka, Hesaraghatta, Bommanahalli, etc.) - one per GBA ward - in public/data/bangalore-localities.json. Powers locality-name -> ward resolution in the my-ward search box."
+              description="369 Bengaluru neighbourhood points (Whitefield, Indiranagar, Koramangala, HSR Layout, JP Nagar, Yelahanka, Hesaraghatta, Bommanahalli, etc.) - one per GBA ward. Powers locality-name -> ward resolution in the my-ward search box."
               frequency="periodic (one-off refresh today)"
             />
           )}
@@ -968,8 +986,10 @@ export function CityAboutContent({
             description={isMadurai
               ? "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited). 11 blocks classified across Madurai district (Madurai East/North/South/West, Melur, Peraiyur, Thirupparankundram, Tirumangalam, Usilampatti, Vadipatti, Kallikudi)."
               : isBangalore
-                ? "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited). 6 canonical blocks across Bangalore Urban district (Bangalore (North), Bangalore-East, Bangalore-South, Bangalore-City, Yelahanka, Anekal) extracted across 7 vintages 2011-2024 from the WRIS ArcGIS REST endpoint by scripts/fetch-wris-groundwater-bangalore.ts. All 6 blocks have been Over-Exploited every year (Bangalore-East worst at 306% draft-vs-recharge in GEC 2024; Yelahanka accelerated 140 -> 260% in 4 years 2020-2024)."
-                : "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited)."
+                ? "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited). 6 canonical blocks across Bangalore Urban district (Bangalore (North), Bangalore-East, Bangalore-South, Bangalore-City, Yelahanka, Anekal) extracted across 7 vintages 2011-2024 from the WRIS ArcGIS REST endpoint. All 6 blocks have been Over-Exploited every year (Bangalore-East worst at 306% draft-vs-recharge in GEC 2024; Yelahanka accelerated 140 -> 260% in 4 years 2020-2024)."
+                : isMumbai
+                  ? "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited). Mumbai City and Mumbai Suburban are the only 2 of Maharashtra's 35 districts EXCLUDED from this assessment - no exploitation categories exist for the city, so the groundwater page says so instead of synthesizing one."
+                  : "Annual block-level Dynamic Groundwater Resource Assessment (Safe / Semi Critical / Critical / Over Exploited)."
             }
             frequency="annual"
           />
@@ -977,7 +997,7 @@ export function CityAboutContent({
             <DataSource
               name="CGWB Ground Water Year Book of Tamil Nadu &amp; Puducherry"
               url="https://cgwb.gov.in/cgwbpnm/search?type=2&cat_id=4&state_id=33"
-              description="Peer-reviewed quarterly depth-to-water-level readings (May / Aug / Nov / Jan) at 21 dug-well stations in Madurai district, sourced from the 2023-24 and 2024-25 Year Books. Replaces an IDW-interpolated ward depth choropleth - Madurai's live WRIS network is too sparse (4 stations) for honest per-ward synthesis. Stitched into a 2-year time series stored in public/data/madurai-cgwb-stations.json."
+              description="Peer-reviewed quarterly depth-to-water-level readings (May / Aug / Nov / Jan) at 21 dug-well stations in Madurai district, sourced from the 2023-24 and 2024-25 Year Books. Replaces an IDW-interpolated ward depth choropleth - Madurai's live WRIS network is too sparse (4 stations) for honest per-ward synthesis. Stitched into a 2-year per-station time series."
               frequency="annual (per Year Book release)"
             />
           )}
@@ -1000,6 +1020,17 @@ export function CityAboutContent({
                 url="https://wellabs.org/"
                 description="Independent academic-grade water balance for Greater Bengaluru: rainfall, runoff, recharge, demand, supply gap, source-mix accounting. Used as a cross-check against JICA Phase 3 numbers; cited in `bangalore-supply-overview.json._secondary_local_source`."
                 frequency="periodic (per WELL Labs release)"
+              />
+            </>
+          )}
+
+          {isMumbai && (
+            <>
+              <DataSource
+                name="CGWB Ground Water Year Book of Maharashtra"
+                url="https://cgwb.gov.in/cgwbpnm/publication-detail"
+                description="~53 National Hydrograph Network wells across Mumbai / Thane / Palghar / Raigad transcribed from the Year Book to January 2025, with water chemistry (EC, chloride, nitrate) - the honest signal for a city excluded from the Dynamic Assessment. India-WRIS also lists ~24 manual wells for the city, but they end in May 2023; we document them rather than plot a stale layer."
+                frequency="annual (per Year Book release)"
               />
             </>
           )}
@@ -1044,7 +1075,7 @@ export function CityAboutContent({
               <DataSource
                 name="OSM bbox extract - 1,897 water-body polygons (BBMP)"
                 url="https://www.openstreetmap.org/"
-                description="OpenStreetMap community-mapped water bodies across BBMP, fetched via Overpass bbox query and committed to public/geojson/bangalore-water-bodies-current.geojson. 1,033 polygons larger than 1 ha become cascade nodes in the round-10 reconstruction; the rest are sub-hectare ponds."
+                description="OpenStreetMap community-mapped water bodies across BBMP, fetched via Overpass bbox query. 1,033 polygons larger than 1 ha become cascade nodes in the round-10 reconstruction; the rest are sub-hectare ponds."
                 frequency="periodic (manual refresh)"
               />
               <DataSource
@@ -1073,9 +1104,26 @@ export function CityAboutContent({
               />
               <DataSource
                 name="Cascade reconstruction (terrain-derived + Layer B curation)"
-                url={`/${config.cityId}/cascades`}
-                description="HydroSHEDS conditioned DEM + D8 flow direction + multi-outflow scoring produces 1,033 cascade nodes / 1,053 edges / 43 river outlets / max depth 11 for the BBMP-wide cascade graph. Layer B curation today: 4 named chains (K&amp;C foam cascade with NGT Forward Foundation anchor / Yelahanka-Hebbal north restoration model with JNNURM Jakkur anchor / Vrishabhavathi headwaters with 1894 Hesaraghatta anchor / Kempegowda old-city heritage fragments). 76 auto-derived chains scored LOW priority pending further Layer B."
+                url={`/${config.cityId}/water-bodies?mode=catchments`}
+                description="HydroSHEDS conditioned DEM + D8 flow direction + multi-outflow scoring produces 1,033 cascade nodes / 1,053 edges / 43 river outlets / max depth 11 for the BBMP-wide cascade graph. Layer B curation today: 4 named chains (K&amp;C foam cascade with NGT Forward Foundation anchor / Yelahanka-Hebbal north restoration model with JNNURM Jakkur anchor / Vrishabhavathi headwaters with 1894 Hesaraghatta anchor / Kempegowda old-city heritage fragments). 76 auto-derived chains scored LOW priority pending further Layer B. Lives as the Catchments view on the water-bodies page."
                 frequency="manual (regenerate after curation updates)"
+              />
+            </>
+          )}
+
+          {isMumbai && (
+            <>
+              <DataSource
+                name="Bombay HC / NGT water-body orders (LawBeat, SANDRP, Live Law)"
+                url={`/${config.cityId}/lake-restoration`}
+                description="Six court anchors curated from legal reporting: the NGT Powai sewage matter (a recommended Rs 5 lakh-per-inlet monthly penalty on BMC), the Banganga Talao immersion refusal, the statewide artificial-ponds immersion order, Lotus Lake (Nerul) protection, the NRI-wetland golf-course reclamation ban, and the Goregaon wetland landfilling notices."
+                frequency="incident-driven (court orders)"
+              />
+              <DataSource
+                name="Lake catchment atlas (FABDEM terrain derivation)"
+                url={`/${config.cityId}/water-bodies?mode=catchments`}
+                description="Forest-and-buildings-removed DEM (FABDEM) + flow-direction analysis derives each BMC lake's contributing catchment - the same pipeline as the other cities. Lives as the Catchments view on the water-bodies page."
+                frequency="static (regenerate on pipeline updates)"
               />
             </>
           )}
@@ -1126,7 +1174,7 @@ export function CityAboutContent({
               <DataSource
                 name="KSPCB / CPCB river quality monitoring"
                 url="https://kspcb.karnataka.gov.in/"
-                description="9 stations across the 3 Bengaluru rivers (Vrishabhavathi / Arkavati / Dakshina Pinakini) extracted from KSPCB monthly water quality reports cross-referenced with CPCB NWMP annual River Water Quality reports. Per-station BOD / COD / DO / pH / fecal coliform readings, 2020-2024 covered. Caveat: OSM polylines for these rivers are partial through built-up BBMP (urban segment flows as storm drains); 8 of 9 sampling stations carry an off_osm_river_polyline flag because they sit at named city places where OSM doesn't trace the river - documented in scripts/snap-river-stations.py."
+                description="9 stations across the 3 Bengaluru rivers (Vrishabhavathi / Arkavati / Dakshina Pinakini) extracted from KSPCB monthly water quality reports cross-referenced with CPCB NWMP annual River Water Quality reports. Per-station BOD / COD / DO / pH / fecal coliform readings, 2020-2024 covered. Caveat: OSM polylines for these rivers are partial through built-up BBMP (urban segment flows as storm drains); 8 of 9 sampling stations carry an off_osm_river_polyline flag because they sit at named city places where OSM doesn't trace the river."
                 frequency="monthly (KSPCB) + annual (CPCB)"
               />
               <DataSource
@@ -1156,6 +1204,23 @@ export function CityAboutContent({
             </>
           )}
 
+          {isMumbai && (
+            <>
+              <DataSource
+                name="MPCB annual Water Quality Status reports"
+                url="https://mpcb.gov.in/water-quality"
+                description="Five editions mined (the 2019-20 report was never published - a named gap). Powers the Mithi BOD series at station 2168: 45.3 -> 18.3 -> 28.2 -> 37.3 -> 53.0 mg/l annual averages to 2023-24 (WQI 32), and the consistently clean Ulhas mainstem. The Waldhuni has no MPCB station at all - no public series exists. Fecal-coliform units are inconsistent across editions, so we treat FC as directional only."
+                frequency="annual"
+              />
+              <DataSource
+                name="CPCB Polluted River Stretches for Restoration - 2025"
+                url="https://cpcb.nic.in/water-quality-data/"
+                description="The October 2025 national PRS list (on 2022-23 data): the Mithi at Mahim is Priority I with max BOD 210 mg/l - India's single worst river stretch. The Ulhas is Priority V (least severe). Dahisar, Poisar, Oshiwara and Waldhuni do not appear in the national list."
+                frequency="periodic (PRS assessment cycles)"
+              />
+            </>
+          )}
+
           <DataSourceGroupHeader title="Flood &amp; civic infrastructure" />
           {isMadurai ? (
             <DataSource
@@ -1169,13 +1234,13 @@ export function CityAboutContent({
               <DataSource
                 name="BWSSB sewerage trunk network (14,121 km)"
                 url={`/${config.cityId}/water-bodies`}
-                description="14,121 km of mapped underground sewerage trunks feeding the 39 BWSSB STPs, extracted from a BWSSB GIS source and shipped as public/geojson/bangalore-sewerage-trunks.geojson. Gravity-fed except across the ridge between valleys, where pumping stations lift to the next basin."
+                description="14,121 km of mapped underground sewerage trunks feeding the 39 BWSSB STPs, extracted from a BWSSB GIS source. Gravity-fed except across the ridge between valleys, where pumping stations lift to the next basin."
                 frequency="static (manual refresh)"
               />
               <DataSource
                 name="BWSSB STP inventory (39 plants)"
                 url={`/${config.cityId}/water-bodies`}
-                description="39 STPs as of 2024 (vs 14 at the JICA Phase 3 baseline in 2017) with locations + design capacity in public/geojson/bangalore-stps.geojson. Aggregate installed capacity ~1,500 MLD against ~1,400 MLD generation; the treatment-meets-generation milestone disguises persistent KSPCB compliance gaps at older plants."
+                description="39 STPs as of 2024 (vs 14 at the JICA Phase 3 baseline in 2017) with locations + design capacity. Aggregate installed capacity ~1,500 MLD against ~1,400 MLD generation; the treatment-meets-generation milestone disguises persistent KSPCB compliance gaps at older plants."
                 frequency="static (manual refresh)"
               />
               <DataSource
@@ -1185,37 +1250,88 @@ export function CityAboutContent({
                 frequency="data gap"
               />
             </>
-          ) : (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Civic-infrastructure layers (drainage / sewerage / flood hazard) are city-specific. See Chennai&apos;s about page for the canonical layer registry.
-            </p>
+          ) : isMumbai ? (
+            <>
+              <DataSource
+                name="BMC Disaster Management - chronic flood-spot register"
+                url={`/${config.cityId}/flood-risk`}
+                description="BMC's own register of monitored waterlogging spots, refreshed weekly in season. 110 spots carry locations; the full pre-monsoon list (496 in 2026, grown from 386 in 2024) is published only as counts - the ward-wise list is an RTI follow-up. No other MMR corporation publishes an equivalent register (a named gap on the flood page)."
+                frequency="weekly (in-season register scrape)"
+              />
+              <DataSource
+                name="Maharashtra WRD red/blue flood-line map sheets"
+                url="https://wrd.maharashtra.gov.in/Site/1315/Flood-Line-Maps"
+                description="The legal river-floodplain boundaries (blue = 25-year level, construction prohibited; red = 100-year, restricted): 41 sheets covering 6 MMR rivers including the Ulhas 0-84 km flood corridor, from WRD's 494-sheet statewide list. Scanned A0 plots, not georeferenced - linked as cited documents; georeferencing into a map overlay is a logged follow-up. BMC publishes no equivalent for the city's own rivers (Mithi, Dahisar, Poisar, Oshiwara)."
+                frequency="static (official map sheets)"
+              />
+              <DataSource
+                name="Chitale Fact-Finding Committee - 26/7/2005 record"
+                url={`/${config.cityId}/flood-risk`}
+                description="The official inquiry into the 26 July 2005 deluge (944 mm in 24 hours) anchors the reference layer. Point coordinates are estimated locality centroids - no reviewed source publishes exact coordinates, and no official GIS inundation extent is public."
+                frequency="static (historical record)"
+              />
+              <DataSource
+                name="iFLOWS-Mumbai (documented transparency gap)"
+                url={`/${config.cityId}/flood-risk`}
+                description="The Mumbai flood-forecast model built with public money briefs officials only - no public dashboard, API or archive. Documented as a transparency gap rather than silently omitted."
+                frequency="data gap"
+              />
+            </>
+          ) : null}
+
+          <DataSourceGroupHeader title={isMadurai ? "Satellite & remote sensing (planned)" : "Satellite & remote sensing"} />
+          {isMadurai && (
+            <>
+              <DataSource
+                name="JRC Global Surface Water (Monthly Recurrence)"
+                url="https://developers.google.com/earth-engine/datasets/catalog/JRC_GSW1_4_MonthlyRecurrence"
+                description="Per-water-body wet/dry history from satellite. Pipeline ready; data layer pending for Madurai's 19 flagships."
+                frequency="historical monthly"
+              />
+              <DataSource
+                name="Copernicus Sentinel-2 (via Earth Engine)"
+                url="https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED"
+                description="NDWI thumbnails + change detection per flagship. Pending for Madurai."
+                frequency="periodic"
+              />
+              <DataSource
+                name="HydroBASINS / MERIT Hydro"
+                url="https://www.hydrosheds.org/products/hydrobasins"
+                description="Catchment polygons for Vaigai dam and its sub-basins, used to ground catchment-rainfall context. Pending wiring for Madurai."
+                frequency="static"
+              />
+            </>
+          )}
+          {isBangalore && (
+            <DataSource
+              name="Google Earth Engine layers (shipped in the rich-lake panels)"
+              url={`/${config.cityId}/water-bodies`}
+              description="Already live for the 14-lake rich cohort rather than planned: 37-year yearly imagery sliders (Landsat + Sentinel-2, 1990-2026), JRC Global Surface Water loss tint (1988-92 vs 2017-21), Dynamic World water-class extension (2022-now) and built-gain tint (2016-18 vs 2023-25), plus Open Buildings and Overture building stats per lake halo."
+              frequency="periodic (per cohort round)"
+            />
+          )}
+          {isMumbai && (
+            <DataSource
+              name="GEE MNDWI shoreline transects (Landsat + Sentinel-2)"
+              url={`/${config.cityId}/shoreline`}
+              description="Our own west-coast shoreline-change measurement, 1990-2026: MNDWI water-index shorelines from annual dry-season composites, sampled along fixed transects. Corroborated against the published record (NCCR's 1990-2016 district table; Maharashtra Shoreline Management Plan 2017 risk grades) because no rate-publishing paper exists for Mumbai. Mumbai's ~3-5 m spring tides add positional noise Chennai's microtidal coast lacks - the page says to lean on the pattern, not single-transect absolutes."
+              frequency="yearly (post dry-season)"
+            />
           )}
 
-          <DataSourceGroupHeader title="Satellite &amp; remote sensing (planned)" />
-          <DataSource
-            name="JRC Global Surface Water (Monthly Recurrence)"
-            url="https://developers.google.com/earth-engine/datasets/catalog/JRC_GSW1_4_MonthlyRecurrence"
-            description="Per-water-body wet/dry history from satellite. Pipeline ready; data layer pending for Madurai's 19 flagships."
-            frequency="historical monthly"
-          />
-          <DataSource
-            name="Copernicus Sentinel-2 (via Earth Engine)"
-            url="https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED"
-            description="NDWI thumbnails + change detection per flagship. Pending for Madurai."
-            frequency="periodic"
-          />
-          <DataSource
-            name="HydroBASINS / MERIT Hydro"
-            url="https://www.hydrosheds.org/products/hydrobasins"
-            description="Catchment polygons for Vaigai dam and its sub-basins, used to ground catchment-rainfall context. Pending wiring for Madurai."
-            frequency="static"
-          />
-
           <DataSourceGroupHeader title="Base geometry &amp; AI" />
+          {isMumbai && (
+            <DataSource
+              name="DataMeet - Mumbai administrative-ward boundaries"
+              url="https://datameet.org/"
+              description="The 24 BMC administrative-ward polygons (2023 vintage) that anchor ward-level joins, plus the 2024 corporation boundaries for the nine-corporation regional view. The other eight corporations' wards have no known public geometry (State Election Commission delimitation PDFs only) - a named gap."
+              frequency="static"
+            />
+          )}
           <DataSource
             name="Anthropic Claude API"
             url="https://docs.anthropic.com/"
-            description="AI city narratives and per-ward profiles. Pending for Madurai."
+            description={`AI city narratives and per-ward profiles. Live for Chennai; pending for ${cityName}.`}
             frequency="daily / monthly"
           />
           </>
@@ -1256,7 +1372,7 @@ export function CityAboutContent({
               </p>
             )}
             <p className="text-xs text-slate-500 dark:text-slate-400 mt-2 italic">
-              Methodology lives in <span className="font-mono">src/lib/utils/river-classification.ts</span>; readings are from CPCB NWMP annual River Water Quality reports.
+              Status thresholds follow CPCB&apos;s published Designated Best-Use criteria; readings are from CPCB NWMP annual River Water Quality reports.
             </p>
           </SubSection>
 

--- a/src/app/[cityId]/about/mumbai-page-descriptions.tsx
+++ b/src/app/[cityId]/about/mumbai-page-descriptions.tsx
@@ -10,7 +10,6 @@
  * baseline.
  */
 
-import Link from "next/link";
 
 function SubSection({
   id,
@@ -275,13 +274,8 @@ export function MumbaiPageDescriptions({ cityId, cityName }: Props) {
           repository manifest.
         </p>
         <p className="text-xs text-slate-500 dark:text-slate-400 italic">
-          See also the dedicated Chennai about page (
-          <Link href="/about" className="text-blue-600 dark:text-blue-400 hover:underline">
-            /about
-          </Link>
-          ) for the canonical methodology pattern this follows. My Ward is the one page still in
-          build for {cityName}; it will be documented here when it ships. Linked
-          from <Link href={`/${cityId}/facts`} className="text-blue-600 dark:text-blue-400 hover:underline">{`/${cityId}/facts`}</Link>.
+          My Ward is the one page still in build for {cityName}; it will be documented here when
+          it ships.
         </p>
       </SubSection>
     </>

--- a/src/app/[cityId]/climate-risk/climate-risk-content.tsx
+++ b/src/app/[cityId]/climate-risk/climate-risk-content.tsx
@@ -114,7 +114,7 @@ function ClimateRiskContentInner({ cityId }: { cityId: string }) {
               })}
             />
           </div>
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="max-w-[300px] space-y-2.5">
               <div className="text-xs font-semibold text-slate-700 dark:text-slate-200">
                 {t("climate.info_title")}

--- a/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
+++ b/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
@@ -205,8 +205,12 @@ export function FloodRiskMumbaiContent({ cityDisplayName }: Props) {
               <li>
                 <strong>No regional flood-spot inventory beyond BMC.</strong> The eastern Ulhas/
                 Waldhuni corridor (Ulhasnagar, Kalyan-Dombivli, Ambernath, Badlapur) and Vasai-Virar
-                flood chronically, but the other corporations publish no equivalent spot list, so
-                only Greater Mumbai is mapped here.
+                flood chronically, but the other corporations publish no equivalent list of observed
+                waterlogging spots, so only Greater Mumbai&apos;s points are mapped here. The state
+                flood-line sheets below are a different kind of record: legal river-floodplain
+                boundaries (where a 25-year or 100-year flood <em>would</em> reach), not registers
+                of where flooding recurs - the two complement rather than substitute for each
+                other.
               </li>
             </ul>
           </section>

--- a/src/app/[cityId]/flood-risk/interactive-flood-content.tsx
+++ b/src/app/[cityId]/flood-risk/interactive-flood-content.tsx
@@ -212,7 +212,7 @@ function InteractiveFloodContentInner({ cityId }: { cityId: string }) {
               })}
             />
           </div>
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="text-xs text-slate-500 dark:text-slate-400 max-w-[260px]">
               {t("flood.source_flood")}{" "}
               <span className="font-semibold text-slate-700 dark:text-slate-300">

--- a/src/app/[cityId]/flood-risk/page.tsx
+++ b/src/app/[cityId]/flood-risk/page.tsx
@@ -14,13 +14,29 @@ interface PageProps {
   params: Promise<{ cityId: string }>;
 }
 
+// Per-city SEO description - the fallback must stay city-neutral (the old
+// Madurai-specific "Vaigai dam release thresholds" text leaked into every
+// other city's search snippet).
+const FLOOD_META_DESC: Record<string, string> = {
+  chennai:
+    "Chennai flood risk - interactive ward map, historical floods, drainage and encroachment layers.",
+  madurai:
+    "Vaigai dam release thresholds, historical floods, and external monitoring sources for Madurai.",
+  bangalore:
+    "Bengaluru flood risk - KSRSAC flood hotspots, rajakaluve drainage network, and historical inundation.",
+  mumbai:
+    "Mumbai flood risk - BMC chronic-flooding register, the 26/7/2005 reference layer, and WRD red/blue flood-line sheets.",
+};
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { cityId } = await params;
   const config = tryGetPlaceConfig(cityId);
   if (!config) return { title: "Flood Risk | Neer Vazhvu" };
   return {
     title: `${config.displayName} Flood Risk | Neer Vazhvu`,
-    description: `Vaigai dam release thresholds, historical floods, and external monitoring sources for ${config.displayName}.`,
+    description:
+      FLOOD_META_DESC[cityId] ??
+      `Flood risk, historical floods, and monitoring sources for ${config.displayName}.`,
     alternates: { canonical: `/${cityId}/flood-risk` },
   };
 }

--- a/src/app/[cityId]/groundwater/chennai-groundwater-client.tsx
+++ b/src/app/[cityId]/groundwater/chennai-groundwater-client.tsx
@@ -224,7 +224,7 @@ function GroundwaterPageContent() {
         </div>
 
         {/* Period + source overlay */}
-        <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+        <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
           {viewMode === "exploitation" ? (
             <div className="text-xs text-slate-500 dark:text-slate-400">
               {t("gw_page.source_cgwb")}

--- a/src/app/[cityId]/groundwater/groundwater-client.tsx
+++ b/src/app/[cityId]/groundwater/groundwater-client.tsx
@@ -518,7 +518,7 @@ export default function CityGroundwaterClient({
           )}
 
           {/* Info pill - source + ward-level gap call-out */}
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="text-xs text-slate-500 dark:text-slate-400 space-y-1">
               <div>
                 <span className="font-semibold text-slate-700 dark:text-slate-300">{config.displayName}</span>{" "}

--- a/src/app/[cityId]/lake-restoration/lake-restoration-content.tsx
+++ b/src/app/[cityId]/lake-restoration/lake-restoration-content.tsx
@@ -66,7 +66,12 @@ export interface CourtOrder {
   writ_petition: string;
   court: string;
   date: string;
-  directive: string;
+  /** Madurai-style: completes "{court} directed the TN Government to {directive}".
+   *  Use `ruling` instead wherever that TN-specific frame doesn't fit. */
+  directive?: string;
+  /** Self-contained ruling sentence, rendered as "{court}: {ruling}".
+   *  The Mumbai orders use this - respondents vary (BMC, NMMC, statewide). */
+  ruling?: string;
   specific_tanks: string[];
   concern: string;
   source: string;
@@ -213,10 +218,24 @@ export function LakeRestorationContent({
             </div>
             <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{order.case}</h2>
             <p className="text-sm text-slate-700 dark:text-slate-300">
-              <span className="font-semibold">{order.court}</span> {t("lake.directed_to")}{" "}
-              {order.directive}. {t("lake.petition_filed")}{" "}
-              <span className="italic">{order.concern}</span> {t("lake.at_word")}{" "}
-              {order.specific_tanks.join(", ")}.
+              {order.ruling ? (
+                <>
+                  <span className="font-semibold">{order.court}</span>: {order.ruling}{" "}
+                </>
+              ) : (
+                <>
+                  <span className="font-semibold">{order.court}</span> {t("lake.directed_to")}{" "}
+                  {order.directive}.{" "}
+                </>
+              )}
+              {t("lake.petition_filed")} <span className="italic">{order.concern}</span>
+              {order.specific_tanks.length > 0 && (
+                <>
+                  {" "}
+                  {t("lake.at_word")} {order.specific_tanks.join(", ")}
+                </>
+              )}
+              .
             </p>
             <a href={order.source} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
               {t("lake.lawbeat_coverage")} →

--- a/src/app/[cityId]/rivers/chennai-rivers-client.tsx
+++ b/src/app/[cityId]/rivers/chennai-rivers-client.tsx
@@ -265,7 +265,7 @@ function RiversPageContent({ cityId, cityDisplayName, mapCenter, mapZoom, basin 
           </div>
 
           {/* Source note overlay */}
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="text-xs text-slate-500 dark:text-slate-400">
               {t("rivers_page.quality_label")}{" "}
               <a

--- a/src/app/[cityId]/rivers/page.tsx
+++ b/src/app/[cityId]/rivers/page.tsx
@@ -22,13 +22,29 @@ interface PageProps {
   params: Promise<{ cityId: string }>;
 }
 
+// Per-city SEO description - the fallback must stay city-neutral (the old
+// Madurai-specific text leaked "Vaigai / Mullaperiyar" into every other
+// city's search snippet).
+const RIVERS_META_DESC: Record<string, string> = {
+  chennai:
+    "River-system map for Chennai - Adyar, Cooum and Kosasthalaiyar, with pollution status from official monitoring.",
+  madurai:
+    "River-system map for Madurai - Vaigai mainstem, tributaries, and the cross-state Mullaperiyar feeder.",
+  bangalore:
+    "River-system map for Bengaluru - Vrishabhavathi, Arkavathi and the Cauvery lifeline, with pollution status from official monitoring.",
+  mumbai:
+    "River-system map for Mumbai - Mithi, Dahisar, Poisar, Oshiwara and the regional Ulhas, with MPCB water-quality status.",
+};
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { cityId } = await params;
   const config = tryGetPlaceConfig(cityId);
   if (!config) return { title: "Rivers | Neer Vazhvu" };
   return {
     title: `${config.displayName} Rivers | Neer Vazhvu`,
-    description: `River-system map for ${config.displayName} - Vaigai mainstem, tributaries, and the cross-state Mullaperiyar feeder.`,
+    description:
+      RIVERS_META_DESC[cityId] ??
+      `River-system map for ${config.displayName} - mainstem rivers, tributaries, and pollution status from official monitoring.`,
     alternates: { canonical: `/${cityId}/rivers` },
   };
 }

--- a/src/app/[cityId]/shoreline/coastal-client.tsx
+++ b/src/app/[cityId]/shoreline/coastal-client.tsx
@@ -100,11 +100,11 @@ const CITY_COPY: Record<string, CoastalCityCopy> = {
 };
 
 export default function CoastalClient({ cityId = "chennai" }: { cityId?: string }) {
-  // No entry -> render nothing rather than fall back to another city's
-  // coastal copy and statistics. FEATURE_AVAILABILITY gates this page to
-  // cities with an entry, so this only fires on a config mistake.
-  const copy = CITY_COPY[cityId];
-  if (!copy) return null;
+  // No entry -> render nothing (after the hooks - hooks must run
+  // unconditionally) rather than fall back to another city's coastal copy
+  // and statistics. FEATURE_AVAILABILITY gates this page to cities with an
+  // entry, so this only fires on a config mistake.
+  const copy: (typeof CITY_COPY)[string] | undefined = CITY_COPY[cityId];
   useLockBodyScroll();
   const [selected, setSelected] = useState<SelectedCoastal | null>(null);
   const [summary, setSummary] = useState<CoastalSummary | null>(null);
@@ -115,6 +115,8 @@ export default function CoastalClient({ cityId = "chennai" }: { cityId?: string 
   // callback (not an effect), and only the first time; the user is in control
   // after that.
   const didAutoSelect = useRef(false);
+
+  if (!copy) return null;
   const handleSummary = (s: CoastalSummary) => {
     setSummary(s);
     if (!didAutoSelect.current && s.featured) {

--- a/src/app/[cityId]/shoreline/coastal-client.tsx
+++ b/src/app/[cityId]/shoreline/coastal-client.tsx
@@ -100,7 +100,11 @@ const CITY_COPY: Record<string, CoastalCityCopy> = {
 };
 
 export default function CoastalClient({ cityId = "chennai" }: { cityId?: string }) {
-  const copy = CITY_COPY[cityId] ?? CITY_COPY.chennai;
+  // No entry -> render nothing rather than fall back to another city's
+  // coastal copy and statistics. FEATURE_AVAILABILITY gates this page to
+  // cities with an entry, so this only fires on a config mistake.
+  const copy = CITY_COPY[cityId];
+  if (!copy) return null;
   useLockBodyScroll();
   const [selected, setSelected] = useState<SelectedCoastal | null>(null);
   const [summary, setSummary] = useState<CoastalSummary | null>(null);
@@ -182,7 +186,7 @@ export default function CoastalClient({ cityId = "chennai" }: { cityId?: string 
           </div>
 
           {/* Sources / honesty note */}
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="text-xs text-slate-500 dark:text-slate-400 space-y-1.5 max-w-xs">
               <div>
                 <span className="font-semibold text-slate-700 dark:text-slate-300">What you see:</span> each dot is a

--- a/src/app/[cityId]/water-bodies/rich-water-bodies-content.tsx
+++ b/src/app/[cityId]/water-bodies/rich-water-bodies-content.tsx
@@ -450,7 +450,7 @@ function WaterBodiesPageContent({ cityId }: { cityId: string }) {
                 })}
               />
             </div>
-            <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+            <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
               <div className="text-xs text-slate-500 dark:text-slate-400">
                 {t("wb.osm_source")}{" "}
                 <span className="font-semibold text-slate-700 dark:text-slate-300">

--- a/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
+++ b/src/app/[cityId]/water-bodies/water-bodies-map-client.tsx
@@ -340,7 +340,7 @@ export default function WaterBodiesMapClient({
           </div>
 
           {/* Map info button - sources */}
-          <MapInfoButton className="absolute top-2 left-2 sm:top-4 sm:left-4 z-[1000]">
+          <MapInfoButton className="absolute top-20 left-2.5 z-[1000]">
             <div className="text-xs text-slate-500 dark:text-slate-400 space-y-1">
               <div>
                 Polygons from <span className="font-semibold text-slate-700 dark:text-slate-300">OpenStreetMap</span>

--- a/src/components/cascade/cascade-methodology-section.tsx
+++ b/src/components/cascade/cascade-methodology-section.tsx
@@ -79,10 +79,10 @@ export function CascadeMethodologySection({
             See cascade health scores:
           </strong>{" "}
           <Link
-            href={`/${cityId}/cascades`}
+            href={`/${cityId}/water-bodies?mode=catchments`}
             className="text-blue-600 dark:text-blue-400 hover:underline"
           >
-            Tank cascades at risk - {cityDisplayName} &rarr;
+            The Catchments view on the water-bodies map &rarr;
           </Link>
           {" "}
           ranks every documented and auto-derived cascade by fragility +

--- a/src/components/cascade/catchment-methodology-section.tsx
+++ b/src/components/cascade/catchment-methodology-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import type { ReactNode } from "react";
 
 /**
@@ -15,8 +16,11 @@ import type { ReactNode } from "react";
  */
 export function CatchmentMethodologySection({
   cityDisplayName,
+  cityId,
 }: {
   cityDisplayName: string;
+  /** When set, "the Catchments view" becomes a link to it. */
+  cityId?: string;
 }): ReactNode {
   return (
     <div className="space-y-4 text-sm text-slate-700 dark:text-slate-300">
@@ -25,7 +29,18 @@ export function CatchmentMethodologySection({
         The <strong>catchment atlas</strong> answers the prior question:{" "}
         <strong>where does each lake&apos;s water come from</strong>. Every
         lake sits at the bottom of a catchment - the land whose rain drains
-        toward it. Click any lake on the Catchments view and we draw its area
+        toward it. Click any lake on the{" "}
+        {cityId ? (
+          <Link
+            href={`/${cityId}/water-bodies?mode=catchments`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Catchments view
+          </Link>
+        ) : (
+          "Catchments view"
+        )}{" "}
+        and we draw its area
         of influence: the catchment polygon, the feeder streams inside it, the
         tanks upstream and downstream, and where its overflow finally reaches a
         river.

--- a/src/components/dashboard/groundwater-snapshot.tsx
+++ b/src/components/dashboard/groundwater-snapshot.tsx
@@ -77,6 +77,9 @@ export function GroundwaterSnapshot({ data, exploreHref = "/groundwater" }: Grou
             <span className="font-semibold">{t("gw_snap.stale_title")}</span>{" "}
             {t("gw_snap.stale_msg")
               .replace("{date}", `${dataDate.toLocaleString("default", { month: "short" })} ${period.year}`)
+              // Chennai-only attribution: this component is gated by
+              // dashboard.groundwaterSnapshot, which only chennai.ts sets.
+              // Parameterize this string before enabling another city.
               .replace("{source}", "OpenCity / CMWSSB")}
           </div>
         )}

--- a/src/components/flood-risk/flood-detail-panel.tsx
+++ b/src/components/flood-risk/flood-detail-panel.tsx
@@ -363,6 +363,9 @@ function STPContent({ props }: { props: STPProperties }) {
         </div>
       )}
       <p className="text-xs text-slate-400 dark:text-slate-500">
+{/* CMWSSB attribution is correct only for Chennai's geojson. This panel
+            renders only for flood.variant === 'interactive' (chennai.ts today);
+            parameterize these source lines before another city adopts it. */}
         Source: CMWSSB Sewerage Collection System
       </p>
       <ConnectedInsight

--- a/src/components/insights/connected-insight.tsx
+++ b/src/components/insights/connected-insight.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useLanguage } from "@/lib/i18n/context";
+import { parsePath } from "@/lib/cities/routing";
 import { interpolate } from "@/lib/utils/format";
 
 interface ConnectedInsightProps {
@@ -34,6 +36,19 @@ export function ConnectedInsight({
   onAction,
 }: ConnectedInsightProps) {
   const { t } = useLanguage();
+  const pathname = usePathname();
+
+  // Call sites pass Chennai-flat paths ("/water-bodies", "/groundwater?ward=..").
+  // Rewrite them for the city we're actually on, or a Bengaluru/Mumbai reader
+  // clicking a connected link lands on Chennai's page. Hash-only targets and
+  // scroll/callback modes never navigate, so they pass through untouched.
+  const { cityId } = parsePath(pathname);
+  const href =
+    cityId !== "chennai" && linkHref.startsWith("/")
+      ? linkHref === "/"
+        ? `/${cityId}`
+        : `/${cityId}${linkHref}`
+      : linkHref;
 
   const message = params
     ? interpolate(t(messageKey), params)
@@ -72,7 +87,7 @@ export function ConnectedInsight({
             {message}
           </p>
           <Link
-            href={linkHref}
+            href={href}
             onClick={handleClick}
             className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium inline-flex items-center gap-1 mt-1"
           >

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -395,7 +395,7 @@ export const translations: Record<string, TranslationEntry> = {
   "lake.cross_water_bodies": { en: "Water bodies map", ta: "நீர்நிலைகள் வரைபடம்", kn: "ಜಲಮೂಲಗಳ ನಕ್ಷೆ" },
   "lake.cross_water_bodies_desc": { en: "Interactive map of the city's water bodies", ta: "நகரின் நீர்நிலைகளின் ஊடாடும் வரைபடம்", kn: "ನಗರದ ಜಲಮೂಲಗಳ ಸಂವಾದಾತ್ಮಕ ನಕ್ಷೆ" },
   "lake.cross_home": { en: "home", ta: "முகப்பு", kn: "ಮುಖಪುಟ" },
-  "lake.cross_home_desc": { en: "Reservoirs, days-of-water-left, Mullaperiyar tracker", ta: "நீர்த்தேக்கங்கள், மீதமுள்ள நீர் நாட்கள், முல்லைப் பெரியார் கண்காணிப்பு", kn: "ಜಲಾಶಯಗಳು, ಉಳಿದ-ನೀರಿನ-ದಿನಗಳು, ಮುಲ್ಲೈಪೆರಿಯಾರ್ ಟ್ರ್ಯಾಕರ್" },
+  "lake.cross_home_desc": { en: "Live reservoir storage and the supply picture at a glance", ta: "நேரடி நீர்த்தேக்க சேமிப்பு மற்றும் நீர் வழங்கல் நிலை ஒரே பார்வையில்", kn: "ನೇರ ಜಲಾಶಯ ಸಂಗ್ರಹ ಮತ್ತು ಪೂರೈಕೆ ಚಿತ್ರಣ ಒಂದೇ ನೋಟದಲ್ಲಿ" },
   "lake.methodology": { en: "Methodology:", ta: "முறையியல்:", kn: "ವಿಧಾನ:" },
   "lake.methodology_text":      {
     en: "Lost-tank list curated from Vencatesan's academic inventory of dying urban tanks. Flagship cards hand-sourced from Wikipedia, INTACH, India Water Portal, Columbia GSAPP's Water Urbanism studio, IAS Gateway, and news reports - confidence flagged per row. Restoration programmes from MMC, TN PWD, Smart City, World Bank, and DHAN Vayalagam public materials.",


### PR DESCRIPTION
Grew from the cross-city leak audit into four related quality fixes, all browser-verified.

## 1. Cross-city leak audit (54-page browser sweep + code-pattern pass)

**Live leaks fixed:**
- **ConnectedInsight links were Chennai-flat everywhere** (~10 sites in the shared rivers/water-bodies/flood/groundwater detail panels) - fixed once in the shared component; links rewrite for the city you're on.
- **SEO metadata was Madurai's for all cities** - every rivers page said "Vaigai mainstem... Mullaperiyar feeder", every flood page "Vaigai dam release thresholds". Now city-keyed with neutral fallbacks.
- **Court-order template** rendered "Bombay High Court directed the TN Government to Refused immersion..." on Mumbai; orders can now carry a self-contained `ruling` (Mumbai's 6 migrated), and the dangling "at ." for orders naming no water body is guarded.
- lake-restoration cross-link said "Mullaperiyar tracker" on every city (now city-neutral en/ta/kn); Mumbai about carried repo-speak linking Chennai's /about (removed).

**Latent hardening:** shoreline `?? CITY_COPY.chennai` fallback → self-hide; guard comments on the two Chennai-only CMWSSB attributions. Deliberate cross-city copy (landing cards, comparative notes, Mekedatu politics) left alone and documented.

## 2. Map UX: (i) button vs zoom control

The info button sat directly on Leaflet's +/- control on every map, leaving less technical readers no visible zoom affordance. Moved below the control at all 8 call sites; DOM-measured on 13 map pages (zoom [10,74]px, info [80,112]px, zero overlap).

## 3. About-page data layer (per review)

- **Mumbai's empty groups filled**: Reservoir & weather (Pravah bulletin, CWC 2015-2025 backfill), Groundwater (CGWB Maharashtra Year Book wells; the generic Dynamic-GWR entry now states Mumbai's exclusion from the assessment), Water bodies (court-order register, FABDEM catchments), Rivers & pollution (MPCB WQ series incl. the never-published 2019-20 edition, CPCB PRS 2025 with the Mithi as India's worst stretch), Flood (BMC register, WRD red/blue flood-line sheets, Chitale 26/7 record, iFLOWS transparency gap), plus MNDWI shoreline and DataMeet geometry entries.
- **"See Chennai's about page" placeholder** and **"Pending for Madurai"** strings (which showed on every city) replaced with city-correct content; the Satellite group is "(planned)" only for Madurai - Bengaluru's entry now describes its shipped GEE layers.
- **Cascades**: the About page documents cascade methodology in detail while the capability lives as the Catchments view on water-bodies with no pointer - methodology sections and source entries now name and link the view directly.
- **Internal repo paths swept out of UI copy** (9 descriptions named scripts/, public/ or src/ files).

## 4. Flood-risk copy + CI workflow hardening

- Mumbai flood page: the "no spot list beyond BMC" gap immediately preceded the official WRD flood-line maps, reading as a contradiction; the paragraph now distinguishes observed-waterlogging registers from legal floodplain boundaries.
- All five artifact-committing workflows now `git pull --rebase` before push (the first Recent-rainfall run lost a push race to the concurrent flood-spots run).
- Coastal self-hide guard moved below the hooks (fixes the rules-of-hooks CI failure on this branch).

## Verification (playwright chromium, running app)

**Verdict: PASS** - zero page errors on fresh servers throughout.

1. ✅ /mumbai/rivers connected links now /mumbai/water-bodies; per-city SEO descriptions curl-verified on all 4 cities
2. ✅ /mumbai/lake-restoration: "TN Government" gone, rulings render, "at ." gone; Madurai template intact
3. ✅ Mumbai about (expanded): all 7 source groups populated (571-3,568 chars each); Pravah/MPCB/PRS/flood-lines/exclusion all present; Bengaluru + Madurai regressions clean; no repo paths in any city's rendered about
4. ✅ Catchments-view links render on the methodology sections (measured on Chennai)
5. ✅ Zoom/info overlap: DOM-measured zero overlap on 13 map pages, desktop + mobile screenshots
6. ✅ Gates: tsc, lint 0 errors (exit-code checked), data:check, 67/67 tests, production build