### PR TITLE
Arkavathi Phase 2: industrial accountability (KSPCB F-register + OCEMS)

### DIFF
--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -271,6 +271,29 @@
               "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
             }
           ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~650 consented industries; ~380 in the Red/Orange (higher-pollution) categories.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~650"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~380",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Ramanagara RO)",
+              "says": "~650 consented industries as on 31-03-2019; ~380 in Red/Orange categories.",
+              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+            }
+          ]
         }
       ],
       "conflicts": [
@@ -482,6 +505,29 @@
               "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
             }
           ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~510 consented industries; ~200 in the Red/Orange (higher-pollution) categories.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~510"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~200",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Ramanagara RO)",
+              "says": "~510 consented industries as on 31-03-2019; ~200 in Red/Orange categories.",
+              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+            }
+          ]
         }
       ]
     },
@@ -643,6 +689,29 @@
               "says": "C&D waste generation (per ULB), Channapatna: 1.0 MT/day. No C&D recycling facility in the district.",
               "citation": "C&D Waste section, p.39",
               "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+            }
+          ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~80 consented industries; ~20 in the Red/Orange (higher-pollution) categories.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~80"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~20",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Ramanagara RO)",
+              "says": "~80 consented industries as on 31-03-2019; ~20 in Red/Orange categories.",
+              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
           ]
         }
@@ -817,6 +886,29 @@
               "says": "C&D waste generation (per ULB), Magadi: 0.5 MT/day. No C&D recycling facility in the district.",
               "citation": "C&D Waste section, p.39",
               "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+            }
+          ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~120 consented industries; ~50 in the Red/Orange (higher-pollution) categories.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~120"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~50",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Ramanagara RO)",
+              "says": "~120 consented industries as on 31-03-2019; ~50 in Red/Orange categories.",
+              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
           ]
         }
@@ -1080,6 +1172,29 @@
               "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
             }
           ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~7,000 consented industries; ~2,600 in the Red/Orange (higher-pollution) categories. Peenya + Dasarahalli ROs (the Vrishabhavathi valley - the basin's industrial core).",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~7,000"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~2,600",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Peenya + Dasarahalli RO)",
+              "says": "~7,000 consented industries as on 31-03-2019; ~2,600 in Red/Orange categories.",
+              "citation": "KSPCB F-register, Peenya + Dasarahalli RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Peenya.pdf"
+            }
+          ]
         }
       ],
       "conflicts": [
@@ -1253,6 +1368,24 @@
               "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
               "citation": "Biomedical Waste section, p.41",
               "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+            }
+          ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "Harohalli became a separate taluk (carved from Kanakapura) only in 2022, so the 2019 F-register counts it within Kanakapura (~510 consented industries). The Harohalli KIADB estate is a major share of that.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "within Kanakapura (~510)"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Ramanagara RO)",
+              "says": "Harohalli not separated; counted within Kanakapura taluk (~510 consented industries as on 31-03-2019).",
+              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted; approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
           ]
         }
@@ -1508,6 +1641,29 @@
               "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
             }
           ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~1,450 consented industries; ~580+ in the Red/Orange (higher-pollution) categories. ~22% of colour codes unresolved, so Red/Orange is a floor.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~1,450"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~580+",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Doddaballapura RO)",
+              "says": "~1,450 consented industries as on 31-03-2019; ~580+ in Red/Orange categories.",
+              "citation": "KSPCB F-register, Doddaballapura RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Doddaballapura.pdf"
+            }
+          ]
         }
       ],
       "caveats": [
@@ -1743,6 +1899,29 @@
               "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
               "citation": "(iii) C&D Waste Management, p.30-32",
               "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+            }
+          ]
+        },
+        {
+          "stream": "Industrial register (KSPCB, 2019)",
+          "summary": "~1,950 consented industries; ~560+ in the Red/Orange (higher-pollution) categories. ~29% of colour codes were unresolved in the scan, so Red/Orange is a floor.",
+          "metrics": [
+            {
+              "label": "Consented industries (2019)",
+              "value": "~1,950"
+            },
+            {
+              "label": "Red + Orange (higher pollution)",
+              "value": "~560+",
+              "emphasis": "bad"
+            }
+          ],
+          "sources": [
+            {
+              "source": "KSPCB F-register (Nelamangala RO)",
+              "says": "~1,950 consented industries as on 31-03-2019; ~560+ in Red/Orange categories.",
+              "citation": "KSPCB F-register, Nelamangala RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Nelamangala.pdf"
             }
           ]
         }

