### PR TITLE
rivers: flag the Mithi's disputed 2023 fecal-coliform figure

### DIFF
--- a/public/data/river-quality-mumbai.json
+++ b/public/data/river-quality-mumbai.json
@@ -116,7 +116,8 @@
        "nitrate_mgl": null,
        "chromium_mgl": null,
        "lead_mgl": null,
-       "cadmium_mgl": null
+       "cadmium_mgl": null,
+       "fecal_coliform_note": "CPCB's official figure, shown as published. Praja Foundation, transcribing the same CPCB series, flags the 100x jump from 5,400 (2022) as a likely recording error ('seems like an error'). Treat the magnitude as directional; either way the Mithi is far beyond the bathing standard."
       }
      ]
     },

--- a/src/components/rivers/river-panel.tsx
+++ b/src/components/rivers/river-panel.tsx
@@ -502,6 +502,11 @@ export function RiverPanel({
                   <div className="mt-1 h-1 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
                     <div className={`h-full rounded-full ${severe ? "bg-red-500" : exceeded ? "bg-orange-400" : "bg-green-400"}`} style={{ width: `${Math.min(ratio * 100, 100)}%` }} />
                   </div>
+                  {latestReading.fecal_coliform_note && (
+                    <p className="mt-1.5 text-[10px] leading-snug text-amber-700 dark:text-amber-400 italic">
+                      ⚠ {latestReading.fecal_coliform_note}
+                    </p>
+                  )}
                 </div>
               );
             })()}

--- a/src/types/river-quality.ts
+++ b/src/types/river-quality.ts
@@ -41,6 +41,11 @@ export interface RiverQualityReading {
   conductivity_us: number | null; // µS/cm
   cod_mgl: number | null; // Chemical oxygen demand mg/L
   fecal_coliform_mpn: number | null; // Fecal coliform MPN/100ml
+  /** Set when the published figure itself is disputed (e.g. the Mithi's
+   *  2023 CPCB value, publicly flagged by Praja as a likely recording
+   *  error). Rendered as a footnote under the FC tile - the number is
+   *  shown as published, never silently corrected. */
+  fecal_coliform_note?: string | null;
   tds_mgl: number | null; // Total dissolved solids mg/L
   nitrate_mgl: number | null; // Nitrate mg/L
   chromium_mgl: number | null; // Chromium mg/L (heavy metal)


### PR DESCRIPTION
User reaction that started it: *"wow Mithi river Fecal Coliform is 1080x?!!"* - which is exactly how a journalist would react, so the number needed provenance before it gets quoted.

## What the research found

- The 540,000 MPN/100ml (2023) **is CPCB's official published figure** for station 2168, faithfully transcribed by Praja and then by us.
- But the series is 1,600 → 3,500 → 92,000 → 17,000 → 5,400 → **540,000**: a clean 100x step from 2022, the signature of a units/decimal slip ("5,400 → 5.40 lakh").
- **Praja itself publicly flags it**: "CPCB's data shows 5,400MPN/100ml fecal coliform in Mithi river in 2022, the level rose to 5.40lakh MPN/100ml within one year, **which seems like an error**" ([FPJ coverage of Praja's report](https://www.freepressjournal.in/mumbai/mumbai-news-only-1-ward-received-24-hour-water-supply-amid-15-shortfall-in-2024-reveals-praja-foundation-report)).

## The fix (honest-data pattern)

The number is **never silently corrected** - it renders as published, now with a data-borne footnote under the FC tile: CPCB's official figure; the jump is publicly flagged as a likely recording error; treat the magnitude as directional; either way the Mithi is far beyond the bathing standard. New optional `fecal_coliform_note` on the reading type, so any future disputed figure gets the same treatment without code changes.

River classification is unaffected (the Mithi is dead-class on BOD alone).

## Verification (browser)

✅ Mithi panel still shows the published 540,000 + 1080x; the amber dispute footnote renders beneath the tile; zero page errors. Gates: tsc clean, lint 0 errors, data:check, 67/67 tests, production build.