### PR TITLE
Bengaluru commitments: BCAP's five water targets join the register

### DIFF
--- a/public/data/commitments-bangalore.json
+++ b/public/data/commitments-bangalore.json
@@ -1,7 +1,7 @@
 {
   "place_id": "bangalore",
-  "updated": "2026-07-05",
-  "headline": "10 commitments on Bengaluru's register: Cauvery Stage V and Varthur's desilting delivered, 3 on track, and 5 waiting on dates their owners set.",
+  "updated": "2026-07-09",
+  "headline": "15 commitments on Bengaluru's register: the city's climate plan joins it with dated water targets - 3 delivered (ward-level consumption data is now public), 6 on track on their owners' own numbers, and 6 overdue, stalled or unverifiable.",
   "intro": "Dated commitments by the institutions that manage this city's water - BWSSB, BDA, the Karnataka government and the tribunals that set deadlines for them - made to residents, courts and funders, and followed from announcement to delivery. Every commitment carries its original citation and every status change carries a dated source. Delivered late is still delivered - the dates show the journey - and when a date moves, the old one stays on the record. Nothing here is our opinion; it is the institutions' own paper, checked against time.",
   "status_legend": {
     "delivered": "The promised thing verifiably happened, even if late. The dates show how late.",
@@ -373,8 +373,129 @@
       "status": "on-track",
       "status_history": [],
       "next_check": "2026-12-01"
+    },
+    {
+      "id": "bcap-ward-consumption-data",
+      "category": "Climate plan (BCAP)",
+      "title": "Publish ward-level water consumption data on an open platform",
+      "committed_by": "BWSSB, under BBMP's Bengaluru Climate Action and Resilience Plan (BCAP)",
+      "what": "BCAP action W,WW,SW-1.2 (timeline: 2025) commits BWSSB to publishing ward-level data on actual consumption of piped water, by customer group, on an open-access platform, so that supply can be planned equitably. A dataset titled 'Ward wise Water consumption data' was published by BWSSB on the national Open Government Data platform on 21 June 2025 - within the promised year - and updated on 5 February 2026. Delivered means the ward-wise dataset exists in open access; the customer-group breakdown, and the follow-on promise to revisit service benchmarks using it (action 1.3), are not verified.",
+      "due": "2025",
+      "commitment_source": {
+        "label": "BCAP Sector-wise Action Recommendations (Apr 2024), water chapter p. 78, action W,WW,SW-1.2; plan launched 27 Nov 2023",
+        "url": "https://apps.bbmpgov.in/bcap/PDF/BCAP_Sector%20Actions_01042024.pdf",
+        "date": "2023-11-27"
+      },
+      "status": "delivered",
+      "status_history": [
+        {
+          "date": "2025-06-21",
+          "status": "delivered",
+          "note": "'Ward wise Water consumption data' published by BWSSB on data.gov.in under the National Data Sharing and Accessibility Policy; jurisdiction Bangalore Urban, sector Water and Sanitation. Last updated 5 Feb 2026 - a sign it is being maintained, not just posted once. Verified for this register on 9 Jul 2026.",
+          "source_label": "Open Government Data platform, catalog 'Water consumption data' (BWSSB)",
+          "source_url": "https://www.data.gov.in/catalog/water-consumption-data"
+        }
+      ],
+      "next_check": null,
+      "revised_due": "delivered 21 Jun 2025"
+    },
+    {
+      "id": "bcap-nrw-15pct",
+      "category": "Climate plan (BCAP)",
+      "title": "Cut non-revenue water to 15% by 2050",
+      "committed_by": "BWSSB, under BBMP's Bengaluru Climate Action and Resilience Plan (BCAP)",
+      "what": "BCAP's water track 2 sets the target: non-revenue water down to 15% by 2050. The direction so far is documented by the board itself: BWSSB chairman Ram Prasath Manohar says unaccounted-for water fell from 51% in 2013 to 26.5% in 2025, saving about 200 MLD, via district metered areas, bulk flow meters and 200 km of cast-iron pipeline replacement (3,000 km identified). Independent estimates run a few points higher (~30%). BCAP was adopted by BBMP, which has since been restructured into the Greater Bengaluru Authority's corporations; BWSSB, the responsible agency, is unchanged.",
+      "due": "2050",
+      "commitment_source": {
+        "label": "BCAP Sector-wise Action Recommendations (Apr 2024), water chapter p. 80, track W,WW,SW-2 goal; plan launched 27 Nov 2023",
+        "url": "https://apps.bbmpgov.in/bcap/PDF/BCAP_Sector%20Actions_01042024.pdf",
+        "date": "2023-11-27"
+      },
+      "status": "on-track",
+      "status_history": [
+        {
+          "date": "2026-04-27",
+          "status": "on-track",
+          "note": "BWSSB chairman: unaccounted-for water reduced from 51% (2013) to 26.5% (2025), ~200 MLD saved. The figure is the board's own; a September 2025 academic study put losses nearer 30%. Either number leaves 11 to 15 points still to close over 24 years.",
+          "source_label": "Elets eGov interview with BWSSB chairman, 27 Apr 2026",
+          "source_url": "https://egov.eletsonline.com/2026/04/building-bengalurus-water-future-technology-climate-resilience-and-citizen-centric-governance/"
+        }
+      ],
+      "next_check": "2026-12-01"
+    },
+    {
+      "id": "bcap-wastewater-reuse",
+      "category": "Climate plan (BCAP)",
+      "title": "Reuse at least 50% of treated wastewater by 2030, 90% by 2050",
+      "committed_by": "BWSSB, under BBMP's Bengaluru Climate Action and Resilience Plan (BCAP)",
+      "what": "The same BCAP track 2 goal that sets the NRW target also commits the city to reusing a minimum of 50% of treated wastewater by 2030 and 90% by 2050. On the board's own April 2026 numbers - 825 MLD reused for environmental purposes plus 30 MLD for commercial applications, against roughly 1,213 MLD treated - the 2030 bar is arguably already met. The caveat is what 'environmental purposes' mostly means: pumping to Kolar and Chikkaballapur tanks, where the state's own ministers have admitted the water needs tertiary treatment it is not getting (see the KC/HN Valley entry). No independent audit of the reuse share exists.",
+      "due": "2030",
+      "commitment_source": {
+        "label": "BCAP Sector-wise Action Recommendations (Apr 2024), water chapter p. 80, track W,WW,SW-2 goal; plan launched 27 Nov 2023",
+        "url": "https://apps.bbmpgov.in/bcap/PDF/BCAP_Sector%20Actions_01042024.pdf",
+        "date": "2023-11-27"
+      },
+      "status": "on-track",
+      "status_history": [
+        {
+          "date": "2026-04-27",
+          "status": "on-track",
+          "note": "BWSSB chairman: 825 MLD of treated water reused for environmental purposes, 30 MLD for commercial applications - about 70% of the ~1,213 MLD currently treated, though a smaller share of all sewage generated. Quality of the reused water remains the open question, per the KC/HN Valley record.",
+          "source_label": "Elets eGov interview with BWSSB chairman, 27 Apr 2026",
+          "source_url": "https://egov.eletsonline.com/2026/04/building-bengalurus-water-future-technology-climate-resilience-and-citizen-centric-governance/"
+        }
+      ],
+      "next_check": "2026-12-01"
+    },
+    {
+      "id": "bcap-permeable-surface",
+      "category": "Climate plan (BCAP)",
+      "title": "Make 40% of the city's surface permeable by 2040",
+      "committed_by": "BBMP (now the Greater Bengaluru Authority's corporations), under BCAP",
+      "what": "BCAP's water track 3 commits the city to making 40% of its surface area permeable by 2040 by reclaiming ecologically sensitive spaces and adopting nature-based solutions. BCAP's own risk assessment shows the scale of the reversal required: 63% of the city's area was already concretised by 2000, and a further 31% lost groundwater-recharge potential between 2000 and 2020. No baseline permeability figure, measurement method or progress reporting has been published, and a July 2025 review of the Climate Action Cell found sponge-space actions discussed in meetings but little documented ground progress. Unverified means exactly that: the promise is citable, its status is not.",
+      "due": "2040",
+      "commitment_source": {
+        "label": "BCAP Sector-wise Action Recommendations (Apr 2024), water chapter p. 94, track W,WW,SW-3 goal; plan launched 27 Nov 2023",
+        "url": "https://apps.bbmpgov.in/bcap/PDF/BCAP_Sector%20Actions_01042024.pdf",
+        "date": "2023-11-27"
+      },
+      "status": "unverified",
+      "status_history": [
+        {
+          "date": "2025-07-23",
+          "status": "unverified",
+          "note": "OpenCity's review of the Climate Action Cell's first 17 months (41 meetings, Feb 2024 to Jun 2025): sponge-space restoration and aquifer mapping were discussed, but the Cell told an RTI applicant it holds no direct responsibility for monitoring outcomes, and no permeability baseline or progress metric has been published.",
+          "source_label": "OpenCity (Dattatraya T Devare), 23 Jul 2025",
+          "source_url": "https://opencity.in/bengaluru-climate-action-cell-achievements-and-disappointments/"
+        }
+      ],
+      "next_check": "2026-12-01"
+    },
+    {
+      "id": "bcap-treatment-95pct",
+      "category": "Climate plan (BCAP)",
+      "title": "Treat 95% of the city's wastewater by 2050, about 60% of it via low-carbon systems",
+      "committed_by": "BWSSB, under BBMP's Bengaluru Climate Action and Resilience Plan (BCAP)",
+      "what": "BCAP's water track 4 sets the target: 95% of wastewater treated by 2050 through a mix of centralised and decentralised systems, of which about 60% should use low-carbon and nature-based technologies. As of March 2026 the city's 34 STPs (1,348.5 MLD installed) treat 1,212.7 MLD against an estimated 1,480 MLD of sewage generated - roughly 82% - with 20 plants being upgraded to NGT norms, 7 of them due by end-2026. A 2025 estimate that counts decentralised plants and a wider boundary puts generation higher (~2,140 MLD) and treatment nearer 75%; both figures are shown because the boundary definitions differ. The low-carbon 60% sub-target has no published tracking at all.",
+      "due": "2050",
+      "commitment_source": {
+        "label": "BCAP Sector-wise Action Recommendations (Apr 2024), water chapter p. 96, track W,WW,SW-4 goal; plan launched 27 Nov 2023",
+        "url": "https://apps.bbmpgov.in/bcap/PDF/BCAP_Sector%20Actions_01042024.pdf",
+        "date": "2023-11-27"
+      },
+      "status": "on-track",
+      "status_history": [
+        {
+          "date": "2026-03-26",
+          "status": "on-track",
+          "note": "34 STPs, 1,348.5 MLD installed capacity, 1,212.7 MLD treated against ~1,480 MLD generated (~82%); 20 STPs under NGT-norm rehabilitation (BOD 20 to 10 mg/l, tertiary stages added), 7 due by end-2026 at ~Rs 33.4 crore. BWSSB's longer roadmap projects 2,511.5 MLD across 79 plants.",
+          "source_label": "Water Today, 26 Mar 2026",
+          "source_url": "https://magazine.watertoday.org/news/national/bengaluru-bwssb-stp-upgrade-ngt-norms-2026-bwssb-rehabilitation-20-stps-bengaluru-bengaluru-sewage-treatment-capacity-2026-ngt-norms-water-treatment-bengaluru"
+        }
+      ],
+      "next_check": "2026-12-01"
     }
   ],
