### PR TITLE
mobile: invisible flood map + regional-card overflow/deficit duplication

### DIFF
--- a/src/app/[cityId]/flood-risk/flood-risk-bangalore-content.tsx
+++ b/src/app/[cityId]/flood-risk/flood-risk-bangalore-content.tsx
@@ -74,7 +74,10 @@ export function FloodRiskBangaloreContent({ cityDisplayName }: Props) {
 
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
         {/* Map area */}
-        <div className="relative flex-1 h-full">
+        <div className="relative h-[45vh] shrink-0 md:h-full md:flex-1 md:shrink">
+          {/* Mobile: the map needs an explicit height - as a flex-basis-0 item
+              next to the tall text sidebar it collapses to 0px and only its
+              floating controls remain visible. Desktop keeps filling the row. */}
           <FloodLeafletMap
             center={[12.9716, 77.5946]}
             zoom={11}

--- a/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
+++ b/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
@@ -63,7 +63,10 @@ export function FloodRiskMumbaiContent({ cityDisplayName }: Props) {
 
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
         {/* Map area */}
-        <div className="relative flex-1 h-full">
+        <div className="relative h-[45vh] shrink-0 md:h-full md:flex-1 md:shrink">
+          {/* Mobile: the map needs an explicit height - as a flex-basis-0 item
+              next to the tall text sidebar it collapses to 0px and only its
+              floating controls remain visible. Desktop keeps filling the row. */}
           <FloodMumbaiLeafletMap center={[19.076, 72.8777]} zoom={11} layerState={layerState} />
 
           {/* Layer-toggle panel */}

--- a/src/app/[cityId]/flood-risk/interactive-flood-content.tsx
+++ b/src/app/[cityId]/flood-risk/interactive-flood-content.tsx
@@ -190,7 +190,10 @@ function InteractiveFloodContentInner({ cityId }: { cityId: string }) {
 
       {/* Map + panel */}
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
-        <div className="relative flex-1 h-full">
+        <div className="relative h-[45vh] shrink-0 md:h-full md:flex-1 md:shrink">
+          {/* Mobile: the map needs an explicit height - as a flex-basis-0 item
+              next to the tall text sidebar it collapses to 0px and only its
+              floating controls remain visible. Desktop keeps filling the row. */}
           <FloodRiskMap
             cityId={cityId}
             center={center}

--- a/src/components/dashboard/regional-water-system.tsx
+++ b/src/components/dashboard/regional-water-system.tsx
@@ -224,7 +224,7 @@ export function RegionalWaterSystem({ cityId }: { cityId: string }) {
           const hasSupply = typeof m.supply_mld === "number";
           return (
             <div key={corp.corporationId} className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5">
-              <div className="flex items-baseline justify-between gap-1">
+              <div className="flex flex-wrap items-baseline justify-between gap-x-1 gap-y-0.5">
                 <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 flex items-baseline gap-1.5">
                   {corp.acronym}{footnotes(m.source_refs)}
                   {(() => {
@@ -236,12 +236,12 @@ export function RegionalWaterSystem({ cityId }: { cityId: string }) {
                           : null;
                     if (pct === null)
                       return hasSupply ? null : (
-                        <span className="text-[8px] uppercase tracking-wide px-1 py-0.5 rounded bg-slate-200 text-slate-600 dark:bg-slate-800 dark:text-slate-400">pending</span>
+                        <span className="text-[9px] font-semibold uppercase tracking-wide px-1 py-0.5 rounded bg-slate-200 text-slate-600 dark:bg-slate-800 dark:text-slate-400">pending</span>
                       );
                     return pct > 0 ? (
-                      <span className="text-[8px] uppercase tracking-wide px-1 py-0.5 rounded bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">{pct}% short</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-wide px-1 py-0.5 rounded bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">{pct}% short</span>
                     ) : (
-                      <span className="text-[8px] uppercase tracking-wide px-1 py-0.5 rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300">no deficit</span>
+                      <span className="text-[9px] font-semibold uppercase tracking-wide px-1 py-0.5 rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300">no deficit</span>
                     );
                   })()}
                 </span>
@@ -272,28 +272,9 @@ export function RegionalWaterSystem({ cityId }: { cityId: string }) {
                   {typeof m.demand_mld === "number" && (
                     <div className="flex justify-between"><span className="text-slate-500">Demand</span><span className="font-mono">{m.demand_mld} MLD</span></div>
                   )}
-                  {(() => {
-                    // Deficit derives from supply/demand when both exist, so a
-                    // corporation never shows the pair without the conclusion;
-                    // a stored deficit_pct (e.g. BMC's published 15%) wins.
-                    const pct =
-                      typeof m.deficit_pct === "number"
-                        ? m.deficit_pct
-                        : typeof m.demand_mld === "number" &&
-                            typeof m.supply_mld === "number" &&
-                            m.demand_mld > 0
-                          ? Math.round(((m.demand_mld - m.supply_mld) / m.demand_mld) * 100)
-                          : null;
-                    if (pct === null) return null;
-                    return (
-                      <div className="flex justify-between">
-                        <span className="text-slate-500">Deficit</span>
-                        <span className="font-mono text-amber-600 dark:text-amber-400">
-                          {pct <= 0 ? "none" : `${pct}%`}
-                        </span>
-                      </div>
-                    );
-                  })()}
+                  {/* The deficit verdict lives ONLY in the header badge
+                      ("{pct}% short" / "no deficit") - it was previously
+                      repeated as a body row, which read as two numbers. */}
                 </div>
               ) : (
                 <div className="text-[10px] text-slate-400 italic py-1.5 px-2 rounded bg-slate-50 dark:bg-slate-800/60">


### PR DESCRIPTION
Both reported from a phone; both reproduced headless at 390px.

## 1. Flood map invisible on mobile (all three flood variants)

The map area was `flex-1` (basis 0) next to a tall text sidebar inside a fixed-height `flex-col` - on mobile the sidebar's content consumed everything and the map collapsed to **0px**, leaving only its absolutely-positioned LAYERS control floating over the prose (exactly the reported screenshot). This was live on Bengaluru's and Chennai's mobile flood pages too, not just Mumbai's.

Fix: the map container gets `h-[45vh] shrink-0` on mobile and keeps `md:h-full md:flex-1` on desktop. Verified: 380px-tall maps on /mumbai, /bangalore and /chennai flood pages at 390px viewport, prose flowing below.

## 2. Regional corporation cards

- **Deficit shown twice** ("15% SHORT" badge and a "Deficit 15%" body row). Per the request - prominent but not duplicated - the verdict now lives only in the header badge, bumped to 9px semibold. The body keeps Supply/Demand.
- **Storage pill overflowed the viewport** (measured at 400px on a 390px screen). The header row now wraps; measured zero elements past the viewport edge after the fix.

## Verification

1. ✅ 390px viewport, fresh server: leaflet height 380px on all three cities (was 0)
2. ✅ Dashboard overflow scan: max element right edge = 390 (was 400)
3. ✅ "Deficit" body rows gone; SHORT/no-deficit badges render
4. 🔍 Desktop regression: maps still fill the row (md:h-full md:flex-1 preserved)
5. ✅ Gates: tsc clean, lint 0 errors, 67/67 tests, production build

Also checked the pipeline watch item while in session: **all crons fired on schedule Jul 6-8** (Pravah's runner timeouts were transient) and the data-freshness sweep ran green both days - 18 feeds fresh, no alerts.