### PR TITLE
fix: three defects found by a platform-wide sweep

### DIFF
--- a/src/app/[cityId]/my-ward/report/city-ward-report-card.tsx
+++ b/src/app/[cityId]/my-ward/report/city-ward-report-card.tsx
@@ -124,14 +124,30 @@ export function CityWardReportCard({
 
   if (error) {
     return (
+      /* This branch is reachable in production: Chennai has no
+         ward-risk-chennai.json (and no compute script), so every visitor to
+         /chennai/my-ward/report was shown "Run npx tsx
+         scripts/compute-chennai-ward-risk.ts to generate it" - a build
+         instruction addressed to us, rendered to readers. Say what is
+         missing and point somewhere useful instead. */
       <div className="max-w-3xl mx-auto p-6 text-sm text-slate-600 dark:text-slate-400">
-        <p>Ward risk data is not yet available for {cityDisplayName}.</p>
-        <p className="mt-2">
-          Run <code className="font-mono text-xs bg-slate-100 dark:bg-slate-800 px-1 rounded">npx tsx scripts/compute-{cityId}-ward-risk.ts</code> to generate it.
+        <p>
+          The ward report card is not available for {cityDisplayName} yet. The
+          composite ward risk score behind it has not been published for this
+          city.
         </p>
-        <Link href={`/${cityId}/my-ward`} className="text-blue-600 hover:underline mt-3 inline-block">
-          ← Back to ward map
-        </Link>
+        <p className="mt-2">
+          The ward map and the ward rankings cover {cityDisplayName} in the
+          meantime.
+        </p>
+        <div className="mt-3 flex gap-4">
+          <Link href={`/${cityId}/my-ward`} className="text-blue-600 hover:underline">
+            ← Back to ward map
+          </Link>
+          <Link href={`/${cityId}/my-ward/rankings`} className="text-blue-600 hover:underline">
+            Ward rankings →
+          </Link>
+        </div>
       </div>
     );
   }

--- a/src/components/my-ward/ward-selector.tsx
+++ b/src/components/my-ward/ward-selector.tsx
@@ -379,9 +379,13 @@ function ResultRow({
         <span className="font-medium text-slate-900 dark:text-slate-100 leading-snug">
           {displayName}
         </span>
+        {/* Not every city publishes a zone per ward - all 250 Delhi wards
+            carry an empty zone_name, because MCD's 12 zones are not in the
+            ward dataset. Rendering the separator unconditionally printed
+            "Ward 16 - " with a dangling dash on every Delhi result. */}
         <span className="text-xs text-slate-400 dark:text-slate-500">
-          {t("ward.ward")} {l.ward_number} -{" "}
-          {getZoneLabel(l.zone_name, language)}
+          {t("ward.ward")} {l.ward_number}
+          {l.zone_name ? ` - ${getZoneLabel(l.zone_name, language)}` : ""}
         </span>
       </button>
     );
@@ -397,9 +401,13 @@ function ResultRow({
         <span className="font-medium text-slate-900 dark:text-slate-100">
           {t("ward.ward")} {w.wardNumber}
         </span>
-        <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">
-          {getZoneLabel(w.zone, language)} {t("ward_search.zone_suffix")}
-        </span>
+        {/* Same reason as above: with no zone, this rendered a bare "zone"
+            label sitting next to nothing on every Delhi ward row. */}
+        {w.zone ? (
+          <span className="text-xs text-slate-400 dark:text-slate-500 shrink-0">
+            {getZoneLabel(w.zone, language)} {t("ward_search.zone_suffix")}
+          </span>
+        ) : null}
       </button>
     );
   }

--- a/src/lib/utils/ward-filter.ts
+++ b/src/lib/utils/ward-filter.ts
@@ -95,6 +95,11 @@ export function filterLocalities(
 export function deriveZones(wards: WardEntry[]): ZoneEntry[] {
   const zoneMap = new Map<string, ZoneEntry>();
   for (const w of wards) {
+    // A city with no zone data (Delhi: all 250 wards carry an empty
+    // zone_name) would otherwise contribute a single nameless zone holding
+    // every ward, which surfaces in search as a blank row reading "250
+    // wards". No zone is not a zone.
+    if (!w.zone) continue;
     const existing = zoneMap.get(w.zone);
     if (existing) {
       existing.wardCount++;


### PR DESCRIPTION
You said I was leaving too many gaps, and that the pattern was that you found the bugs, not me. So rather than wait for a fifth null-rendered-as-data report, I swept the whole platform for the class.

**Method.** All 67 city x page routes (route list taken from the measured 200-status matrix, because nav-link discovery missed a third of them) plus 20 populated ward states, in a local production build under CDP, scanning rendered text for `NaN`, `undefined`, `null`, `Invalid Date`, `[object Object]`, `0 of 0`, degenerate series and error boundaries, while capturing every console error and uncaught exception. Every page polls until its text stops growing, so a still-loading page reports NOT-READY instead of a false clean.

**Result.** 48 text-bearing pages: zero exceptions, zero console errors, zero null-artifact tokens. Three defects, all below:

## 1. A build instruction rendered to readers (live, flagship city)

`https://www.neervazhvu.org/chennai/my-ward/report?ward=1` currently shows:

> Ward risk data is not yet available for Chennai. Run `npx tsx scripts/compute-chennai-ward-risk.ts` to generate it.

`ward-risk-chennai.json` was never committed and no `compute-chennai-ward-risk` script exists, while `bangalore`, `madurai`, `delhi` and `mumbai` all ship theirs. The branch was written for a developer running the repo; it is what the public gets. It now names what is missing and links to the ward map and rankings, both of which do cover Chennai (verified 200 for every city that ships `/my-ward`, so the new link cannot dead-end).

## 2 and 3. Delhi's ward selector printed empty labels

All 250 Delhi wards carry `zone_name: ""` - MCD's 12 zones are not in the ward dataset - and the selector rendered the zone unconditionally:

| | before | after |
|---|---|---|
| locality row | `Ward 16 - ` | `Ward 16` |
| ward row | `Ward 1 zone` | `Ward 1` |

`deriveZones` also folded all 250 wards into a single nameless zone; it now skips empty zone names, so a blank row reading "250 wards" cannot surface.

## Verification

Every claim measured, each against a control that would fail if I broke the working case:

- Delhi loses the stray dash and the bare "zone"; **Chennai still renders** `Ward 1 - Thiruvottiyur` and `Ward 1 Thiruvottiyur zone`
- Chennai's report page now reads as a named gap with two working links
- tsc clean, 0 lint errors, 68/68 tests, ward profiles, `data:check`, production build. No Python touched, so the API job runs against files identical to `main`.

## Not fixed here (data, not rendering)

- **Chennai has no ward-risk data at all.** The report card is a genuinely missing feature for the flagship city, not just bad copy. Fixing the message stops it leaking a CLI command; it does not give Chennai a report card.
- **Delhi has no ward-to-MCD-zone mapping**, so Delhi's selector cannot be browsed by zone.

## Also found, deliberately not touched

- `src/app/[cityId]/my-ward/my-ward-client.tsx` is dead code - nothing imports it. It duplicates the live `MyWardPage`, so it is a fork waiting to drift.
- `selectNarrative` maps `storagePct` 0 to the **crisis** variant, and the shared `city_story.*` strings hardcode "Chennai's". Any city with null storage that turns on `dashboard.aiBriefing` would print "Chennai's reservoirs are critically low. Reservoirs hold 0% of capacity." on its own dashboard. Currently unreachable - `aiBriefing` is Chennai-only - so it is a landmine, not a live bug.
- `(config.heroMode ?? "days-left")` means a new city that forgets `heroMode` gets the days-left hero, which for null storage computes 0 days. All five cities set it explicitly today.