--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -274,7 +274,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~650 consented industries; ~380 in the Red/Orange (higher-pollution) categories.",
+          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher). The industrial universe behind the stretch.",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -289,7 +289,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "~650 consented industries as on 31-03-2019; ~380 in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
@@ -508,7 +508,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~510 consented industries; ~200 in the Red/Orange (higher-pollution) categories.",
+          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -523,7 +523,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "~510 consented industries as on 31-03-2019; ~200 in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
@@ -694,7 +694,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~80 consented industries; ~20 in the Red/Orange (higher-pollution) categories.",
+          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -709,7 +709,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "~80 consented industries as on 31-03-2019; ~20 in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
@@ -891,7 +891,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~120 consented industries; ~50 in the Red/Orange (higher-pollution) categories.",
+          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -906,7 +906,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "~120 consented industries as on 31-03-2019; ~50 in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
             }
@@ -1175,7 +1175,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~7,000 consented industries; ~2,600 in the Red/Orange (higher-pollution) categories. Peenya + Dasarahalli ROs (the Vrishabhavathi valley - the basin's industrial core).",
+          "summary": "Consented industries across the Peenya + Dasarahalli ROs - the Vrishabhavathi valley, the basin's industrial core - by pollution-potential colour.",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -1190,7 +1190,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Peenya + Dasarahalli RO)",
-              "says": "~7,000 consented industries as on 31-03-2019; ~2,600 in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Peenya + Dasarahalli RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Peenya.pdf"
             }
@@ -1644,7 +1644,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~1,450 consented industries; ~580+ in the Red/Orange (higher-pollution) categories. ~22% of colour codes unresolved, so Red/Orange is a floor.",
+          "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~22% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -1659,7 +1659,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Doddaballapura RO)",
-              "says": "~1,450 consented industries as on 31-03-2019; ~580+ in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Doddaballapura RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Doddaballapura.pdf"
             }
