### PR TITLE
fix: don't chart a storage history Delhi will never have

### DIFF
--- a/src/app/[cityId]/data.ts
+++ b/src/app/[cityId]/data.ts
@@ -631,11 +631,22 @@ export async function loadCityHistory(config: PlaceConfig): Promise<CityHistory>
     if (error || !data) break;
     if (data.length === 0) break;
     for (const row of data) {
+      const tmc = row.storage_tmc as number | null;
+      const pct = row.storage_pct_frl as number | null;
+      // A reading can exist without a storage volume: BBMB publishes Bhakra's
+      // level, inflow and outflow but never Delhi's share as a volume, so
+      // Delhi's rows land here with both storage fields NULL. Counting those
+      // as points made pointCount 1 while nothing was plottable, so the
+      // chart's honest "no history" branch (pointCount === 0) never fired and
+      // readers got the full chart chrome - title, range tabs, "1 readings" -
+      // wrapped around an empty plot. This chart plots storage only, so a row
+      // with neither field is not a point in it.
+      if (tmc === null && pct === null) continue;
       all.push({
         source_code: row.source_code as string,
         date: row.date as string,
-        storage_tmc: row.storage_tmc as number | null,
-        storage_pct_frl: row.storage_pct_frl as number | null,
+        storage_tmc: tmc,
+        storage_pct_frl: pct,
       });
     }
     if (data.length < PAGE_SIZE) break;

--- a/src/components/dashboard/dashboard-history-section.tsx
+++ b/src/components/dashboard/dashboard-history-section.tsx
@@ -130,6 +130,7 @@ export function DashboardHistorySection({
           (s) => s.hasPublicFeed === false,
         ) ?? false
       }
+      absentNote={tryGetPlaceConfig(cityId)?.reservoirHistoryAbsentNote}
       unit={unit}
       series={state.payload.series}
       forecast={state.payload.forecast}