-  "update_model": "Statuses change only against a dated citation. The register is re-checked against a small calendar of documents: BDA/GBA lake reviews and NGT filings for the rejuvenation entries, BWSSB announcements and Karnataka budget documents (February-March) for the Cauvery entries, and CWC/CWMA agendas for Mekedatu. Each commitment carries a next-check date; a passed next-check with no new citation is itself flagged, never silently updated.",
+  "update_model": "Statuses change only against a dated citation. The register is re-checked against a small calendar of documents: BDA/GBA lake reviews and NGT filings for the rejuvenation entries, BWSSB announcements and Karnataka budget documents (February-March) for the Cauvery entries, CWC/CWMA agendas for Mekedatu, and for the BCAP entries the Climate Action Cell's outputs plus BCAP's own three-yearly review of targets and actions, first due around late 2026. Each commitment carries a next-check date; a passed next-check with no new citation is itself flagged, never silently updated.",
   "sources_note": "Sources are named institutions' own documents where they exist (NGT orders, JICA press releases, cabinet approvals) and dated reporting in Deccan Herald, Citizen Matters, The Hindu and others where they do not. Where two sources conflict (silt volumes, project costs, connection targets) both figures are shown with their labels. Approximate dates are marked as such."
 }


### PR DESCRIPTION
## What