@@ -1904,7 +1904,7 @@
         },
         {
           "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "~1,950 consented industries; ~560+ in the Red/Orange (higher-pollution) categories. ~29% of colour codes were unresolved in the scan, so Red/Orange is a floor.",
+          "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~29% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
           "metrics": [
             {
               "label": "Consented industries (2019)",
@@ -1919,7 +1919,7 @@
           "sources": [
             {
               "source": "KSPCB F-register (Nelamangala RO)",
-              "says": "~1,950 consented industries as on 31-03-2019; ~560+ in Red/Orange categories.",
+              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
               "citation": "KSPCB F-register, Nelamangala RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
               "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Nelamangala.pdf"
             }

--- a/public/data/basins/arkavathi/prs.json
+++ b/public/data/basins/arkavathi/prs.json
@@ -359,6 +359,32 @@
           "level": "spatial estimate",
           "body": "Two industrial areas sit within a few hundred metres of the stretch (near Acchalu Village, Ramanagara taluk); the MPRs name two Red-category units there and report their effluent as treated and recycled. The larger clusters - Peenya, Bidadi, Harohalli, Doddaballapura - lie roughly 6-10 km upstream in the Vrishabhavathi valley and reach the stretch through the valley's drain network, consistent with the MPRs' own note that the Arkavathi's pollution originates mainly upstream in the V-Valley catchment. Open the Pressures floor for the industrial areas and their CETP coverage.",
           "layerRef": "pressures"
+        },
+        {
+          "key": "register",
+          "label": "Registered industries (KSPCB F-register)",
+          "level": "basin - per Regional Office (2019)",
+          "body": "The basin's KSPCB Regional Offices list ~11,800 consented industries (F-register, as on 31-03-2019) - at least ~37% in the Red or Orange (higher-pollution) categories. The Vrishabhavathi valley alone (Peenya + Dasarahalli) accounts for ~7,000. Per-taluk counts sit on the Gaps layer. Figures are approximate - OCR-extracted from scanned 2019 registers:",
+          "points": [
+            "Ramanagara district (~1,357): Ramanagara ~650, Kanakapura ~510, Magadi ~120, Channapatna ~80.",
+            "Bengaluru / Vrishabhavathi valley: Peenya ~5,070, Dasarahalli ~1,960 - the basin's industrial core.",
+            "Arkavathi headwaters: Nelamangala ~1,950, Doddaballapura ~1,450.",
+            "~4,400 Red/Orange industries basin-wide, against only ~12 on CPCB continuous monitoring (below) - the accountability gap in one line."
+          ],
+          "link": { "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf", "label": "Open a KSPCB F-register (Ramanagara)" }
+        },
+        {
+          "key": "monitoring",
+          "label": "Continuous monitoring (OCEMS)",
+          "level": "individual industry (basin)",
+          "body": "Twelve industries in the Arkavathi catchment are enrolled in CPCB's OCEMS real-time online effluent/emission monitoring - seven monitoring liquid effluent (flow / pH / TDS at the outlet), the rest monitoring stack emissions. But every parameter reads \"NA\" in CPCB's public feed, and the live connectivity dashboard (who is transmitting vs offline) is captcha-gated - so none of these self-reported readings are publicly verifiable. What the public record shows (CPCB OCEMS: cems.cpcb.gov.in, rtdms.cpcb.gov.in; accessed July 2026):",
+          "points": [
+            "Effluent-monitored (7, pharma): Anthem Biosciences (Ramanagara), Eurofins Advinus BioPharma (Ramanagara), Neoanthem Lifesciences (Harohalli), Gomti Research & Pharmachem (Kumbalgodu), Bio-gen Extracts (Dobaspet), Racs Pharma Chem and R L Fine Chem (Kudumalakunte).",
+            "Emission/stack-monitored (5): KPC Gas Power (Bidadi, power), Mukand Sumi Special Steel (Kanakapura), E Nano Incintech (Kanakapura) and Ramky Enviro (Doddaballapura) - common hazardous-waste incinerators, Maridi Bio (Harohalli, biomedical incinerator).",
+            "Every one of these industries' parameter values is \"NA\" in the public OCEMS feed; live values and connectivity status sit behind a login / captcha wall.",
+            "Coverage is partial by design: only large \"17-category\" industries are on OCEMS, and Bengaluru-urban units cannot be assigned to the Arkavathi sub-basin from public city labels (the feed carries no coordinates)."
+          ],
+          "link": { "url": "https://cems.cpcb.gov.in/public/#/l/realtime-connectivity-status-dashboard", "label": "Open CPCB's live connectivity dashboard" }
         }
       ]
     },

--- a/scripts/build_fregister.py
+++ b/scripts/build_fregister.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Reproducible extraction of KSPCB F-register (consented-industry) counts for the
+Arkavathi basin, per Regional Office / taluk, coloured by pollution category.
+
+The F-register is published as scanned PDFs whose table layout drifts between ROs
+(colour appears as a single letter, a full word, or only as the leading letter of
+the XGN category code). We derive colour from THREE signals in priority order:
+  1) an explicit full-word colour cell (Red/Orange/Green/White),
+  2) the leading letter of the XGN category code (R-44, O1324, G55, ...),
+  3) a per-file-detected single-letter colour column.
+Totals count every data row (F.No is an integer) after de-duping by (name,address).
+
+Counts are APPROXIMATE - OCR from scanned 2019 registers. Emits an aggregates JSON;
+does not write into the app data (the numbers are transcribed into gaps.json /
+prs.json by hand, rounded + caveated). Requires: pdfplumber. Sources: fregister-sources.json.
+
+Usage:  python3 scripts/build_fregister.py [--out aggregates.json]
+"""
+import argparse, collections, json, os, re, subprocess, sys, tempfile, urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = json.load(open(os.path.join(HERE, "fregister-sources.json")))
+COLNORM = {"R": "Red", "O": "Orange", "G": "Green", "W": "White"}
+FULLWORD = {"RED": "Red", "ORANGE": "Orange", "GREEN": "Green", "WHITE": "White"}
+CODE_RE = re.compile(r"^([ROGW])[-\s]?\d", re.I)
+
+
+def norm(s):
+    return re.sub(r"\s+", "", (s or "").lower())
+
+
+def fetch(url, dest):
+    if os.path.exists(dest):
+        return
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    import ssl
+    ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+    with urllib.request.urlopen(req, context=ctx, timeout=120) as r, open(dest, "wb") as f:
+        f.write(r.read())
+
+
+def detect_letter_col(rows):
+    counts, distinct = collections.Counter(), collections.defaultdict(set)
+    for c in rows:
+        for i, x in enumerate(c):
+            u = (x or "").strip().upper()
+            if u in ("R", "O", "G", "W"):
+                counts[i] += 1
+                if u != "O":
+                    distinct[i].add(u)
+    cand = [i for i in counts if len(distinct[i]) >= 2]
+    return max(cand, key=lambda i: counts[i]) if cand else None
+
+
+def colour(cells, lc):
+    for x in cells:
+        u = (x or "").strip().upper()
+        if u in FULLWORD:
+            return FULLWORD[u]
+    for x in cells:
+        m = CODE_RE.match((x or "").strip())
+        if m:
+            return COLNORM[m.group(1).upper()]
+    if lc is not None and lc < len(cells):
+        u = (cells[lc] or "").strip().upper()
+        if u in COLNORM:
+            return COLNORM[u]
+    return None
+
+
+def load_rows(paths):
+    import pdfplumber
+    seen, rows = set(), []
+    for path in paths:
+        pdf = pdfplumber.open(path)
+        for p in pdf.pages:
+            t = p.extract_table()
+            if not t:
+                continue
+            for r in t:
+                c = [(x or "").replace("\n", " ").strip() for x in r]
+                if len(c) < 7 or not re.fullmatch(r"\d+", c[0] or ""):
+                    continue
+                key = (norm(c[3]) if len(c) > 3 else "", norm(c[4]) if len(c) > 4 else "")
+                if not key[0] or key in seen:
+                    continue
+                seen.add(key)
+                rows.append(c)
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.join(HERE, "..", "docs", "partnerships",
+                    "paani_partnership", "kspcb-fregister-basin-final.json"))
+    ap.add_argument("--cache", default=os.path.join(tempfile.gettempdir(), "kspcb_freg"))
+    args = ap.parse_args()
+    try:
+        import pdfplumber  # noqa
+    except ImportError:
+        sys.exit("pip install pdfplumber")
+    os.makedirs(args.cache, exist_ok=True)
+    out = {}
+    for ro, meta in SRC["regional_offices"].items():
+        if not meta.get("basin"):
+            continue
+        paths = []
+        for fn in meta["files"]:
+            dest = os.path.join(args.cache, fn)
+            fetch(SRC["base_url"] + fn.replace(" ", "%20"), dest)
+            paths.append(dest)
+        rows = load_rows(paths)
+        lc = detect_letter_col(rows)
+        tot = collections.Counter()
+        per = collections.defaultdict(lambda: collections.Counter())
+        for c in rows:
+            tot["_total"] += 1
+            col = colour(c, lc)
+            tot[col or "_unclassified"] += 1
+            tk = norm(c[6]) if len(c) > 6 else ""
+            per[tk]["_total"] += 1
+            if col in ("Red", "Orange"):
+                per[tk]["_ro"] += 1
+        out[ro] = {k: tot[k] for k in ("_total", "Red", "Orange", "Green", "White", "_unclassified")}
+        if ro == "Ramanagara":
+            out["_ramanagara_taluks"] = {tk: {"total": v["_total"], "ro": v["_ro"]}
+                                         for tk, v in per.items() if v["_total"] >= 20}
+        print(f"{ro:15s} total={tot['_total']:5d} R={tot['Red']:4d} O={tot['Orange']:4d} "
+              f"G={tot['Green']:4d} W={tot['White']:4d} unclass={tot['_unclassified']:4d}")
+    json.dump(out, open(args.out, "w"), indent=1)
+    gt = sum(out[r]["_total"] for r in out if not r.startswith("_"))
+    gro = sum(out[r]["Red"] + out[r]["Orange"] for r in out if not r.startswith("_"))
+    print(f"\nBASIN total={gt}  R+O={gro} ({round(100 * gro / gt)}%)  -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fregister-sources.json
+++ b/scripts/fregister-sources.json
@@ -1,0 +1,14 @@
+{
+  "_note": "KSPCB 'F-register' = the district/Regional-Office register of consented industries (Water/Air Act consent), as on 31-03-2019. Published as scanned PDFs. Used for the Arkavathi-basin industrial-register accountability layer (per-taluk counts on the Gaps layer + basin denominator in the PRS Industrial tab). Counts are OCR-extracted and approximate. See scripts/build_fregister.py.",
+  "base_url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/",
+  "as_on": "2019-03-31",
+  "regional_offices": {
+    "Ramanagara":   { "files": ["Ramanagara.pdf"], "basin": true, "maps_to_units": ["ramanagara", "kanakapura", "channapatna", "magadi", "harohalli"], "note": "per-taluk split is clean here" },
+    "Nelamangala":  { "files": ["Nelamangala.pdf", "Nelamangala_1.pdf"], "basin": true, "maps_to_units": ["nelamangala"], "note": "Arkavathi headwaters" },
+    "Doddaballapura": { "files": ["Doddaballapura.pdf", "Doddaballapura_1.pdf", "Doddaballapura_2.pdf"], "basin": true, "maps_to_units": ["doddaballapura"], "note": "Arkavathi headwaters" },
+    "Peenya":       { "files": ["Peenya.pdf", "Peenya_1.pdf", "Peenya_2.pdf"], "basin": true, "maps_to_units": ["bbmp"], "note": "Vrishabhavathi valley - the basin's industrial core" },
+    "Dasarahalli":  { "files": ["Dasarahalli.pdf"], "basin": true, "maps_to_units": ["bbmp"], "note": "Vrishabhavathi valley (NW Bengaluru)" },
+    "Bommanahalli": { "files": ["Bommanahalli.pdf"], "basin": false, "note": "SE Bengaluru -> K&C valley / Dakshina Pinakini, NOT Arkavathi - excluded" },
+    "Yelahanka":    { "files": ["Yelahanka.pdf", "Yalahanka_compressed.pdf"], "basin": false, "note": "N Bengaluru - straddles Arkavathi vs Pennar - excluded pending clean split" }
+  }
+}

--- a/src/app/[cityId]/about/about-content.tsx
+++ b/src/app/[cityId]/about/about-content.tsx
@@ -1207,6 +1207,12 @@ export function CityAboutContent({
                 description="The polluted-stretch entry point on the basin atlas: the CPCB/NGT stretch 2020 vs 2025, its priority, and per-area gaps (sewage, industrial, solid, hazardous, FSTP, e-flow, treated-water reuse, flood plain). Built from 7 NMCG Monthly Progress Reports (Karnataka, 2020-2026), the CPCB &lsquo;Polluted River Stretches for Restoration of Water Quality - 2025&rsquo; report (Oct 2025; Arkavathi Priority I, BOD 72 mg/L, Hesaraghatta to d/s Kanakapura), District Environment Plans (Ramanagara 2021, Bengaluru Urban 2022), and Paani Earth&apos;s digitised stretch geometry. KSPCB&apos;s own 2022-23 lab reads Priority IV - shown as a central-vs-state divergence. Every figure carries its admin level; &lsquo;nil / not reported&rsquo; means absent from the documents, not necessarily absent on the ground. Co-built with Paani Earth."
                 frequency="NMCG monthly; CPCB + DEP periodic"
               />
+              <DataSource
+                name="KSPCB F-register - consented-industry register (2019)"
+                url="https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                description="The KSPCB Regional-Office registers of consented industries (Water/Air Act), as on 31-03-2019, published as scanned PDFs. Extracted per taluk and by pollution category (Red/Orange/Green/White) for the basin&apos;s ROs - Ramanagara (Ramanagara/Kanakapura/Magadi/Channapatna), Peenya + Dasarahalli (Vrishabhavathi valley), Nelamangala and Doddaballapura (headwaters). ~11,800 consented industries basin-wide, at least ~37% Red/Orange - the industrial denominator against which only ~12 appear on CPCB continuous monitoring. Per-taluk counts on the Gaps layer; basin summary in the PRS Industrial tab. Counts are OCR-extracted and approximate; SE/N Bengaluru ROs (Bommanahalli/Yelahanka) excluded as they drain to other basins. See scripts/build_fregister.py."
+                frequency="periodic (KSPCB republishes registers)"
+              />
             </>
           )}
 

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -139,6 +139,9 @@ interface PrsCategory {
   points?: string[];
   /** A map layer this category maps to (e.g. "pressures", "evidence-points"). */
   layerRef?: string;
+  /** An external source to open in a new tab (e.g. a live CPCB dashboard the
+   *  reader can inspect for themselves). */
+  link?: { url: string; label: string };
   /** No known public data yet - shown as an explicit honest gap. */
   noData?: boolean;
 }
@@ -1577,6 +1580,16 @@ function PRSPanel({
                   <button onClick={() => onShowLayer(cat.layerRef!)} className="inline-flex items-center gap-1 text-[12px] font-medium text-blue-600 dark:text-blue-400 hover:underline">
                     Show {layerByFamily[cat.layerRef].label} on the map →
                   </button>
+                )}
+                {cat.link && (
+                  <a
+                    href={cat.link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-2.5 py-1.5 text-[12px] font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50"
+                  >
+                    {cat.link.label} ↗
+                  </a>
                 )}
               </>
             )}


### PR DESCRIPTION
## What

Phase 2 of the Arkavathi basin deep-dive: the **industrial-accountability layer**. Rebased onto current `main`.

- **KSPCB F-register as the industrial denominator** - the full count of consented industries in the Arkavathi basin, with the Red/Orange share, set against the ~12 industries actually visible on CPCB OCEMS. Makes the monitoring gap legible instead of implied.
- **OCEMS note** - a cited caveat on why continuous-emission data is effectively absent for these units.
- **F-register card de-duplicated** so the numbers appear once, not thrice.

## Changes

- `scripts/build_fregister.py` + `scripts/fregister-sources.json` - reproducible build of the F-register denominator.
- `public/data/basins/arkavathi/gaps.json`, `prs.json` - gap data + polluted-river-stretch additions.
- `src/components/basin/basin-atlas.tsx` - external-link affordance on PRS categories (opens the live CPCB dashboard).
- `src/app/[cityId]/about/about-content.tsx` - source note.