### PR TITLE
Data freshness: daily per-city staleness checks, auto-derived at onboarding

### DIFF
--- a/.github/workflows/data-freshness.yml
+++ b/.github/workflows/data-freshness.yml
@@ -1,0 +1,85 @@
+name: Data freshness check
+
+# Daily staleness sweep across every city's ingested feeds - reservoir
+# tables in Supabase, the provisional-rainfall artifacts, and the weekly
+# city-specific artifacts. Checks are DERIVED from the city configs by
+# scripts/check-data-freshness.ts, so a newly onboarded city is covered
+# automatically (and CI's data:check gate fails if its feeds aren't
+# checkable).
+#
+# Why this exists: individual scrape steps tolerate failures by design
+# (continue-on-error / skipped bulletins), so job conclusions read
+# "success" while data quietly ages - Chennai went 5 days stale behind
+# green runs in July 2026. This workflow is the alarm that fires on the
+# DATA, not the jobs.
+#
+# Runs after the morning pipelines (rainfall 02:45, Pravah 04:00, daily
+# pipeline 04:51 UTC) so a healthy morning reads fresh.
+
+on:
+  schedule:
+    - cron: '30 6 * * *'   # 06:30 UTC = 12:00 IST daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check data freshness
+        id: freshness
+        continue-on-error: true
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: npx tsx scripts/check-data-freshness.ts --check
+
+      - name: Alert on stale feeds
+        if: steps.freshness.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `Data freshness: stale feeds - ${today}`;
+            const report = fs.existsSync('freshness-report.md')
+              ? fs.readFileSync('freshness-report.md', 'utf-8')
+              : 'freshness-report.md missing - the checker itself errored; see the run log.';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'pipeline-alert',
+              state: 'open',
+            });
+            const existing = issues.find(i => i.title === title);
+            if (!existing) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: ['pipeline-alert', 'data-freshness'],
+                body: [
+                  report,
+                  '',
+                  `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                  '',
+                  'Known recovery: CMWSSB and Pravah both intermittently block GitHub',
+                  'runner IPs while responding normally from residential IPs - running the',
+                  'scraper locally recovers the day (see neer-vazhvu-api/scripts/).',
+                  '',
+                  'This issue is created once per day while feeds remain stale.',
+                ].join('\n'),
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "find src -name '*.test.ts' | xargs tsx --test",
     "test:watch": "find src -name '*.test.ts' | xargs tsx --test --watch",
     "i18n:check": "node scripts/check-i18n.mjs",
-    "data:check": "tsx scripts/check-restoration-data.ts"
+    "data:check": "tsx scripts/check-restoration-data.ts && tsx scripts/check-data-freshness.ts --validate"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/scripts/check-data-freshness.ts
+++ b/scripts/check-data-freshness.ts
@@ -1,0 +1,319 @@
+/**
+ * Data-freshness checks - per-city, derived from the city configs.
+ *
+ * Two modes:
+ *
+ *   npx tsx scripts/check-data-freshness.ts --validate
+ *     Registry-completeness gate, run in CI via `npm run data:check`.
+ *     Fails when a registered city has feeds the checker cannot derive
+ *     (missing rainfall artifact, unknown reservoir table, dangling
+ *     extra-feed entries). This is what makes freshness checks
+ *     AUTO-CREATED at city onboarding: the new city's PR cannot pass CI
+ *     until its feeds are checkable (or explicitly exempted below).
+ *
+ *   npx tsx scripts/check-data-freshness.ts --check
+ *     The actual staleness sweep, run daily by
+ *     .github/workflows/data-freshness.yml after the morning pipelines.
+ *     Queries Supabase for reservoir feeds and reads committed artifacts
+ *     for file feeds. Writes freshness-report.md and exits 1 when
+ *     anything is stale (the workflow turns that into a GitHub issue).
+ *
+ * Checks are DERIVED, not hand-listed:
+ *   - Reservoir feeds: every waterSource with hasPublicFeed !== false,
+ *     against reservoir_daily (legacy-v1, Chennai) or reservoir_daily_v2
+ *     (everyone else), per source_code for v2.
+ *   - Daily provisional rainfall: public/data/rainfall-recent-<city>.json
+ *     is REQUIRED for every registered city (generated_at must be fresh).
+ *   - Weekly / city-specific artifacts live in EXTRA_FEEDS - the one
+ *     place new non-uniform feeds are registered.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { resolve } from "path";
+import { listAllPlaces } from "../src/lib/cities";
+import type { PlaceConfig } from "../src/lib/cities/types";
+
+const ROOT = resolve(__dirname, "..");
+
+/* ── Cadence tolerances (days) ─────────────────────────────────────────── */
+// Reservoir bulletins skip days (Pravah's OFBiz errors, CMWSSB runner
+// blocks are tolerated up to the same threshold the pipeline itself uses).
+const RESERVOIR_MAX_AGE_DAYS = 4;
+const RAINFALL_MAX_AGE_DAYS = 2;
+
+/* ── Extra file feeds (weekly / city-specific artifacts) ───────────────── */
+// Register non-uniform feeds here. `dateFrom` supports a JSON field path
+// ("json:generated_at") or a regex over the raw file ("regex:<pattern>",
+// first capture group must be YYYY-MM-DD).
+interface ExtraFeed {
+  id: string;
+  cityId: string;
+  file: string;
+  maxAgeDays: number;
+  dateFrom: string;
+  note?: string;
+}
+const EXTRA_FEEDS: ExtraFeed[] = [
+  {
+    id: "bmc-flood-spots",
+    cityId: "mumbai",
+    file: "public/data/mumbai-flood-hotspots.geojson",
+    maxAgeDays: 9, // weekly (Mondays) + 2 days grace
+    dateFrom: "regex:fetched (\\d{4}-\\d{2}-\\d{2})",
+    note: "BMC DM register, weekly scrape",
+  },
+];
+
+// Cities allowed to skip a derived check, with the reason on record.
+// (Empty today - add `"<cityId>:<feedId>": "reason"` entries only when a
+// feed genuinely cannot exist for that city.)
+const EXEMPTIONS: Record<string, string> = {};
+
+/* ── Derivation ────────────────────────────────────────────────────────── */
+interface Check {
+  id: string;
+  cityId: string;
+  kind: "supabase-reservoir" | "file";
+  maxAgeDays: number;
+  // supabase-reservoir
+  table?: "reservoir_daily" | "reservoir_daily_v2";
+  sourceCode?: string;
+  // file
+  file?: string;
+  dateFrom?: string;
+  note?: string;
+}
+
+function deriveChecks(places: PlaceConfig[]): { checks: Check[]; problems: string[] } {
+  const checks: Check[] = [];
+  const problems: string[] = [];
+
+  for (const place of places) {
+    const cityId = place.cityId;
+
+    // 1. Reservoir feeds - one check per feed-backed source.
+    const feedSources = (place.waterSources ?? []).filter(
+      (s) => s.hasPublicFeed !== false,
+    );
+    const table =
+      place.reservoirDataSource === "legacy-v1"
+        ? "reservoir_daily"
+        : "reservoir_daily_v2";
+    if (feedSources.length > 0) {
+      if (table === "reservoir_daily") {
+        // Legacy table has no source_code column - one city-level check.
+        checks.push({
+          id: `${cityId}:reservoir`,
+          cityId,
+          kind: "supabase-reservoir",
+          table,
+          maxAgeDays: RESERVOIR_MAX_AGE_DAYS,
+          note: `${feedSources.length} reservoirs, legacy table`,
+        });
+      } else {
+        for (const s of feedSources) {
+          const key = `${cityId}:reservoir:${s.sourceCode}`;
+          if (EXEMPTIONS[key]) continue;
+          checks.push({
+            id: key,
+            cityId,
+            kind: "supabase-reservoir",
+            table,
+            sourceCode: s.sourceCode,
+            maxAgeDays: RESERVOIR_MAX_AGE_DAYS,
+            note: s.displayName,
+          });
+        }
+      }
+    }
+
+    // 2. Daily provisional rainfall - required for every registered city.
+    const rainfallKey = `${cityId}:rainfall-recent`;
+    const rainfallFile = `public/data/rainfall-recent-${cityId}.json`;
+    if (!EXEMPTIONS[rainfallKey]) {
+      if (!existsSync(resolve(ROOT, rainfallFile))) {
+        problems.push(
+          `${cityId}: missing ${rainfallFile} - wire the city into ` +
+            `fetch_recent_rainfall.py + rainfall-recent-refresh.yml, or add an ` +
+            `EXEMPTIONS entry ("${rainfallKey}") with the reason.`,
+        );
+      } else {
+        checks.push({
+          id: rainfallKey,
+          cityId,
+          kind: "file",
+          file: rainfallFile,
+          dateFrom: "json:generated_at",
+          maxAgeDays: RAINFALL_MAX_AGE_DAYS,
+          note: "Open-Meteo provisional daily fill",
+        });
+      }
+    }
+  }
+
+  // 3. Extra feeds.
+  const cityIds = new Set(places.map((p) => p.cityId));
+  for (const f of EXTRA_FEEDS) {
+    if (!cityIds.has(f.cityId)) {
+      problems.push(`extra feed ${f.id}: unknown cityId ${f.cityId}`);
+      continue;
+    }
+    if (!existsSync(resolve(ROOT, f.file))) {
+      problems.push(`extra feed ${f.id}: file not found: ${f.file}`);
+      continue;
+    }
+    checks.push({ ...f, kind: "file" });
+  }
+
+  return { checks, problems };
+}
+
+/* ── Date extraction for file feeds ────────────────────────────────────── */
+function extractFileDate(check: Check): string | null {
+  const raw = readFileSync(resolve(ROOT, check.file!), "utf-8");
+  const spec = check.dateFrom!;
+  if (spec.startsWith("json:")) {
+    const field = spec.slice(5);
+    const v = JSON.parse(raw)[field];
+    return typeof v === "string" ? v.slice(0, 10) : null;
+  }
+  if (spec.startsWith("regex:")) {
+    const m = raw.match(new RegExp(spec.slice(6)));
+    return m?.[1] ?? null;
+  }
+  return null;
+}
+
+/* ── Supabase (plain REST, no client dep) ──────────────────────────────── */
+function loadEnv(): { url: string; key: string } {
+  let url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  let key =
+    process.env.SUPABASE_SERVICE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if ((!url || !key) && existsSync(resolve(ROOT, ".env.local"))) {
+    for (const line of readFileSync(resolve(ROOT, ".env.local"), "utf-8").split("\n")) {
+      const i = line.indexOf("=");
+      if (i < 0 || line.startsWith("#")) continue;
+      const k = line.slice(0, i).trim();
+      const v = line.slice(i + 1).trim();
+      if (!url && (k === "SUPABASE_URL" || k === "NEXT_PUBLIC_SUPABASE_URL")) url = v;
+      if (!key && (k === "SUPABASE_SERVICE_KEY" || k === "NEXT_PUBLIC_SUPABASE_ANON_KEY"))
+        key = v;
+    }
+  }
+  if (!url || !key) {
+    console.error("Supabase env missing (SUPABASE_URL / SUPABASE_SERVICE_KEY).");
+    process.exit(2);
+  }
+  return { url, key };
+}
+
+async function latestReservoirDate(
+  env: { url: string; key: string },
+  check: Check,
+): Promise<string | null> {
+  const params =
+    check.table === "reservoir_daily"
+      ? `select=date&order=date.desc&limit=1`
+      : `select=date&city_id=eq.${check.cityId}&source_code=eq.${check.sourceCode}&order=date.desc&limit=1`;
+  const res = await fetch(`${env.url}/rest/v1/${check.table}?${params}`, {
+    headers: { apikey: env.key, Authorization: `Bearer ${env.key}` },
+  });
+  if (!res.ok) throw new Error(`supabase ${res.status} for ${check.id}`);
+  const rows = (await res.json()) as { date: string }[];
+  return rows[0]?.date ?? null;
+}
+
+/* ── Main ──────────────────────────────────────────────────────────────── */
+function ageDays(dateStr: string, now: Date): number {
+  return Math.floor((now.getTime() - new Date(dateStr + "T00:00:00Z").getTime()) / 86_400_000);
+}
+
+async function main() {
+  const mode = process.argv.includes("--check")
+    ? "check"
+    : process.argv.includes("--validate")
+      ? "validate"
+      : null;
+  if (!mode) {
+    console.error("Usage: check-data-freshness.ts --validate | --check");
+    process.exit(2);
+  }
+
+  const places = listAllPlaces();
+  const { checks, problems } = deriveChecks(places);
+
+  if (mode === "validate") {
+    console.log(`Freshness registry: ${checks.length} checks derived across ${places.length} cities.`);
+    for (const p of problems) console.error(`  FAIL: ${p}`);
+    if (problems.length) {
+      console.error(
+        "\nOnboarding a new city? Every registered city must have checkable feeds - " +
+          "see the header of scripts/check-data-freshness.ts.",
+      );
+      process.exit(1);
+    }
+    console.log("All cities have checkable feeds.");
+    return;
+  }
+
+  // --check
+  if (problems.length) {
+    // A broken registry is itself a staleness alert - report, don't hide.
+    console.error("Registry problems (fix via --validate):");
+    for (const p of problems) console.error(`  ${p}`);
+  }
+
+  const env = loadEnv();
+  const now = new Date();
+  type Row = { check: Check; last: string | null; age: number | null; stale: boolean; error?: string };
+  const rows: Row[] = [];
+
+  for (const check of checks) {
+    try {
+      const last =
+        check.kind === "file" ? extractFileDate(check) : await latestReservoirDate(env, check);
+      if (!last) {
+        rows.push({ check, last: null, age: null, stale: true, error: "no date found" });
+        continue;
+      }
+      const age = ageDays(last, now);
+      rows.push({ check, last, age, stale: age > check.maxAgeDays });
+    } catch (e) {
+      rows.push({ check, last: null, age: null, stale: true, error: String(e).slice(0, 120) });
+    }
+  }
+
+  const stale = rows.filter((r) => r.stale);
+  const lines: string[] = [];
+  lines.push(`## Data freshness - ${now.toISOString().slice(0, 10)}`);
+  lines.push("");
+  lines.push(
+    stale.length === 0
+      ? `All ${rows.length} feeds fresh.`
+      : `**${stale.length} of ${rows.length} feeds stale.**`,
+  );
+  lines.push("");
+  lines.push("| feed | city | last data | age (d) | max | status |");
+  lines.push("|---|---|---|---|---|---|");
+  for (const r of rows.sort((a, b) => Number(b.stale) - Number(a.stale))) {
+    lines.push(
+      `| ${r.check.id} | ${r.check.cityId} | ${r.last ?? "-"} | ${r.age ?? "-"} | ` +
+        `${r.check.maxAgeDays} | ${r.stale ? `STALE${r.error ? ` (${r.error})` : ""}` : "ok"} |`,
+    );
+  }
+  if (problems.length) {
+    lines.push("");
+    lines.push("Registry problems:");
+    for (const p of problems) lines.push(`- ${p}`);
+  }
+
+  const report = lines.join("\n");
+  writeFileSync(resolve(ROOT, "freshness-report.md"), report);
+  console.log(report);
+  if (stale.length || problems.length) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/src/lib/cities/madurai.ts
+++ b/src/lib/cities/madurai.ts
@@ -95,6 +95,7 @@ export const MADURAI: CityConfig = {
       catchmentAreaSqkm: null,
       displayOrder: 3,
       isPrimaryDrinkingSource: false,
+      hasPublicFeed: false,
     },
   ],
   // Madurai's groundwater data is sparse at the ward scale (only 4 WRIS