--- a/src/components/dashboard/multi-source-history-chart.tsx
+++ b/src/components/dashboard/multi-source-history-chart.tsx
@@ -38,6 +38,11 @@ interface Props {
   /** True when NO source for this city has a public feed - the empty state
    *  then says so instead of promising an ingestion that cannot arrive. */
   noPublicFeed?: boolean;
+  /** Set when no authority publishes a storage series for this place at all.
+   *  Takes precedence over `noPublicFeed`, which infers the same thing from
+   *  the source feed flags and gets it wrong for a place like Delhi that has a
+   *  live feed carrying no storage. */
+  absentNote?: string;
 }
 
 const TIME_TABS = [
@@ -120,6 +125,7 @@ export function MultiSourceHistoryChart({
   scopeLabel,
   defaultTab = "1yr",
   noPublicFeed = false,
+  absentNote,
 }: Props) {
   const [tab, setTab] = useState<TabKey>(defaultTab);
   const [view, setView] = useState<ViewMode>("by_source");
@@ -304,12 +310,15 @@ export function MultiSourceHistoryChart({
     return (
       <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50/40 dark:bg-amber-950/20 p-4 text-sm text-slate-700 dark:text-slate-300">
         <div className="font-semibold text-amber-800 dark:text-amber-300 text-xs uppercase tracking-wider mb-1">
-          Reservoir history pending
+          {absentNote || noPublicFeed
+            ? "No storage history to chart"
+            : "Reservoir history pending"}
         </div>
         <p>
-          {noPublicFeed
-            ? `No authority publishes a daily storage series for ${cityDisplayName}'s sources, so there is no history to chart. Each source card names who would have to publish it.`
-            : `${cityDisplayName} reservoir storage history hasn't been backfilled yet. Once daily storage readings start landing, this chart fills in automatically.`}
+          {absentNote ??
+            (noPublicFeed
+              ? `No authority publishes a daily storage series for ${cityDisplayName}'s sources, so there is no history to chart. Each source card names who would have to publish it.`
+              : `${cityDisplayName} reservoir storage history hasn't been backfilled yet. Once daily storage readings start landing, this chart fills in automatically.`)}
         </p>
       </div>
     );

--- a/src/lib/cities/delhi.ts
+++ b/src/lib/cities/delhi.ts
@@ -141,6 +141,14 @@ export const DELHI: CityConfig = {
     cgwbStations: true,
   },
   reservoirDataSource: 'v2',
+  // Delhi impounds nothing. It draws a canal share, a river pond and a
+  // borewell field, and its two dam entitlements (Bhakra, Tehri) sit in other
+  // states' reservoirs where the storage published is the whole dam's, never
+  // Delhi's slice. So there is no storage series to chart and there will not
+  // be one until BBMB or THDC publish a share - which is a finding about who
+  // holds the numbers, not a backlog item.
+  reservoirHistoryAbsentNote:
+    "Delhi owns no reservoir storage of its own, so no authority publishes a daily storage series for it. BBMB publishes Bhakra's level, inflow and outflow but not Delhi's share as a volume, and Delhi's share of the dam is set per season in BBMB Technical Committee minutes that are not public. Each source card below names who would have to publish the number.",
   waterSources: [
     {
       // The Yamuna arm: Wazirabad pond feeds Wazirabad + Chandrawal WTPs.

--- a/src/lib/cities/types.ts
+++ b/src/lib/cities/types.ts
@@ -383,6 +383,17 @@ export interface BasePlaceConfig {
    *  not a bug. */
   reservoirHistoryNote?: string;
 
+  /** Why no storage history exists for this place, when the answer is "nobody
+   *  publishes one" rather than "we have not backfilled it yet".
+   *
+   *  The chart used to infer this from `hasPublicFeed` across the sources, but
+   *  that is the wrong question: Delhi's BBMB feed is live and still yields no
+   *  storage series, because level over FRL is not a volume and Delhi's share
+   *  of Bhakra is unpublished. With a live feed present the inferred branch
+   *  promised the chart "fills in automatically", which will never happen.
+   *  Set this and that promise is replaced by the actual reason. */
+  reservoirHistoryAbsentNote?: string;
+
   /** Ships /:cityId/commitments - the Commitments Register (dated commitments
    *  by named institutions with a cited status lifecycle; history kept, never
    *  overwritten). Requires public/data/commitments-{cityId}.json. */


### PR DESCRIPTION
## What was rendering

Delhi's dashboard drew the full storage-history chart - heading, range tabs, "1 readings, 26 Jul 2026 - 26 Jul 2026" - around an empty plot.

## Two defects, both a null passing as data

**1. `pointCount` counted rows, not plottable points.** `loadCityHistory` pushed every `reservoir_daily_v2` row whether or not it carried a storage value. BBMB publishes Bhakra's level, inflow and outflow but never Delhi's share as a volume, so Delhi's one row has `storage_tmc` *and* `storage_pct_frl` NULL. That row counted, `pointCount` came back `1`, and the chart's honest "no history" branch keys on `pointCount === 0`, so it never fired. The empty state I built for exactly this case was unreachable. Rows with no storage value are now skipped, since this chart plots storage only.

**2. The empty state asked the wrong question.** It inferred "nobody publishes this" from `hasPublicFeed` across the sources. Delhi's BBMB feed went live today, so `every(hasPublicFeed === false)` is false and Delhi would have fallen through to *"history hasn't been backfilled yet. Once daily storage readings start landing, this chart fills in automatically."* That promise cannot be kept: level over FRL is not a volume ratio, and Delhi's share of the dam is set per season in BBMB Technical Committee minutes that are not public. A live feed is not the same as a storage series. Places where no storage series exists at all now say so through a new `reservoirHistoryAbsentNote`, which names who would have to publish the number.

## Result

Delhi's chart is now a named gap instead of empty chrome, which is also the real answer to your question: **Delhi impounds nothing**, so there is no storage series to chart, and that absence is the finding rather than a backlog item.

## Verified against live data

| city | pointCount before | after |
|---|---|---|
| delhi | 1 (unplottable) | **0** - empty state fires |
| chennai | 2695 | 2695 |
| mumbai | 1136 | 1136 |
| madurai | 4098 | 4098 |
| bangalore | 8188 | 8188 |

Zero all-null points among the four unaffected cities, so the filter dropped nothing real. Measured against production for each, and confirmed in a browser on a local production build: Delhi now renders the amber "No storage history to chart" box with the note, while Chennai still renders the full chart ("2,695 readings - 15 Jan 2003 - 25 Jul 2026") and Bangalore its own ("8,188 readings").

Full CI matrix run locally: tsc clean, 0 lint errors, ward profiles, `data:check`, 68/68 tests, production build. The branch touches no Python, so the API job runs against files identical to `main`.

## Correction to an earlier note in this PR

I first wrote that Bengaluru's chart was blank too. That was wrong: I queried `cityId=bengaluru`, but the place id is `bangalore`, so I was measuring a city that does not exist and reading its empty payload as a finding. Bangalore's chart is healthy - 8,188 readings across KRS, Hemavathi, Kabini and Harangi since 2018 - and unchanged by this PR.

The BBMB copy follow-up from #194 still stands: Delhi's config, About page and `features.md` assert BBMB has not updated since 04.09.2025, which stopped being true today. Still waiting to see whether the resumption is durable before rewriting it.
