### PR TITLE
Arkavathi atlas: working 'Show on the map' for industrial areas, uniform IA accountability rows; legible Cauvery sub-basin borders

### DIFF
--- a/public/data/basins/arkavathi/accountability.json
+++ b/public/data/basins/arkavathi/accountability.json
@@ -1080,6 +1080,9 @@
         "prop": "name",
         "contains": [
           "Peenya"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },
@@ -1107,6 +1110,24 @@
             "CAG (2017) found KIADB areas without CETPs and ~2,571 ML/yr untreated discharge - the plan's response has no reported follow-through."
           ],
           "legalRef": "effluent"
+        },
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No hazardous waste action for Bidadi Industrial Area in the Action Plan (Jan 2019) beyond general compliance."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "MPRs carry stretch-level hazardous-waste totals only (~4,033 MTPA from 97 industries); nothing Bidadi-specific.",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Hazardous waste for Bidadi Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "hazardous"
         },
         {
           "key": "solid-waste",
@@ -1166,6 +1187,9 @@
         "prop": "name",
         "contains": [
           "Bidadi"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },
@@ -1191,6 +1215,24 @@
           },
           "gaps": [],
           "legalRef": "effluent"
+        },
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No hazardous waste action for Harohalli Industrial Area in the Action Plan (Jan 2019) beyond general compliance."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "MPRs carry stretch-level hazardous-waste totals only (~4,033 MTPA from 97 industries); nothing Harohalli-specific.",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Hazardous waste for Harohalli Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "hazardous"
         },
         {
           "key": "fecal-sludge",
@@ -1269,6 +1311,9 @@
         "prop": "name",
         "contains": [
           "Harohalli"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },
@@ -1296,6 +1341,24 @@
             "The stretch's only CETPs have no public compliance reporting."
           ],
           "legalRef": "effluent"
+        },
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No hazardous waste action for Kumbalagodu Industrial Area in the Action Plan (Jan 2019) beyond general compliance."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "MPRs carry stretch-level hazardous-waste totals only (~4,033 MTPA from 97 industries); nothing Kumbalagodu-specific.",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Hazardous waste for Kumbalagodu Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "hazardous"
         },
         {
           "key": "solid-waste",
@@ -1356,6 +1419,9 @@
         "contains": [
           "Kumbalagodu",
           "Kumbalgodu"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },
@@ -1365,6 +1431,42 @@
       "name": "Dabaspet Industrial Area",
       "inBasinNote": "KIADB area in the Kumudavathi/TG Halli catchment (Nelamangala side); OCEMS-enrolled units include Bio-gen Extracts.",
       "categories": [
+        {
+          "key": "effluent",
+          "label": "Industrial effluent / CETP",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No industrial effluent or CETP commitment for Dabaspet Industrial Area found in the Action Plan (Jan 2019)."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any ingested MPR (through June 2025).",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Industrial effluent for Dabaspet Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "effluent"
+        },
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No hazardous waste action for Dabaspet Industrial Area in the Action Plan (Jan 2019) beyond general compliance."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "MPRs carry stretch-level hazardous-waste totals only (~4,033 MTPA from 97 industries); nothing Dabaspet-specific.",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Hazardous waste for Dabaspet Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "hazardous"
+        },
         {
           "key": "solid-waste",
           "label": "Solid waste",
@@ -1425,6 +1527,9 @@
           "Dabaspet",
           "Dabaspete",
           "Dobaspet"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },
@@ -1434,6 +1539,44 @@
       "name": "Doddaballapura Industrial Area",
       "inBasinNote": "Textile-heavy KIADB area at the Arkavathi headwaters; Ramky Enviro's hazardous-waste incinerator (OCEMS-enrolled) sits here.",
       "categories": [
+        {
+          "key": "effluent",
+          "label": "Industrial effluent / CETP",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No industrial effluent or CETP commitment for Doddaballapura Industrial Area found in the Action Plan (Jan 2019)."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any ingested MPR (through June 2025).",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Industrial effluent for Doddaballapura Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding.",
+            "A textile-heavy estate at the Arkavathi headwaters, with no CETP commitment or effluent reporting on record."
+          ],
+          "legalRef": "effluent"
+        },
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No hazardous waste action for Doddaballapura Industrial Area in the Action Plan (Jan 2019) beyond general compliance."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "MPRs carry stretch-level hazardous-waste totals only (~4,033 MTPA from 97 industries); nothing Doddaballapura-specific.",
+            "asOf": "June 2025"
+          },
+          "gaps": [
+            "Hazardous waste for Doddaballapura Industrial Area appears in neither the Action Plan nor the MPRs - the reporting gap is the finding.",
+            "Ramky Enviro's hazardous-waste incinerator (OCEMS-enrolled) operates in this estate, yet neither the plan nor the MPRs itemise it."
+          ],
+          "legalRef": "hazardous"
+        },
         {
           "key": "solid-waste",
           "label": "Solid waste",
@@ -1493,6 +1636,9 @@
         "contains": [
           "Doddaballapur",
           "Apparel Park"
+        ],
+        "kinds": [
+          "industrial-area"
         ]
       }
     },

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -260,8 +260,9 @@ export interface AccRegion {
   /** Regions the documents never itemise carry this instead of categories. */
   silentNote?: string;
   /** How to find this region on the map: the layer family plus a property
-   *  match (exact values or substring contains). */
-  mapMatch?: { family: string; prop?: string; values?: string[]; contains?: string[] };
+   *  match (exact values or substring contains). When the family is split into
+   *  kind-filtered layer entries, `kinds` names which entries to switch on. */
+  mapMatch?: { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
   categories: AccCategory[];
 }
 export interface AccountabilityData {
@@ -335,6 +336,24 @@ function MapController({
       map.setView(defaultFocus.center, defaultFocus.zoom);
     }
   }, [fitBounds, defaultFocus, hasSelection, map]);
+  return null;
+}
+
+/** Fly to a freshly highlighted region ("Show X on the map"). Keyed on the
+ *  bbox so other layers streaming in (which recompute the bounds object but
+ *  not its extent) don't re-trigger the flight. */
+function HighlightFlyer({ bounds }: { bounds: L.LatLngBounds | null }) {
+  const map = useMap();
+  const lastRef = useRef<string>("");
+  useEffect(() => {
+    // Highlight cleared (Reset): forget the last flight so re-highlighting
+    // the same region flies again.
+    if (!bounds) { lastRef.current = ""; return; }
+    const key = bounds.toBBoxString();
+    if (key === lastRef.current) return;
+    lastRef.current = key;
+    map.flyToBounds(bounds, { padding: [30, 30], maxZoom: 13, duration: 0.8 });
+  }, [bounds, map]);
   return null;
 }
 
