### PR TITLE
overture: auto-discover the latest release instead of pinning

### DIFF
--- a/public/data/rich-bodies/pallikaranai-overture-buildings.json
+++ b/public/data/rich-bodies/pallikaranai-overture-buildings.json
@@ -1,10 +1,10 @@
 {
   "body_id": "pallikaranai",
-  "computed_at": "2026-06-08T08:59:44.688114+00:00",
+  "computed_at": "2026-07-08T06:46:27.469299+00:00",
   "data_source": {
-    "dataset": "Overture Maps Foundation - buildings (2026-04-15.0)",
-    "release_date": "2026-04-15",
-    "url_root": "s3://overturemaps-us-west-2/release/2026-04-15.0/theme=buildings/type=building/*",
+    "dataset": "Overture Maps Foundation - buildings (2026-06-17.0)",
+    "release_date": "2026-06-17",
+    "url_root": "s3://overturemaps-us-west-2/release/2026-06-17.0/theme=buildings/type=building/*",
     "license": "CDLA-Permissive 2.0",
     "method": "Per-building polygon download via DuckDB+spatial+httpfs query on the Overture parquet release filtered by chip bbox. Buildings counted as inside a region when their centroid is within the region polygon. Area summed from each footprint's planar area at 13N.",
     "providers": "Microsoft + OpenStreetMap + Google + other partners (combined and deduplicated by Overture)",
@@ -42,8 +42,8 @@
     },
     {
       "region": "Halo: 1km buffer - body",
-      "building_count": 48257,
-      "building_area_ha": 639.67,
+      "building_count": 48250,
+      "building_area_ha": 639.63,
       "with_height_metadata": 4,
       "region_area_ha": 3409.87,
       "built_up_fraction_pct": 18.76
@@ -51,7 +51,7 @@
   ],
   "headline_for_v0": [
     "Inside primary boundary: 422 buildings covering 4 ha (0.3%).",
-    "Inside 1 km halo: 48,257 buildings covering 640 ha (18.8%)."
+    "Inside 1 km halo: 48,250 buildings covering 640 ha (18.8%)."
   ],
   "comparison_note": "Compare side-by-side with the Google Open Buildings v3 numbers in pallikaranai-open-buildings-verification.json (2023 release). Delta indicates construction since 2023."
 }

--- a/scripts/verify_rich_body_overture_buildings.py
+++ b/scripts/verify_rich_body_overture_buildings.py
@@ -37,19 +37,42 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _rich_body_zones import load_body_zones, ZONE_BODY, ZONE_HALO  # noqa: E402
 
-DEFAULT_OVERTURE_RELEASE = "2026-04-15.0"
 DEFAULT_ANOMALY_PCT = 20.0  # any zone changing > this triggers review
+
+# Overture retires old releases from the public bucket (the pinned
+# 2026-04-15.0 vanished and broke the June refresh), so the default is
+# discovered from the bucket's own listing rather than pinned.
+OVERTURE_LIST_URL = (
+    "https://overturemaps-us-west-2.s3.amazonaws.com/"
+    "?list-type=2&prefix=release/&delimiter=/"
+)
+
+
+def latest_overture_release() -> str:
+    """Newest release id in the public bucket (ids sort as dates)."""
+    import re
+    import urllib.request
+
+    with urllib.request.urlopen(OVERTURE_LIST_URL, timeout=60) as resp:
+        xml = resp.read().decode()
+    releases = re.findall(r"<Prefix>release/([^/<]+)/</Prefix>", xml)
+    if not releases:
+        raise RuntimeError(
+            f"no releases found at {OVERTURE_LIST_URL} - bucket layout changed?"
+        )
+    return sorted(releases)[-1]
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--body-id", default="pallikaranai")
-    ap.add_argument("--release", default=DEFAULT_OVERTURE_RELEASE)
+    ap.add_argument("--release", default=None,
+                    help="Overture release id; default = newest in the bucket")
     ap.add_argument("--anomaly-pct", type=float, default=DEFAULT_ANOMALY_PCT,
                     help="Flag any zone whose count changes by more than this percent vs the previous JSON.")
     args = ap.parse_args()
     body_id = args.body_id
-    release = args.release
+    release = args.release or latest_overture_release()
     overture_url = (
         f"s3://overturemaps-us-west-2/release/{release}/"
         f"theme=buildings/type=building/*"


### PR DESCRIPTION
The monthly Overture buildings refresh failed on 2026-07-08 with `No files found that match the pattern "s3://overturemaps-us-west-2/release/2026-04-15.0/..."` - Overture retires old releases from the public bucket (only 2026-05-20.0 and 2026-06-17.0 exist now), so any pinned release id eventually breaks the workflow.

## Fix

`--release` now defaults to the newest release discovered from the bucket's own S3 listing (manual override unchanged). If the listing format ever changes, the script fails with an explicit error rather than a mystery pattern-miss.

## Verification

1. ✅ Discovery returns `2026-06-17.0` from the live bucket
2. ✅ Full end-to-end run for pallikaranai against the discovered release: 92,147 candidate buildings fetched, zone counts computed (422 body / 48,250 halo), canonical JSON written - counts moved within the 20% anomaly threshold, so no candidate-file review path triggered
3. 🔍 After merge, dispatch `overture-buildings-refresh.yml` to refresh the remaining rich bodies on the same release