### PR TITLE
Mobile fixes on the TOSS Conf click-along route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ docs/paani_data/
 # Python bytecode
 scripts/__pycache__/
 __pycache__/
+
+# Conference talk decks (local only)
+/talks/

--- a/src/app/[cityId]/commitments/commitments-client.tsx
+++ b/src/app/[cityId]/commitments/commitments-client.tsx
@@ -81,7 +81,7 @@ function CommitmentRow({ p, cityId, highlight }: { p: TrackedCommitment; cityId:
       {/* The one-line collapsed view: chip · title · dates. Nothing else. */}
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-3 px-3 py-2.5 text-left"
+        className="w-full flex flex-wrap sm:flex-nowrap items-center gap-x-3 gap-y-1 px-3 py-2.5 text-left"
         aria-expanded={open}
       >
         <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${STATUS_STYLE[p.status]}`}>
@@ -90,7 +90,7 @@ function CommitmentRow({ p, cityId, highlight }: { p: TrackedCommitment; cityId:
         <span className="flex-1 text-sm font-medium text-slate-800 dark:text-slate-200 leading-snug">
           {p.title}
         </span>
-        <span className={`text-xs font-mono shrink-0 ${p.revised_due ? "text-amber-600 dark:text-amber-400" : "text-slate-500"}`}>
+        <span className={`text-xs font-mono shrink-0 max-sm:order-last max-sm:basis-full ${p.revised_due ? "text-amber-600 dark:text-amber-400" : "text-slate-500"}`}>
           {fmtDue(p)}
         </span>
         <svg

--- a/src/app/[cityId]/rivers/rivers-client.tsx
+++ b/src/app/[cityId]/rivers/rivers-client.tsx
@@ -373,7 +373,7 @@ export default function RiversClient({
     <div className="relative h-[calc(100vh-64px)] flex flex-col">
       {/* Stats bar */}
       <div className="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700 px-4 py-2 flex flex-wrap gap-x-5 gap-y-1 items-center text-sm shrink-0">
-        <span className="font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">
+        <span className="font-semibold text-slate-700 dark:text-slate-300 sm:whitespace-nowrap">
           {cityDisplayName} - {scopeLabel}
         </span>
         {showHeaderStats && (


### PR DESCRIPTION
## What

Two one-line layout fixes for phone-width viewports, found during the mobile pass for the TOSS Conf '26 live click-along (audience drives the site on their own phones):

- **Commitments register**: the collapsed row's due-date span carried `shrink-0`, so long revised-date strings (e.g. `2023-12 -> Aug 2028 (smart-meter build-out)`) refused to shrink - forcing a 484px layout viewport (browser zooms the page out ~20%) and crushing the title column to one word per line. On mobile the date now wraps onto its own line under the row; `sm:` and up unchanged.
- **Rivers header**: the city scope label carried `whitespace-nowrap`, forcing a 450px layout viewport on /bangalore/rivers - which also affects the Cauvery basin overlay hosted on that page. The label now wraps on mobile only.

Also adds `/talks/` to .gitignore (local conference decks stay out of the repo).

## Verification

Driven with emulated-mobile Chrome (390x844, touch) via puppeteer-core:
- Production before fix: /chennai/commitments = 484px, /bangalore/rivers = 450px layout width
- Local build after fix: both pages and the Cauvery KA overlay = exactly 390px, no horizontal overflow
- Full click-along route re-driven: Chennai dashboard (incl. Tamil toggle), Cauvery overlay -> TN side -> sub-basin drill-down, commitments register - all functional by touch