@@ -648,6 +667,18 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     return b.isValid() ? b : null;
   }, [selectedRiverId, shedData, boundaryData, selectedSheds, manifest.defaultFocus]);
 
+  // Frame the region highlighted from the accountability matrix ("Show X on
+  // the map") once its layer data is in. Matching mirrors the highlight style.
+  const highlightBounds = useMemo(() => {
+    if (!mapHighlight) return null;
+    const feats = (data[mapHighlight.family]?.features ?? []).filter((f) =>
+      matchesHighlight(mapHighlight, { family: mapHighlight.family } as BasinLayer, f),
+    );
+    if (!feats.length) return null;
+    const b = L.geoJSON({ type: "FeatureCollection", features: feats } as FC).getBounds();
+    return b.isValid() ? b : null;
+  }, [mapHighlight, data]);
+
   function selectRiver(riverId: string | null) {
     setSelectedRiverId(riverId);
     setSelectedFeature(null);
@@ -908,7 +939,10 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
         <MapContainer center={manifest.mapCenter} zoom={manifest.mapZoom} className="h-full w-full" preferCanvas zoomControl={false}>
           <ZoomControl position="bottomright" />
           <MapResizer />
-          <MapController fitBounds={fitBounds} defaultFocus={manifest.defaultFocus} hasSelection={selectedRiverId != null} />
+          {/* mapHighlight counts as a selection here so Reset (which clears it)
+              flies back to the overview instead of staying zoomed into the
+              estate the HighlightFlyer framed. */}
+          <MapController fitBounds={fitBounds} defaultFocus={manifest.defaultFocus} hasSelection={selectedRiverId != null || mapHighlight != null} />
           <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} />
 
           {/* One shared canvas, stacked by DRAW ORDER (not panes): base outlines
@@ -1041,10 +1075,14 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
             // place in the hierarchy.
             const isBase = l.family === "boundary" || l.family === "admin-district";
             const isAdmin = l.family.startsWith("admin");
-            const hlActive = mapHighlight?.family === l.family;
+            // The key must encode WHICH region is highlighted, not just that
+            // one is: react-leaflet only re-applies styles on remount, so a
+            // boolean flag would leave the first highlight stuck when the
+            // user picks a different region of the same family.
+            const hlSig = mapHighlight?.family === l.family ? JSON.stringify(mapHighlight) : "";
             return (
               <GeoJSON
-                key={`${layerKey(l)}-${selectedRiverId}-${tiles.isDark}-${hlActive ? "hl" : ""}`}
+                key={`${layerKey(l)}-${selectedRiverId}-${tiles.isDark}-${hlSig}`}
                 data={fcScoped}
                 interactive={!isBase}
                 style={(feat?: Feature) => fillStyle(l, feat, faded, null, mapHighlight)}
@@ -1102,6 +1140,8 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                 ));
             });
           })}
+
+          <HighlightFlyer bounds={highlightBounds} />
 
           {/* Visitor's own location: an accuracy ring + a solid blue dot, drawn
               last so it sits on top of every layer. */}
