### PR TITLE
flood map: tap popups + collapsible layers panel + bigger touch zoom targets

### DIFF
--- a/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
+++ b/src/app/[cityId]/flood-risk/flood-risk-mumbai-content.tsx
@@ -39,6 +39,9 @@ interface Props {
  * now; Marathi follows in the i18n pass.
  */
 export function FloodRiskMumbaiContent({ cityDisplayName }: Props) {
+  // Mobile: the layer panel covered over half the map width and blocked
+  // pinch-zoom gestures; it starts collapsed there. Desktop keeps it open.
+  const [layersOpen, setLayersOpen] = useState(false);
   const [layerState, setLayerState] = useState({
     showChronic: true,
     showSubway: true,
@@ -71,9 +74,16 @@ export function FloodRiskMumbaiContent({ cityDisplayName }: Props) {
 
           {/* Layer-toggle panel */}
           <div className="absolute top-3 right-3 z-[500] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow-md p-3 space-y-2 text-xs max-w-[230px]">
-            <div className="font-semibold text-slate-700 dark:text-slate-300 text-[11px] uppercase tracking-wide">
+            <button
+              type="button"
+              onClick={() => setLayersOpen((v) => !v)}
+              aria-expanded={layersOpen}
+              className="md:pointer-events-none flex w-full items-center justify-between gap-2 font-semibold text-slate-700 dark:text-slate-300 text-[11px] uppercase tracking-wide"
+            >
               Layers
-            </div>
+              <span className="md:hidden text-slate-400">{layersOpen ? "−" : "+"}</span>
+            </button>
+            <div className={`${layersOpen ? "block" : "hidden"} md:block space-y-2`}>
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
@@ -134,6 +144,7 @@ export function FloodRiskMumbaiContent({ cityDisplayName }: Props) {
                 Drains + nallas (OSM)
               </span>
             </label>
+            </div>
           </div>
         </div>
 

--- a/src/app/[cityId]/flood-risk/flood-risk-mumbai-leaflet-map.tsx
+++ b/src/app/[cityId]/flood-risk/flood-risk-mumbai-leaflet-map.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MapContainer, TileLayer, CircleMarker, Tooltip, GeoJSON } from "react-leaflet";
+import { MapContainer, TileLayer, CircleMarker, Tooltip, Popup, GeoJSON } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import type { FeatureCollection, Feature } from "geojson";
 import type { Layer, PathOptions } from "leaflet";
@@ -226,6 +226,22 @@ export function FloodMumbaiLeafletMap({ center, zoom, layerState }: MapProps) {
               </>
             )}
           </Tooltip>
+          {/* Tooltips are hover-only; on phones a tap must open something. */}
+          <Popup>
+            <strong>{m.name || "(unnamed)"}</strong>
+            {m.depth_label && (
+              <>
+                <br />
+                <span style={{ fontSize: "11px" }}>26/7/2005: {m.depth_label}</span>
+              </>
+            )}
+            {m.note && (
+              <>
+                <br />
+                <span style={{ fontSize: "11px", color: "#64748b" }}>{m.note}</span>
+              </>
+            )}
+          </Popup>
         </CircleMarker>
       ))}
       {visibleHotspots.map((m) => (
@@ -252,6 +268,23 @@ export function FloodMumbaiLeafletMap({ center, zoom, layerState }: MapProps) {
               </>
             )}
           </Tooltip>
+          <Popup>
+            <strong>{m.name || "(unnamed point)"}</strong>
+            {m.ward && <span style={{ fontSize: "11px" }}> · Ward {m.ward}</span>}
+            <br />
+            <span style={{ fontSize: "11px", color: "#64748b" }}>{m.category_label}</span>
+            {m.location && (
+              <>
+                <br />
+                <span style={{ fontSize: "11px", color: "#64748b" }}>{m.location}</span>
+              </>
+            )}
+            <br />
+            <span style={{ fontSize: "10px", color: "#94a3b8", fontStyle: "italic" }}>
+              BMC publishes this spot inventory, not per-spot flood dates - event
+              history is a named gap we are pursuing.
+            </span>
+          </Popup>
         </CircleMarker>
       ))}
     </MapContainer>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,3 +220,13 @@
   color: #e2e8f0;            /* slate-200 */
   text-shadow: 0 0 4px rgba(0, 0, 0, 0.85);
 }
+
+/* Touch devices: Leaflet's default 30px zoom buttons are small tap targets
+   for less technical users - stakeholder feedback on the flood map. */
+.leaflet-touch .leaflet-bar.leaflet-control-zoom a.leaflet-control-zoom-in,
+.leaflet-touch .leaflet-bar.leaflet-control-zoom a.leaflet-control-zoom-out {
+  width: 40px;
+  height: 40px;
+  line-height: 40px;
+  font-size: 20px;
+}


### PR DESCRIPTION
Response to stakeholder feedback on the Mumbai flood map: *"still struggling with zooming... this seems a static point, unable to see past flooding incidents."*

## What was wrong

1. **"Static point" was literal on phones**: spot markers had hover-only tooltips - a tap did nothing. Every marker now opens a popup with everything BMC publishes per spot (name, official location, ward, category), plus an honest footnote: BMC publishes the spot *inventory*, not per-spot flood dates - event history is a named gap (the per-spot logs exist inside BMC tied to rain-gauge IDs; RTI candidate).
2. **The LAYERS panel blocked zooming on mobile** - it covered over half the map width, eating the pinch-gesture area. It now starts collapsed behind a "Layers +" button on mobile; desktop is unchanged (always open, button inert).
3. **30px zoom buttons** are small targets for less technical users; bumped to 40px on touch devices (with specificity to beat leaflet.css load order).

(The likely root cause of the zoom complaint - the map rendering at 0px on mobile - was fixed separately in #157 and deployed earlier today.)

## Verification (390px, touch-enabled headless)

1. ✅ Tap on a spot → popup: "Jijamata Nagar · Ward R/S / Chronic flooding spot (BMC DM register) / Bander Pakhadi Road... / BMC publishes this spot inventory, not per-spot flood dates..."
2. ✅ Panel collapsed on load at 390px; expands on tap; desktop panel open without interaction
3. ✅ Zoom buttons measure 40x40 (were 30x30)
4. 🔍 Desktop regression: hover tooltips still work alongside the new popups; zero page errors both breakpoints
5. ✅ Gates: tsc clean, lint 0 errors, 67/67 tests, production build