### PR TITLE
freshness: track the MMR dam-storage artifact

### DIFF
--- a/scripts/check-data-freshness.ts
+++ b/scripts/check-data-freshness.ts
@@ -55,6 +55,14 @@ interface ExtraFeed {
 }
 const EXTRA_FEEDS: ExtraFeed[] = [
   {
+    id: "mmr-dam-storage",
+    cityId: "mumbai",
+    file: "public/data/mmr-dam-storage.json",
+    maxAgeDays: 4, // daily Pravah artifact; same tolerance as the DB feed
+    dateFrom: "json:_fetched",
+    note: "regional corporation cards' source-storage pills",
+  },
+  {
     id: "bmc-flood-spots",
     cityId: "mumbai",
     file: "public/data/mumbai-flood-hotspots.geojson",


### PR DESCRIPTION
Follow-up to #152, found live today: the regional corporation cards' "source storage as of" pills read `public/data/mmr-dam-storage.json` (the Pravah workflow's artifact-commit), and that feed was missing from the checker. It sat at its launch-day snapshot (4 Jul) unnoticed until the user asked - refreshed manually today since mwrdpravah is timing out GitHub runner IPs.

Adds it to EXTRA_FEEDS: `_fetched` date, 4-day tolerance (same as the DB feed). Verified: `--check` now reports 18 feeds, all fresh, with the new row ok.