### PR TITLE
Mobile: two pages were forcing the layout viewport wider than the phone

### DIFF
--- a/src/app/[cityId]/allocations/allocations-client.tsx
+++ b/src/app/[cityId]/allocations/allocations-client.tsx
@@ -259,7 +259,13 @@ function AuthorityRow({ auth }: { auth: Authority }) {
         className="w-full flex items-center gap-3 px-3 py-2.5 text-left"
         aria-expanded={open}
       >
-        <span className="shrink-0 text-sm font-medium text-slate-800 dark:text-slate-200 leading-snug">
+        {/* NOT shrink-0. Authority names run long - Delhi's "Haryana
+            Irrigation & Water Resources (Western Yamuna Canal)" measures
+            465px - and refusing to shrink pushed the whole page's layout
+            viewport to 522px on a 393px phone, so the browser scaled every
+            page element down ~25% to fit. min-w-0 lets the flex item shrink
+            below its content width; the name then wraps instead. */}
+        <span className="min-w-0 text-sm font-medium text-slate-800 dark:text-slate-200 leading-snug">
           {auth.name}
         </span>
         <span className="flex-1 min-w-0 text-xs text-slate-500 truncate hidden sm:block">

--- a/src/components/story/story-shortcodes.tsx
+++ b/src/components/story/story-shortcodes.tsx
@@ -187,7 +187,11 @@ export function Figure({
       <figcaption className="text-xs text-slate-500 dark:text-slate-400 mt-2 leading-relaxed">
         <span className="text-slate-700 dark:text-slate-300">{caption}</span>
         {" "}
-        <span className="text-slate-400 dark:text-slate-500">
+        {/* break-words: `source` is a raw Wikimedia Commons URL, which has no
+            break opportunity, so it measured 428px and dragged the layout
+            viewport past the device width - shrinking the whole Origins page
+            on a phone. Wrapping the URL keeps the page at device width. */}
+        <span className="text-slate-400 dark:text-slate-500 break-words">
           {credit ? `- ${credit} ` : ""}- {t("story.source")} {source}
         </span>
       </figcaption>
@@ -215,7 +219,8 @@ export function TimeLapse({ src, alt, caption, source }: TimeLapseProps) {
       </div>
       <figcaption className="text-xs text-slate-500 dark:text-slate-400 mt-2 leading-relaxed">
         <span className="text-slate-700 dark:text-slate-300">{caption}</span>{" "}
-        <span className="text-slate-400 dark:text-slate-500">- {t("story.source")} {source}</span>
+        {/* Same unbreakable-URL problem as the Hero/Figure credits above. */}
+        <span className="text-slate-400 dark:text-slate-500 break-words">- {t("story.source")} {source}</span>
       </figcaption>
     </figure>
   );
@@ -353,7 +358,11 @@ export function BeforeAfter({
       </div>
       <figcaption className="text-xs text-slate-500 dark:text-slate-400 mt-2 leading-relaxed">
         <span className="text-slate-700 dark:text-slate-300">{caption}</span>{" "}
-        <span className="text-slate-400 dark:text-slate-500">
+        {/* break-words: `source` is a raw Wikimedia Commons URL, which has no
+            break opportunity, so it measured 428px and dragged the layout
+            viewport past the device width - shrinking the whole Origins page
+            on a phone. Wrapping the URL keeps the page at device width. */}
+        <span className="text-slate-400 dark:text-slate-500 break-words">
           {credit ? `- ${credit} ` : ""}- {t("story.source")} {source}
         </span>
       </figcaption>


### PR DESCRIPTION
Fixes two pages that were quietly rendering **shrunk** on phones.

Neither page *overflowed*, which is why this never looked like a broken layout. Each contained an element that couldn't fit 393px, so the browser widened the **layout viewport** to accommodate it and scaled the whole page down. The reader just sees everything smaller, with nothing obviously wrong.

Measured on an emulated iPhone 14 Pro (393×852, DPR 3, `mobile: true`):

| page | before | after |
|---|---|---|
| `/delhi/allocations` | **522px** (~25% shrink) | **393px** |
| `/delhi/origins` | **444px** | **393px** |

## Allocations

The authority name carried `shrink-0`, so it couldn't shrink inside its flex row. Delhi has the longest names on the platform — *"Haryana Irrigation & Water Resources (Western Yamuna Canal)"* measures 465px alone — and five states' worth of them.

Swapped to `min-w-0`, letting the flex item shrink below its content width so the name wraps.

## Origins

The story credit spans interpolate a raw Wikimedia Commons URL. A URL has no break opportunity, so the span measured 428px and dragged the viewport with it. Added `break-words` to all three credit spans (Hero, Figure, inline).

## Also fixes other cities

Both are **shared components**, so Chennai and Madurai allocations are fixed too (Chennai was 421px). Desktop verified unchanged at 1280px.

## Known remaining, out of scope

**`/chennai/origins` is still 402px** — a *different* cause: a full-bleed figure using `-mx-6 sm:-mx-12 md:-mx-24` whose 24px negative margin exceeds the page padding at 393px. Delhi's origins doesn't use it, so it's outside this Delhi audit. Happy to fix separately.

Also noted but not touched, as design calls rather than defects:
- tap targets under 44px (11-30/page; **594 on `/my-ward/rankings`**, which is the 250-row table)
- caption/label text at 10-11px across pages
- `/delhi/my-ward` reproduces a 468px viewport but the probe finds no oversized element once expanded — likely transient during hydration, wants a real-device check

## A note on method

Worth recording: the first audit pass produced **false positives on every page**. Running `chrome --headless --window-size=390,x` renders a *desktop* layout and clips it, so everything looks catastrophically broken. A control run on Chennai failed identically — which is what exposed the instrument rather than the site.

The real audit uses CDP `Emulation.setDeviceMetricsOverride` with `mobile: true`, which is what makes the `<meta viewport>` tag take effect, and measures `scrollWidth` vs `innerWidth` in the DOM.

**All 12 Delhi pages have zero horizontal overflow.** Nothing is clipped or side-scrolling.

## Verification

tsc clean · 0 lint errors · 68/68 tests · production build passes · before/after measured with the same harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
