### PR TITLE
Story figures: full-bleed overhung the phone viewport by 8px a side

### DIFF
--- a/src/components/story/story-shortcodes.tsx
+++ b/src/components/story/story-shortcodes.tsx
@@ -159,13 +159,19 @@ export function Figure({
   fit = "cover",
 }: FigureProps) {
   const { t } = useLanguage();
-  // "wide" breaks well past the prose column. The negative margins are
-  // heavy on large screens so detailed images (maps, diagrams) render
-  // close to viewport width rather than being squeezed into the
-  // 768px reading column.
+  // "wide" breaks well past the prose column so detailed images (maps,
+  // diagrams) render close to viewport width rather than being squeezed into
+  // the reading measure.
+  //
+  // The base value MUST match the article's own horizontal padding, which is
+  // px-4 (16px) on mobile - see story-page.tsx. It was -mx-6 (24px), so every
+  // full-bleed figure hung 8px off each edge of a 393px phone, which dragged
+  // the layout viewport to 402px and made the browser shrink the whole page.
+  // The larger breakpoints keep their existing values: they bleed into the
+  // centring gutter of a max-w-4xl article, which is what "wide" is for.
   const wrapperCls =
     size === "wide"
-      ? "my-8 -mx-6 sm:-mx-12 md:-mx-24 lg:-mx-40 xl:-mx-56"
+      ? "my-8 -mx-4 sm:-mx-12 md:-mx-24 lg:-mx-40 xl:-mx-56"
       : "my-8";
   // For "contain" we add a subtle background so letterboxed sides don't
   // sit awkwardly against the prose - especially noticeable in dark mode.


### PR DESCRIPTION
The two full-bleed images on `/chennai/origins` overhung the phone viewport by **8px on each side**.

The `Figure` "wide" size uses negative margins to break out of the prose column. Its base value was `-mx-6` (24px), but the article's own mobile padding is `px-4` (16px) — so the bleed overshot by exactly 8px.

Nothing visibly overflowed, which is why it never looked broken: the browser widened the **layout viewport** to 402px on a 393px phone and scaled the whole page down. Readers just saw a slightly shrunken Origins page.

## Fix

Base changed to `-mx-4` so the bleed matches the padding exactly. One value.

Verified with CDP device emulation (iPhone 14 Pro, 393×852, `mobile: true`):

| page | before | after |
|---|---|---|
| `/chennai/origins` | 402px | **393px** |
| `/delhi/origins` | 393px | **393px** (unchanged) |

Desktop unchanged: 1024px and 1280px measure the same as `main`.

## Not fixed, and pre-existing

**`/chennai/origins` horizontally scrolls at 768px** (+57px here, +72px on `main`). The larger breakpoints (`sm:-mx-12 md:-mx-24 lg:-mx-40`) bleed further than the gutter available at those widths. A fixed margin fundamentally can't express this — the safe bleed is `(viewport − container) / 2`, which depends on the viewport.

I tried replacing the whole ladder with a viewport-pinned full bleed (`w-screen` + `ml-[calc(50%-50vw)]`) and **backed it out**. It did fix 768px, but left the figure 40px off-centre at 1024px and above for a reason I couldn't pin down — and shipping a desktop regression to fix a tablet width that was already broken is a bad trade. The tablet case deserves its own change.

Also surfaced while measuring, unrelated to this component: **the site header nav overflows between 640px and ~722px** on every page (`hidden sm:flex` switches on the desktop nav at 640px, but it needs 698px). Worth a separate look.

## Verification

tsc clean · 0 lint errors · 68/68 tests · before/after measured with the same CDP harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