Adds five commitments from BBMP's Bengaluru Climate Action and Resilience Plan (BCAP, launched 27 Nov 2023) to the Bengaluru Commitments Register, taking it from 10 to 15 entries. Data-only change to `public/data/commitments-bangalore.json`.

| Commitment | Due | Status | Basis |
|---|---|---|---|
| Ward-level consumption data on an open platform | 2025 | **delivered** | Dataset on data.gov.in, published 21 Jun 2025, updated 5 Feb 2026 |
| Non-revenue water to 15% | 2050 | on-track | BWSSB chairman: 51% (2013) to 26.5% (2025), ~200 MLD saved |
| Wastewater reuse >=50% by 2030, 90% by 2050 | 2030 | on-track | BWSSB: 825 MLD environmental + 30 MLD commercial reuse (Apr 2026); quality caveat cross-referenced to KC/HN Valley entry |
| 40% permeable city surface | 2040 | unverified | No baseline or progress metric published; OpenCity CAC review (Jul 2025) cited |
| 95% wastewater treatment, ~60% low-carbon | 2050 | on-track | ~82% treated as of Mar 2026; 20 STPs under NGT-norm upgrades |

Every status carries a dated citation per the register's rules. Headline recounted (3 delivered / 6 on track / 6 overdue-stalled-unverifiable) and the update calendar now includes BCAP's own three-yearly target review (first due late 2026).

## Provenance notes

- Commitment source for all five: BCAP Sector-wise Action Recommendations PDF (Apr 2024), water chapter pp. 76-102, with page-level references per entry.
- BCAP predates the GBA restructure; entries note that BWSSB (the responsible agency for four of five) is unchanged.
- Conflicting figures (NRW 26.5% vs ~30%; sewage generation 1,480 vs 2,140 MLD) are shown side by side per register convention.

## Validation

- JSON parses; all statuses are legal legend values; schema matches existing entries (verified against the client's field usage).
- Served locally: `/data/commitments-bangalore.json` returns 15 commitments; `/bangalore/commitments` renders.