### PR TITLE
fix: About data-source cards overflow on mobile (all cities)

### DIFF
--- a/src/app/[cityId]/about/about-content.tsx
+++ b/src/app/[cityId]/about/about-content.tsx
@@ -142,16 +142,21 @@ function DataSourceGroupHeader({ title }: { title: string }) {
 function DataSource({ name, url, description, frequency }: DataSourceItem) {
   return (
     <div className="border border-slate-200 dark:border-slate-700 rounded-lg p-3">
-      <div className="flex items-start justify-between gap-3">
+      {/* Stack on mobile: a shrink-0 badge with a long frequency string
+          ("static (Nov 2017 baseline; ...)") overflowed the viewport and
+          squeezed the title to one word per line at 390px (QA, Bengaluru). */}
+      <div className="flex flex-col gap-0.5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
         <a
           href={url}
           target={url.startsWith("/") ? undefined : "_blank"}
           rel={url.startsWith("/") ? undefined : "noopener noreferrer"}
-          className="font-medium text-blue-600 dark:text-blue-400 hover:underline"
+          className="font-medium text-blue-600 dark:text-blue-400 hover:underline min-w-0 break-words"
         >
           {name}
         </a>
-        <span className="text-xs text-slate-400 dark:text-slate-500 font-mono shrink-0">{frequency}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500 font-mono whitespace-normal break-words sm:text-right sm:max-w-[45%] sm:shrink-0">
+          {frequency}
+        </span>
       </div>
       <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{description}</p>
     </div>


### PR DESCRIPTION
## What

The About page's data-source cards overflow the viewport on mobile: the frequency badge is `shrink-0` with unbounded text, so long cadence strings (e.g. Bengaluru's JICA card: "static (Nov 2017 baseline; periodic refresh on subsequent...)") push past the right edge and squeeze the source title to one word per line at 390px.

Spotted on the live Bengaluru About page during Delhi-onboarding QA (screenshot from a phone; reproduced headlessly).

## Fix

The card header stacks vertically on mobile (`flex-col` + `break-words`, structurally overflow-proof) and keeps the side-by-side layout from `sm:` up with the badge capped at 45% width and allowed to wrap. Shared component, so all cities benefit; no data or copy changes.