### PR DESCRIPTION
Phase 1 of the data-freshness spec, scoped to what this week proved we need: **alerts on our own ingested data going stale**, per city, for the daily and weekly jobs.

## Why

Scrape steps tolerate failures by design, so job conclusions read "success" while data quietly ages:
- Chennai went **5 days stale behind green runs** (issue #150 - CMWSSB timing out runner IPs)
- Today's "successful" Pravah run was actually **3 timeouts** (mwrdpravah also blocks datacenter IPs; recovered by a local run)

## How it works

`scripts/check-data-freshness.ts` **derives** checks from the city configs - nothing hand-listed per city:

| feed class | derivation | tolerance |
|---|---|---|
| Reservoirs | every `waterSource` with `hasPublicFeed !== false`, per `source_code` (v2) or city-level (Chennai legacy) | 4 days (pipeline's own) |
| Provisional rainfall | `rainfall-recent-{city}.json` required for every registered city | 2 days |
| Weekly artifacts | `EXTRA_FEEDS` registry (BMC flood-spots today) | 9 days |

**Auto-created at onboarding**: `--validate` runs inside `npm run data:check` (CI on every PR) - a new city cannot merge until its feeds are checkable or explicitly exempted with a reason on record.

**Daily sweep**: `data-freshness.yml` runs `--check` at 06:30 UTC (after the morning pipelines), and files a deduped `pipeline-alert` issue with the full feed table when anything is stale.

Side effects of today's diagnosis, already in this branch's parent (main): Pravah + CMWSSB both recovered via local runs; both sites block GitHub runner IPs intermittently - if that persists, scraper egress is the next conversation.