### PR TITLE
fix: Explore highlighted alongside Dashboard on city home pages

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -100,7 +100,14 @@ function ExploreDropdown({
   const ref = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   // Active when ANY explore link's city-aware href matches the current path.
-  const exploreCityHrefs = new Set(EXPLORE_ITEMS.map((i) => rewriteNavHref(i.href, cityId)));
+  // Only features the city supports: an unsupported feature rewrites to the
+  // city HOME, which would light Explore up alongside Dashboard on /<city>
+  // (seen on Mumbai, which lacks climate-risk).
+  const exploreCityHrefs = new Set(
+    EXPLORE_ITEMS.filter((i) => isFeatureSupportedForCity(i.href, cityId)).map((i) =>
+      rewriteNavHref(i.href, cityId),
+    ),
+  );
   const isExploreActive = exploreCityHrefs.has(pathname) || EXPLORE_PATHS.has(pathname);
 
   // Close on click outside
@@ -199,7 +206,9 @@ export function Header() {
 
   const isExploreActive =
     EXPLORE_PATHS.has(pathname) ||
-    EXPLORE_ITEMS.some((i) => rewriteNavHref(i.href, cityId) === pathname);
+    EXPLORE_ITEMS.filter((i) => isFeatureSupportedForCity(i.href, cityId)).some(
+      (i) => rewriteNavHref(i.href, cityId) === pathname,
+    );
 
   // The root path "/" is the project landing page, not a city. Render a
   // minimal header there: brand + city switcher + toggles, with no


### PR DESCRIPTION
On /mumbai (and silently on /bangalore and /madurai too), the Explore nav trigger rendered as active at the same time as Dashboard.

Root cause: both `isExploreActive` computations mapped every Explore item through `rewriteNavHref` **without filtering to features the city supports**. An unsupported feature (climate-risk on Mumbai; climate-risk + shoreline on Bengaluru/Madurai) rewrites to the city home URL, so on `/<city>` the set contained the current pathname. The dropdown's item *rendering* already filtered via `isFeatureSupportedForCity` - the active-state checks just didn't.

## Verification (playwright, running app)

| page | Explore state |
|---|---|
| /mumbai, /bangalore, /madurai, /chennai | inactive ✅ |
| /mumbai/flood-risk, /chennai/flood-risk | active ✅ |

Zero page errors; tsc clean, lint 0 errors, 67/67 tests.