@@ -1171,12 +1211,12 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
           </button>
         )}
 
-        {/* Reset: clears ANY active selection (river scope, gap unit, or clicked
-            feature) so every layer shows basin-wide and nothing is greyed out,
-            and flies back to the overview. */}
-        {(selectedRiverId || selectedGapUnit || selectedFeature || selectedPrs) && (
+        {/* Reset: clears ANY active selection (river scope, gap unit, clicked
+            feature, or accountability-matrix highlight) so every layer shows
+            basin-wide and nothing is greyed out, and flies back to the overview. */}
+        {(selectedRiverId || selectedGapUnit || selectedFeature || selectedPrs || mapHighlight) && (
           <button
-            onClick={() => { setSelectedGapUnit(null); setSelectedFeature(null); setSelectedPrs(false); setGapFromPrs(false); selectRiver(null); }}
+            onClick={() => { setSelectedGapUnit(null); setSelectedFeature(null); setSelectedPrs(false); setGapFromPrs(false); setMapHighlight(null); selectRiver(null); }}
             className="absolute top-3 right-3 z-[500] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-md shadow px-3 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800"
           >
             ↺ Reset{selectedRiver ? " to whole basin" : ""}
@@ -1268,12 +1308,37 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                 depUnit={manifest.defaultGapUnit}
                 onShowRegion={(r) => {
                   if (!r.mapMatch) return;
-                  setEnabled((s) => ({ ...s, [r.mapMatch!.family]: true }));
-                  setMapHighlight(r.mapMatch);
+                  const m = r.mapMatch;
+                  // Toggle keys are layerKey(l) (family:kindFilter for split
+                  // families), so enabling the bare family name would miss the
+                  // kind-filtered entries (e.g. pressures-industrial). Which
+                  // kinds to switch on: mapMatch.kinds, else a kind-valued
+                  // property match, else every entry of the family.
+                  const kinds = m.kinds ?? (m.prop === "kind" ? m.values : undefined);
+                  setEnabled((s) => {
+                    const next = { ...s };
+                    for (const l of manifest.layers) {
+                      if (l.family !== m.family) continue;
+                      if (l.kindFilter && kinds && !kinds.includes(l.kindFilter)) continue;
+                      next[layerKey(l)] = true;
+                    }
+                    return next;
+                  });
+                  setMapHighlight(m);
+                  // On phones this sheet covers the map - close it so the
+                  // highlighted region is actually visible.
+                  if (typeof window !== "undefined" && window.innerWidth < 768) setSelectedPrs(false);
                 }}
                 onShowLayer={(family) => {
                   const lyr = layerByFamily[family];
-                  setEnabled((s) => ({ ...s, [family]: true }));
+                  // Enable every entry of the family - kind-split families
+                  // (e.g. pressures-industrial) key their toggles by
+                  // family:kindFilter, so the bare family key would miss them.
+                  setEnabled((s) => {
+                    const next = { ...s };
+                    for (const l of manifest.layers) if (l.family === family) next[layerKey(l)] = true;
+                    return next;
+                  });
                   if (lyr) {
                     setFocusedFloor(lyr.floor);
                     setExpandedFloors((s) => { const n = new Set(s); n.add(lyr.floor); return n; });
@@ -1515,12 +1580,16 @@ const ADMIN_DASH: Record<string, string | undefined> = {
   "admin-gp": "1 4",
 };
 
-type MapHighlight = { family: string; prop?: string; values?: string[]; contains?: string[] };
+type MapHighlight = { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
 
 function matchesHighlight(hl: MapHighlight | null | undefined, l: BasinLayer, feat: Feature | undefined): boolean {
   if (!hl || hl.family !== l.family) return false;
+  const p = (feat?.properties ?? {}) as Record<string, unknown>;
+  // Kind guard: a name-contains match must not leak onto other kinds sharing
+  // the family (e.g. a 17-category industry whose address names the estate).
+  if (hl.kinds && !hl.kinds.includes(String(p.kind ?? ""))) return false;
   if (!hl.prop) return true;
-  const v = String((feat?.properties as Record<string, unknown>)?.[hl.prop] ?? "");
+  const v = String(p[hl.prop] ?? "");
   if (hl.values?.includes(v)) return true;
   return hl.contains?.some((c) => v.toLowerCase().includes(c.toLowerCase())) ?? false;
 }

--- a/src/components/basin/basin-overview.tsx
+++ b/src/components/basin/basin-overview.tsx
@@ -357,8 +357,12 @@ export function BasinOverview({
     const v = ref ? metricFor(ref) : null;
     const isSel = key === selectedKey;
     return {
-      color: isSel ? "#0f172a" : "#475569",
-      weight: isSel ? 2.5 : 1,
+      // Separators must survive same-colour neighbours (most sub-basins share
+      // a fill class): dark hairlines on the light basemap, light on dark.
+      // The selected outline flips too - near-black vanishes in dark mode.
+      color: isSel ? (tiles.isDark ? "#f8fafc" : "#0f172a") : tiles.isDark ? "#e2e8f0" : "#1e293b",
+      weight: isSel ? 3 : 1.8,
+      opacity: isSel ? 1 : 0.75,
       fillColor: metricColor(metric, v),
       fillOpacity: tiles.isDark ? 0.45 : 0.55,
     };


### PR DESCRIPTION
## What

Three fixes to the basin surfaces, validated on a local dev server (desktop + phone).

### 1. "Show on the map" now works for industrial areas (Arkavathi atlas)

- **Root cause:** the accountability matrix enabled the layer under its bare family key (`pressures-industrial`), but kind-split families key their toggles as `family:kindFilter` - so the KIADB layer never switched on. ULBs worked because `admin-town` has no kind filter.
- `onShowRegion`/`onShowLayer` now enable the matching kind-filtered entries; a new optional `kinds` field on `mapMatch` scopes which (the six named KIADB areas set `["industrial-area"]`).
- The map now **flies to the matched region** once its layer data loads (`HighlightFlyer`), and on phones the detail sheet closes so the highlight is actually visible (it used to cover the whole map).
- The layer's remount key now encodes **which** region is highlighted, not just that one is - switching from one estate to another used to leave the yellow border stuck on the first.
- A kind guard stops name-contains matches leaking onto 17-category industry points whose addresses mention the estate (real collisions exist, e.g. "Anugraha Chemicals ... Doddaballapura").
- **Reset** now also clears the highlight, appears when only a highlight is active, and returns the map to the overview framing.

### 2. Uniform accountability rows for all named industrial areas

Every named KIADB area now carries the same five rows - Industrial effluent / CETP, Hazardous waste, Solid waste, Sewage, Treated-water reuse (Harohalli keeps its extra fecal-sludge row). Where the documents say nothing, the row is added as silent ("Not in plan or MPR") in the standard wording, with the relevant legal reference linked:

- Hazardous waste added for Bidadi, Harohalli, Kumbalagodu, Dabaspet, Doddaballapura (MPR note: stretch-level totals only, ~4,033 MTPA from 97 industries, nothing area-specific)
- Effluent/CETP added for Dabaspet and Doddaballapura
- Doddaballapura's rows carry two extra gap lines from its existing dossier note: textile-heavy estate with no CETP commitment on record, and Ramky Enviro's OCEMS-enrolled hazardous-waste incinerator itemised in neither plan nor MPRs

The MPR refresh script only rewrites `mpr.asOf`, so it is unaffected.

### 3. Legible sub-basin separators on the Cauvery overview

Unselected sub-basins drew a 1px slate hairline under a half-opacity choropleth fill, so neighbours sharing a fill class merged into one blob, and the hairline vanished entirely on the dark basemap. Separators are now 1.8px and theme-aware (dark on light, light on dark), and the selected outline flips to near-white in dark mode. Applies to both cauvery-ka (9 sub-basins) and cauvery-tn (18).

## Testing

- `tsc --noEmit`, ESLint, and `next build` clean (one pre-existing unused-var warning in basin-overview.tsx untouched)
- Manually exercised on a local dev server, including the mobile flow where the bug was reported