### PR TITLE
Arkavathi: district-first DEP snapshot - 7 NGT themes per ULB + governance tab (Paani round 3)

### DIFF
--- a/public/data/basins/arkavathi/gaps.json
+++ b/public/data/basins/arkavathi/gaps.json
@@ -1,2385 +1,7887 @@
 {
-  "units": {
-    "ramanagara": {
-      "name": "Ramanagara (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021",
-      "headline": "Treatment gaps have held for 4+ years; a sanctioned upgrade is the lever to close them",
-      "streams": [
+  "version": 2,
+  "title": "District Environment Plan (DEP) 2022 Snapshot",
+  "note": "District Environment Plans (2022) are prepared at the district level and are not river basin-specific. As a result, the information shown may include areas outside the Arkavathi Basin.",
+  "governance": {
+    "items": [
+      {
+        "heading": "Who executes the plan",
+        "body": "The NGT's compliance framework puts the District Magistrate in charge: DEP action plans are to be executed with progress on targets reviewed at least once a month, and states must consolidate their DEPs into a State Environment Plan published on the state website.",
+        "source": {
+          "source": "NGT order 05.07.2021 in OA 360/2018 (directions d and e)",
+          "says": "“The District Magistrates may accordingly execute the action plans by reviewing the progress on various targets at least once in a month.”",
+          "citation": "CPCB status report on DEP preparation before the NGT, OA 360/2018, p.5",
+          "url": "https://www.greentribunal.gov.in/sites/default/files/news_updates/Status%20Report%20on%20Preparation%20of%20District%20Environment%20Plan%20(DEP)%20in%20OA%20No.%20360%20of%202018%20(Shree%20Nath%20Sharma%20Vs.%20Union%20of%20India%20&%20Ors.).pdf"
+        }
+      },
+      {
+        "heading": "What the plans must cover",
+        "body": "Per the NGT's scope in OA 360/2018, every DEP covers 7 thematic areas: waste management (solid, plastic, C&D, biomedical, hazardous, e-waste), water quality, domestic sewage, industrial wastewater, air quality, mining activity and noise pollution. The tabs above follow that structure, per ULB where the plans report it."
+      }
+    ],
+    "gaps": [
+      "No updated edition of any of the four districts' DEPs has been published since 2021/2022 - progress against the plans' own timelines is not visible in the public domain.",
+      "If District Magistrates hold the mandated monthly reviews, no known public record of their minutes or outcomes exists.",
+      "No known public copy of Karnataka's consolidated State Environment Plan, required by direction (e) to be uploaded on the state website."
+    ]
+  },
+  "districts": [
+    {
+      "key": "bengaluru-south",
+      "name": "Bengaluru South (Earlier Ramanagara)",
+      "dep": {
+        "label": "Ramanagara DEP (approved 31-03-2021)",
+        "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+      },
+      "pctInBasin": 59.9,
+      "counts": [
         {
-          "stream": "Sewage",
-          "summary": "4.0 MLD treatment gap, steady across every report 2021-2025",
-          "metrics": [
-            {
-              "label": "STP capacity",
-              "value": "7.5 MLD (2021-2025; 7.56 in 2026)"
-            },
-            {
-              "label": "Treated (capacity utilisation)",
-              "value": "6.0 MLD (2021-2025; 6.5 in 2026)"
-            },
-            {
-              "label": "Treatment gap",
-              "value": "4.0 MLD (2021-2025)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "STP compliance",
-              "value": "Not yet complying (every year 2021-2025)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Rs 220.17 cr upgrade DPR",
-              "value": "Sanctioned; works not yet started (2021-2025)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "~18.9-23.3 MLD generated vs 17.5 MLD installed STP capacity (district); Ramanagara STP 'not adequate'; treated/untreated volumes 'Not Estimated'.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 10.0,
-            "unit": "MLD"
-          }
+          "label": "City Municipal Councils (CMC)",
+          "value": "3 - Ramanagara, Channapatna, Kanakapura"
         },
         {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "No common effluent treatment plant; the documents differ on whether that's a problem",
-          "metrics": [
-            {
-              "label": "Industrial areas mapped (basin)",
-              "value": "4, all >5 km from a CETP (Neer Vazhvu estimate, 2026)"
-            },
-            {
-              "label": "DEP position",
-              "value": "Effluent \"fully recycled, zero discharge\"; 581 industries \"meeting standards\" (DEP 2021)"
-            },
-            {
-              "label": "CAG finding",
-              "value": "38 of 66 sampled KIADB areas had no CETP; ~2,571 ML/yr untreated (CAG 2017)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "\"There are no CETPs in the Ramanagara District.\" Trade effluent reported fully recycled with zero discharge; all 581 wastewater-discharging industries reported meeting standards.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            },
-            {
-              "source": "CAG Report No. 8 of 2017 (p.18)",
-              "says": "In 38 of 66 sampled KIADB industrial areas, basic facilities including CETP/CSTP were not provided; 4,077 units operating without; ~2,571 million litres/yr untreated waste let off as surface discharge.",
-              "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
-              "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "taluk"
+          "label": "Town Municipal Councils (TMC)",
+          "value": "2 - Magadi, Bidadi"
         },
         {
-          "stream": "Municipal solid waste",
-          "summary": "~15 of 40 TPD processed (2025); 35 collected; the rest unprocessed, plus a district sanitary-landfill shortfall",
-          "metrics": [
-            {
-              "label": "Sanitary-landfill gap (district)",
-              "value": "3 of 5 sites short; 2 under litigation (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "~129.66 TPD urban generated district-wide; legacy waste 58,600 t (Magadi alone 46,000 t); sanitary-landfill sites under litigation.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 35.0,
-            "unit": "TPD"
-          }
+          "label": "Town Panchayats (TP)",
+          "value": "1 - Harohalli (newly declared)"
         },
         {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 18.7,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+          "label": "Gram Panchayats",
+          "value": "127 (872 villages)"
+        }
+      ],
+      "countsNote": "ULB roster and GP count as reported in the DEP. The DEP details each CMC/TMC/TP; gram panchayats get only estimates.",
+      "mapMatch": {
+        "family": "admin-district",
+        "prop": "name",
+        "values": [
+          "Bengaluru South"
+        ]
+      },
+      "districtThemes": [
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "solid-waste",
+          "summary": "Solid waste status and gap tables are given ULB-wise for 5 ULBs plus a district GP estimate; Harohalli TP is excluded everywhere as 'Newly declared TP and DPR is yet to be prepared'.",
           "metrics": [
             {
-              "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+              "label": "Village/Gram Panchayats solid waste generated per day (theoretical, 200 gms/head/day)",
+              "value": "162.9754 MT"
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+              "label": "GP population used for estimate",
+              "value": "814877"
             },
             {
-              "label": "Disposal facilities",
-              "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+              "label": "Total ULB wards",
+              "value": "139"
+            },
+            {
+              "label": "Wards with 100% source segregation (of 139)",
+              "value": "115 (gap 24)"
+            },
+            {
+              "label": "Road length covered by regular sweeping",
+              "value": "199.9 KM of 662.8 KM (gap 462.8 KM)"
+            },
+            {
+              "label": "Bulk waste generators identified / with onsite composting",
+              "value": "335 / 0"
+            },
+            {
+              "label": "Sanitary landfills available vs required",
+              "value": "2 of 5 (gap 3)"
+            },
+            {
+              "label": "Total legacy waste at 5 dumpsites",
+              "value": "58600 tonnes"
+            },
+            {
+              "label": "NGOs engaged vs required",
+              "value": "0 of 16"
+            },
+            {
+              "label": "EPR: producers / brand owners in RO Ramanagara jurisdiction",
+              "value": "24 producers, 4 brand owners"
+            },
+            {
+              "label": "SWM by-laws",
+              "value": "Adopted by all ULBs"
             }
           ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
-              "citation": "Hazardous Waste section, p.46",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
+          "openActions": [
+            "Awareness programmes, penalties and colour-coded-bin segregation to reach 100% source segregation; bar mesh in nallahs and drains - ULB's - 31-12-2021",
+            "Cover manpower gap for sweeping within 6 months; PPE kits for all workers - ULB's - 31-12-2021",
+            "Prepare DPR and outsource mechanical road sweeping (none exists in district) - ULB's - 31-3-2022",
+            "Centralized-tender DPR to purchase SWM equipment (trolleys, trucks) - ULB's - 31-3-2022",
+            "Establish waste deposition centres for domestic hazardous waste in each taluk; MOU with TSDF - ULB's - 31-3-2022",
+            "Notices to all 335 bulk waste generators to install onsite organic waste composters; stop collecting their wet waste after notice period - ULB's - 31-3-2022",
+            "Upgrade wet-waste facilities and establish leachate treatment plants at SWM facilities - ULB's - 31-3-2022",
+            "Identify authorized recyclers / cement plants and channelize segregated dry waste (currently partially segregated, remainder landfilled) - ULB's - 31-3-2022",
+            "Make existing sanitary landfills functional; construct SLFs where absent - ULB's - 31-3-2023",
+            "Remediate legacy dumpsites per CPCB-aligned DPRs - ULB's - 31-3-2023",
+            "Identify and tie up with NGOs for SWM awareness - ULB's - 31-3-2022",
+            "Register waste pickers and issue ID cards - ULB's - 31-3-2022",
+            "Direct Grama Panchayats to quantify actual solid waste generated (currently theoretical) - GPs"
+          ],
+          "pages": [
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.29,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "plastic-waste",
+          "summary": "Plastic waste generation is inventoried per ULB (district total 1.05 TPD); GP quantities are not available and no ULB has an MOU with authorised plastic recyclers.",
           "metrics": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+              "label": "Total ULB plastic waste generated",
+              "value": "1.05 TPD"
+            },
+            {
+              "label": "Producers / brand owners in RO Ramanagara jurisdiction",
+              "value": "24 producers, 4 brand owners"
+            },
+            {
+              "label": "GP plastic waste",
+              "value": "Details not available"
+            },
+            {
+              "label": "Door-to-door dry waste collection",
+              "value": "139 of 139 wards (100%)"
             }
           ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
-              "citation": "Biomedical Waste section, p.41",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
+          "openActions": [
+            "Provide dustbins and collection centres at prominent public places - ULB's - 31-12-2021",
+            "Establish plastic waste collection centres and execute MOU with KSPCB-authorised plastic recyclers (none executed yet) - ULB's + village panchayats - 31-12-2021",
+            "Explore plastic use in road construction with PWD; co-processing in cement plants - ULB's - 31-3-2021",
+            "Village panchayats and ULBs to quantify plastic waste generated in their jurisdiction - ULB's - 31-12-2021",
+            "Mass awareness on banned single-use plastics; records to KSPCB every 6 months - ULB's + Gram Panchayats + KSPCB - 31-3-2021"
+          ],
+          "pages": [
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40
           ]
         },
         {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 1.0,
-            "unit": "TPD"
-          },
-          "summary": "Construction & demolition waste.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "cd-waste",
+          "summary": "C&D waste is inventoried per ULB (district total 4.9 TPD) but is currently dumped in low-lying areas; the district has no C&D recycling facility.",
           "metrics": [
             {
-              "label": "C&D waste generated",
-              "value": "1.0 TPD (DEP 2021)"
+              "label": "Total C&D waste generated",
+              "value": "4.9 TPD"
             },
             {
-              "label": "Recycling facility",
-              "value": "None in the district (DEP 2021)"
+              "label": "C&D recycling facility in district",
+              "value": "No"
+            },
+            {
+              "label": "User fee on C&D waste",
+              "value": "Fixed by all 5 ULB's"
+            },
+            {
+              "label": "Permission system for bulk C&D generators",
+              "value": "None - to be framed"
             }
           ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "C&D waste generation (per ULB), Ramanagara: 1.0 MT/day. No C&D recycling facility in the district.",
-              "citation": "C&D Waste section, p.39",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
+          "openActions": [
+            "Establish designated C&D collection points in each taluk and deposition points at district headquarters (currently dumped in low-lying areas) - ULB's + District administration - 31-3-2022",
+            "Frame common by-laws and permission system for bulk generators (>20 tons/day or 300 tons/project) - ULB's - 31-3-2022",
+            "Identify land and set up a common C&D waste recycling facility - ULB's + District administration + Town Planning - 31-3-2022",
+            "Frame district policy for use of recycled C&D products in paving blocks and road layers with PWD - ULB's + District administration + PWD - 31-3-2022",
+            "KSPCB training to ULBs once in 6 months and mass awareness on C&D - ULB's + KSPCB - 31-3-2022"
+          ],
+          "pages": [
+            41,
+            42,
+            43,
+            44
           ]
         },
         {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher). The industrial universe behind the stretch.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "biomedical-waste",
+          "summary": "Biomedical waste is reported district-wide only: 538 healthcare establishments, one CBMWTF (M/s Maridi Eco Industries Pvt Ltd), with conflicting generation figures (1290 vs 666 kg/day).",
           "metrics": [
             {
-              "label": "Consented industries (2019)",
-              "value": "~650"
+              "label": "Bedded healthcare facilities",
+              "value": "209"
             },
             {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~380",
-              "emphasis": "bad"
+              "label": "Non-bedded HCF",
+              "value": "329"
+            },
+            {
+              "label": "HCFs authorized by SPCB",
+              "value": "344"
+            },
+            {
+              "label": "HCEs not applied for renewal (notices issued)",
+              "value": "194"
+            },
+            {
+              "label": "CBWTFs",
+              "value": "one (M/s Maridi Eco Industries Pvt Ltd)"
+            },
+            {
+              "label": "Capacity of CBWTFs (as printed)",
+              "value": "250000 Kg/day"
+            },
+            {
+              "label": "Deep burials for BMW",
+              "value": "116 Nos"
+            },
+            {
+              "label": "BMW generated per day (p45)",
+              "value": "1290 Kg/day"
+            },
+            {
+              "label": "BMW treated per day (p45)",
+              "value": "1000 Kg/day"
+            },
+            {
+              "label": "BMW generated = disposed per Annual Report 2020 (p46)",
+              "value": "666 kg/day (550 kg/d to CBMWTF + 116 kg/day deep burial in veterinary institutions)"
+            },
+            {
+              "label": "HCEs with bar coding",
+              "value": "40%"
             }
           ],
-          "sources": [
+          "openActions": [
+            "Implement 100% bar-code tracking of BMW (currently 40% of HCEs) - District Health Officer + CBMWTF + HCE's + KSPCB - 31-12-2021",
+            "Veterinary institutions to execute agreement with CBMWTF for BMW disposal (notice issued; deep burial currently practiced) - District Health Officer",
+            "Awareness and training for HCE and ULB staff once in 6 months - DHO + CBMWTF + KSPCB - 31-12-2021",
+            "Ensure 100% compliance with BMW Rules 2016 via regular inspections - DHO + District level monitoring committee - 31-12-2021",
+            "Maintain list of registered HCFs in the district - Health Department + KSPCB - 31-3-2022"
+          ],
+          "pages": [
+            45,
+            46,
+            47,
+            48,
+            49
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "hazardous-waste",
+          "summary": "Hazardous waste is district-wide only: 171 authorized HW-generating industries, 6827.95 MT/annum, with one common TSDF and one common incinerator located in the district.",
+          "metrics": [
             {
-              "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+              "label": "Industries generating HW (as on 31-3-2021)",
+              "value": "171 Nos"
+            },
+            {
+              "label": "Quantity of HW",
+              "value": "6827.95 MT/Annum"
+            },
+            {
+              "label": "Incinerable HW",
+              "value": "2021.73 MT/Annum"
+            },
+            {
+              "label": "Land-fillable HW",
+              "value": "1377.847 MT/Annum"
+            },
+            {
+              "label": "Recyclable/utilizable HW",
+              "value": "3323.6 MT/Annum"
+            },
+            {
+              "label": "Common TSDF",
+              "value": "1 (M/s Mother Earth Environtech Pvt Ltd)"
+            },
+            {
+              "label": "Standalone incinerator",
+              "value": "1 (M/s E Nano Incintech)"
+            },
+            {
+              "label": "HW recycling/re-processing industries",
+              "value": "19 (p51) / 18 (p52)"
+            },
+            {
+              "label": "Contaminated sites",
+              "value": "Nil"
             }
+          ],
+          "openActions": [
+            "Establish hazardous waste collection centres linked to common TSDF (none exist; household HW currently goes to dry waste collection centres) - ULB's - 31-12-2022"
+          ],
+          "pages": [
+            50,
+            51,
+            52,
+            53
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "e-waste",
+          "summary": "E-waste is district-wide only: ULBs report Nil inventory, 5 ULB-established collection centres exist, there are no producers/PROs in the jurisdiction and no recycler linkage.",
+          "metrics": [
+            {
+              "label": "Inventory of E-Waste",
+              "value": "Nil MT/year (as per ULBs)"
+            },
+            {
+              "label": "Collection centres established by ULBs",
+              "value": "5 No."
+            },
+            {
+              "label": "Collection centres by Producers/PROs",
+              "value": "Nil (no producers in district)"
+            },
+            {
+              "label": "Authorized E-waste recyclers/dismantlers in RO-Ramanagara jurisdiction",
+              "value": "4"
+            }
+          ],
+          "openActions": [
+            "Carry out inventorisation of e-waste and bulk generators - ULB + KSPCB - 31-3-2022",
+            "Notify public about e-waste collection centres - ULB's - 31-12-2021",
+            "Execute MOU with authorized e-waste recyclers/dismantlers (no linkage exists) - ULB's - 31-12-2021",
+            "Inventorise informal e-waste trading/recycling/dismantling - ULB's - 31-12-2021",
+            "KSPCB/ULB workshops and awareness programmes - KSPCB - 31-12-2021"
+          ],
+          "pages": [
+            53,
+            54,
+            55,
+            56
+          ]
+        },
+        {
+          "theme": "water-quality",
+          "status": "covered",
+          "summary": "River network (197.25 km), 102 tanks, KSPCB river monitoring and one NGT Priority-III polluted stretch (Tippagondanahalli reservoir to Kanakapura Town) are reported district-wide; lake water quality is not monitored at all.",
+          "metrics": [
+            {
+              "label": "River stretch in district",
+              "value": "197.25 Km (Arkavathy 94.00, Vrishabhavathy 33.00, Suvarnamukhi 27.25, Shimsha 4.00, Kanva 39.00)"
+            },
+            {
+              "label": "Nalas/drains joining Arkavathi",
+              "value": "5 Nos of nalas and 12 nos of drains"
+            },
+            {
+              "label": "Lakes/Ponds",
+              "value": "102 nos of Tanks, 16669.69 Hectares (survey under progress)"
+            },
+            {
+              "label": "Polluted river stretch",
+              "value": "Tippagondanahalli reservoir to Kanakapura Town, Priority-III (NGT O.A. No. 673/2018)"
+            },
+            {
+              "label": "KSPCB river sampling points",
+              "value": "Arkavathi 4 (Manchanabele dam to Sangam), Cauvery 3 (Sangam to Ajjibore), Vrishabhavathi valley 4 - monthly"
+            },
+            {
+              "label": "Estimated borewells / GW extraction permissions (2017-2021)",
+              "value": "33 / 21"
+            },
+            {
+              "label": "Ground water polluted areas if any (as printed, p62)",
+              "value": "6"
+            },
+            {
+              "label": "Lake water quality monitoring",
+              "value": "Not carried out; no frequency fixed"
+            },
+            {
+              "label": "Environmental monitoring cell",
+              "value": "None exists"
+            }
+          ],
+          "openActions": [
+            "Constitute district Environmental Monitoring Cell and inventorise all water bodies with quality data - Minor Irrigation + Groundwater authority + CNNL + Zilla Panchayat + KSPCB - 31-3-2022",
+            "Increase KSPCB sampling points along river stretches - KSPCB - 31-3-2022",
+            "Lake owners (ULBs/GPs/TPs) to monitor lake water quality per CPCB frequency and report quarterly - ULB's - 31-3-2022",
+            "Identify wastewater-carrying drains joining water bodies, sample them, plug/divert; bar meshes in drains - ULB's - 31-3-2022",
+            "Groundwater authority to fix borewell monitoring frequency per CPCB guidelines (currently once in two years / yearly twice per conflicting statements) - Groundwater authority - 31-3-2022",
+            "Complete inventory of sewage discharge points beyond the polluted stretch, across the whole river length - KSPCB + ULB's + panchayats - 31-3-2022",
+            "Implement action plan for Priority-III polluted stretch restoration (in progress) - KSPCB - 31-3-2022",
+            "Continue groundwater recharge structure programme; rainwater harvesting action plan - Groundwater authority - 31-3-2022",
+            "Develop district mobile app/helpline for water pollution complaints - District Administration - 31-3-2022"
+          ],
+          "pages": [
+            60,
+            61,
+            62,
+            63,
+            64,
+            65,
+            66,
+            67,
+            68
+          ]
+        },
+        {
+          "theme": "domestic-sewage",
+          "status": "covered",
+          "summary": "Sewage is reported ULB-wise with mutually inconsistent totals (18.87 / 27.4 / 23.32 / 28.81 MLD); installed treatment capacity is 17.5 MLD in 3 STPs, and 3 ULBs (Channapatna, Bidadi, Harohalli) have no STP.",
+          "metrics": [
+            {
+              "label": "Total sewage from towns and cities (p61 headline)",
+              "value": "18.87 MLD"
+            },
+            {
+              "label": "Sum of ULB-wise sewage table on p61",
+              "value": "27.4 MLD"
+            },
+            {
+              "label": "Total sewage from Class II cities and above (p69)",
+              "value": "23.32 MLD"
+            },
+            {
+              "label": "Total wastewater generated in STP gap table (p72-73)",
+              "value": "28.81 MLD"
+            },
+            {
+              "label": "Total available treatment capacity",
+              "value": "17.5 MLD (Ramanagara 7.5 + Kanakapura 6.29 + Magadi 3.71)"
+            },
+            {
+              "label": "Towns with STPs / needing STPs",
+              "value": "3 / 3"
+            },
+            {
+              "label": "Untreated sewage percentage",
+              "value": "not quantified"
+            },
+            {
+              "label": "Quantity of sewage flowing into lakes",
+              "value": "Not Estimated"
+            },
+            {
+              "label": "Untreated flows",
+              "value": "Untreated sewage from missing links in CMC Ramanagara and CMC Kanakapura limits indirectly discharged to river"
+            }
+          ],
+          "openActions": [
+            "Intercept and divert missing links bypassing STPs; complete UGD connections - LB's + KUWS&DB + KUIDFC + panchayats - 31-3-2023",
+            "Prepare DPR for channelization of sewage and interception of all drains (excluding industrial) to STPs - LB's + KUWS&DB - 31-3-2023",
+            "Install Web Cams and OCEEMS in STPs - LB's - 31-3-2023",
+            "Provide modular treatment / in-situ bioremediation for untapped drains - LB's - 31-3-2023",
+            "Formulate action plan for long-term reuse of treated STP water - LB's - 31-3-2023",
+            "Lay sewerage network and connect households to utilise installed STP capacity - LB's + KUWS&DB + Urban Development - 31-3-2022",
+            "Treat rural wastewater flowing to river by bio-remediation/phyto-remediation/oxidation ponds - LB's - 31-3-2022",
+            "Establish STPs of adequate capacity on I&D model for high-load drains - LB's + KUWS&DB - 31-3-2022"
+          ],
+          "pages": [
+            61,
+            69,
+            70,
+            71,
+            72,
+            73,
+            74,
+            75
+          ]
+        },
+        {
+          "theme": "industrial-wastewater",
+          "status": "covered",
+          "summary": "Industrial wastewater (5.652 MLD) is reported district-wide; KSPCB states no industry is permitted to discharge to water bodies, all treated in-premises ETPs, and the district has no CETP.",
+          "metrics": [
+            {
+              "label": "Operating industries (F-Reg, RO Ramanagara, 31-03-2021)",
+              "value": "Red 94 (incl. 2 of 17-category), Orange 163, Green 333, White 8"
+            },
+            {
+              "label": "Industries discharging waste water (p76)",
+              "value": "581 Nos"
+            },
+            {
+              "label": "Industries generating the 5.652 MLD (p61)",
+              "value": "562 Nos"
+            },
+            {
+              "label": "Total industrial waste water generated",
+              "value": "5.652 MLD"
+            },
+            {
+              "label": "Treated industrial waste water discharged into Nalas/Rivers",
+              "value": "Nil"
+            },
+            {
+              "label": "Common Effluent Treatment Facilities (CETPs)",
+              "value": "Nil - There are no CETP's in the Ramanagara District"
+            },
+            {
+              "label": "Industries meeting standards / not meeting",
+              "value": "581 / Nil"
+            }
+          ],
+          "pages": [
+            61,
+            76,
+            77,
+            78
+          ]
+        },
+        {
+          "theme": "air-quality",
+          "status": "covered",
+          "summary": "Air quality is district-wide: one KSPCB CAAQM station at RO Ramanagara, no manual stations, all towns stated to comply with NAAQS; main sources are large industries, quarrying/blasting, stone crushers, m-sand and granite units, and unpaved roads.",
+          "metrics": [
+            {
+              "label": "Continuous Ambient Air Quality Monitoring Stations",
+              "value": "01 (KSPCB Regional Office, Ramanagara premises)"
+            },
+            {
+              "label": "Manual monitoring stations operated by SPCB",
+              "value": "None"
+            },
+            {
+              "label": "Towns failing NAAQS",
+              "value": "Nil"
+            },
+            {
+              "label": "Air polluting industries",
+              "value": "464 Nos"
+            }
+          ],
+          "openActions": [
+            "Carry out inventory of air pollution sources and hotspots; task force to monitor AAQ around mining areas every 6 months; convert unpaved roads to paved - District task force + Mines & Geology + KSPCB + PWD - 31-3-2022",
+            "Prepare district action plan for prominent sources: roadside/industrial/mining-area plantation, pave open areas, phase out 15-year-old vehicles - District administration + Urban Development + Social forestry + RTO + PWD - 31-3-2022",
+            "Dust suppression at quarrying/blasting, stone crushers and m-sand units; green belts at crusher units and SWM facilities; prohibit open burning - Forest Dept + ULB's + Agriculture + Mines & Geology + KSPCB",
+            "Disseminate air quality information (KSPCB website / SAMEER app) - KSPCB - 31-3-2022"
+          ],
+          "pages": [
+            57,
+            58,
+            59
+          ]
+        },
+        {
+          "theme": "mining",
+          "status": "covered",
+          "summary": "Mining is district-wide: building stone, ornamental and black granite quarrying with an internally inconsistent licence count (92 headline vs larger breakdown); no sand mining and no illegal mining identified, monitored by an existing district task force.",
+          "metrics": [
+            {
+              "label": "Type of mining activity",
+              "value": "Building Stone, Ornamental"
+            },
+            {
+              "label": "Licensed mining operations (headline)",
+              "value": "92"
+            },
+            {
+              "label": "Breakdown (as printed)",
+              "value": "Building stone: 94; Ornamental-56; Crusher-36; Black granite: Quarrying lease-09, Patta land-49"
+            },
+            {
+              "label": "% area covered under mining",
+              "value": "0.1040%"
+            },
+            {
+              "label": "Area of sand mining",
+              "value": "nil"
+            },
+            {
+              "label": "Illegal mining identified",
+              "value": "No such illegal mining activities identified"
+            }
+          ],
+          "pages": [
+            79,
+            80
+          ]
+        },
+        {
+          "theme": "noise",
+          "status": "covered",
+          "summary": "Noise is district-wide: only KSPCB has a single noise meter, there are no fixed ambient noise monitoring stations, and sign boards in silent zones are stated as adequate.",
+          "metrics": [
+            {
+              "label": "Noise measuring devices",
+              "value": "1 No. with KSPCB RO Ramanagara (S12 SLM/Noise Dosimeter); ULBs, SHOs, Traffic police have none"
+            },
+            {
+              "label": "Fixed ambient noise monitoring stations",
+              "value": "None in district"
+            },
+            {
+              "label": "Sign boards in silent zones",
+              "value": "Adequate numbers installed by Police Department"
+            }
+          ],
+          "openActions": [
+            "All ULBs, SHOs and Traffic police to procure portable noise level meters - ULB's + SHO's + Dy SP + Traffic Police + District administration + KSPCB - 31-03-2022",
+            "Install/retrofit fixed ambient noise monitoring stations with existing CAAQM - District Administration + KSPCB + ULB's - 31-12-2023"
+          ],
+          "pages": [
+            81,
+            82,
+            83
           ]
         }
       ],
-      "conflicts": [
-        "DEP says there are no CETPs needed and all 581 industries meet standards with effluent 'fully recycled, zero discharge' - while the CAG audit found 38 of 66 sampled KIADB areas had no CETP and ~2,571 ML/yr of untreated discharge.",
-        "The DEP's own district sewage-generation total is inconsistent (~18.9 MLD in one table vs ~23.3 MLD in another)."
-      ]
-    },
-    "kanakapura": {
-      "name": "Kanakapura (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021",
-      "headline": "Sewage roughly within STP capacity; the gaps here are no CETP for its industrial areas and unprocessed solid waste",
-      "streams": [
+      "ulbs": [
         {
-          "stream": "Sewage",
-          "summary": "Small treatment gap (0.6 MLD) - STP capacity exceeds the current load",
-          "metrics": [],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Kanakapura sewage generation ~4.4 MLD; STP capacity 6.29 MLD.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 4.4,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "Two mapped industrial areas, neither with a CETP nearby",
-          "metrics": [
-            {
-              "label": "Industrial areas mapped",
-              "value": "2, incl. 1 KIADB (Paani layer, 2026)"
-            },
-            {
-              "label": "With a CETP nearby",
-              "value": "0 - both >5 km from the nearest CETP (Neer Vazhvu estimate, 2026)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "District CETPs",
-              "value": "0 - \"no CETPs in the Ramanagara district\" (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Neer Vazhvu spatial estimate",
-              "says": "Both mapped Kanakapura industrial areas sit >5 km from the nearest common effluent facility - a proximity estimate from the industrial-areas and common-facilities layers, not confirmed service connectivity."
-            },
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "\"There are no CETPs in the Ramanagara District.\"",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            },
-            {
-              "source": "CAG Report No. 8 of 2017 (p.18)",
-              "says": "38 of 66 sampled KIADB industrial areas had no CETP/CSTP.",
-              "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
-              "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "taluk"
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "~24 TPD generated; district-wide processing and landfill gaps apply",
-          "metrics": [
-            {
-              "label": "Generated",
-              "value": "~24 TPD (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Kanakapura urban solid waste ~24 TPD; district has 0 of 335 bulk generators composting onsite and a 3-site sanitary-landfill shortfall.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 24.0,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 18.7,
-            "unit": "TPD",
-            "estimated": true
+          "key": "ramanagara-cmc",
+          "name": "Ramanagara",
+          "type": "CMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "RAMANAGARA"
+            ]
           },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Ramanagara CMC generates 40.16 (per day, unit not printed) of solid waste from 31 wards; collection is 100% but source segregation covers 23 of 31 wards, only 49 of 196 km of road is swept, no sanitary landfill exists (site under litigation) and 2500 tonnes of legacy waste await a prepared-but-unstarted DPR.",
+              "metrics": [
+                {
+                  "label": "Wards / Households / Population",
+                  "value": "31 / 20195 (2011 Census) / 95167"
+                },
+                {
+                  "label": "Solid waste generated per day (unit not printed in table)",
+                  "value": "40.16"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "23 of 31 (gap 8)"
+                },
+                {
+                  "label": "Road length swept",
+                  "value": "49 of 196 (gap 147)"
+                },
+                {
+                  "label": "Sweeping manpower (required/available)",
+                  "value": "40 / 50 (gap Nil)"
+                },
+                {
+                  "label": "Wards with 100% collection / door-to-door",
+                  "value": "31 of 31 / 31 of 31 (100%)"
+                },
+                {
+                  "label": "Waste transport fleet",
+                  "value": "23 available vs 22 required (Tractor-3, MiniTipper-2, Compactors-2, Auto tippers-16)"
+                },
+                {
+                  "label": "Bulk waste generators / with onsite composting",
+                  "value": "47 (Hotel-10, Marriage Hall-31, Lodges-6) / 0"
+                },
+                {
+                  "label": "Wet-waste facilities (existing/functional)",
+                  "value": "5 / 5"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "4 (materials partially segregated, remainder landfilled)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "Existing dumpsite under litigation; required 1, available 0, gap 1"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "2500 Tonnes (DPR prepared but not yet started)"
+                },
+                {
+                  "label": "NGOs required/available",
+                  "value": "5 / 0"
+                }
+              ],
+              "openActions": [
+                "Send proposal for procurement of SWM site at Harisandra Village to government for approval and construct SLF - Ramanagara CMC - 31-3-2023",
+                "Implement legacy waste remediation per already-prepared DPR (2500 t, not yet started) - Ramanagara CMC - 31-3-2023",
+                "Achieve 100% source segregation in remaining 8 wards via awareness, penalties, colour-coded bins - Ramanagara CMC - 31-12-2021",
+                "Close 147 km regular-sweeping gap using full manpower utilisation/outsourcing - Ramanagara CMC - 31-12-2021",
+                "Get onsite composting commissioned at all 47 bulk waste generators - Ramanagara CMC - 31-3-2022",
+                "Tie up with 5 NGOs for SWM awareness - Ramanagara CMC - 31-3-2022"
+              ],
+              "pages": [
+                12,
+                13,
+                15,
+                16,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                28,
+                30,
+                31
+              ]
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Ramanagara CMC generates 0.2 TPD of plastic waste, achieves 100% door-to-door dry waste collection, but has no MOU with authorised plastic recyclers.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "0.2 TPD"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "31 of 31 wards, 100%"
+                }
+              ],
+              "openActions": [
+                "Execute MOU with KSPCB-authorised plastic recyclers and set up collection centres - Ramanagara CMC - 31-12-2021"
+              ],
+              "pages": [
+                33,
+                34
+              ]
             },
             {
-              "label": "Disposal facilities",
-              "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Ramanagara CMC reports 1.0 TPD of C&D waste, currently dumped in low-lying areas with no separate collection point.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "1.0 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish separate C&D collection and deposition points (currently dumped in low-lying areas) - Ramanagara CMC + District administration - 31-3-2022"
+              ],
+              "pages": [
+                41,
+                42
+              ]
+            },
             {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
-              "citation": "Hazardous Waste section, p.46",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Ramanagara CMC-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Ramanagara CMC has a 7.5 MLD STP (7.56 MLD on p61) against 10.12 MLD generated (10.0 on p61), a 2.62 MLD gap, 60% UGD coverage and missing links discharging untreated sewage indirectly to the river; the plan states the existing STP is not adequate.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "10.12 MLD (p69,72) / 10.0 MLD (p61)"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "7.5 MLD (p69,71,72) / 7.56 MLD (p61)"
+                },
+                {
+                  "label": "Gap",
+                  "value": "2.62 MLD"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "60% provided, 40% to be completed"
+                },
+                {
+                  "label": "STP adequacy",
+                  "value": "The existing STP is not adequate for existing sewage generation"
+                },
+                {
+                  "label": "Untreated discharge",
+                  "value": "Untreated sewage through missing links indirectly discharged to river"
+                }
+              ],
+              "openActions": [
+                "Complete remaining 40% of UGD work - Ramanagara CMC + KUWS&DB - 31-3-2022",
+                "Intercept and divert missing links bypassing the STP to the existing STP - Ramanagara CMC + KUWS&DB - 31-3-2023",
+                "Augment treatment capacity (existing STP inadequate for 10.12 MLD) - Ramanagara CMC + KUWS&DB - 31-3-2023"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                71,
+                72,
+                74
+              ]
             }
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.29,
-            "unit": "TPD",
-            "estimated": true
+          "key": "channapatna-cmc",
+          "name": "Channapatna",
+          "type": "CMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "CHANNAPATNA"
+            ]
           },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Channapatna CMC generates 36 (per day, unit not printed) of solid waste from 31 wards with 100% collection; 24 of 31 wards achieve source segregation, sweeping covers 52.9 of 126.80 km, the dumpsite is under litigation with 2200 tonnes of legacy waste and no remediation DPR.",
+              "metrics": [
+                {
+                  "label": "Wards / Households / Population",
+                  "value": "31 / 15990 (2011 Census) / 71942"
+                },
+                {
+                  "label": "Solid waste generated per day (unit not printed in table)",
+                  "value": "36"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "24 of 31 (gap 7)"
+                },
+                {
+                  "label": "Road length swept",
+                  "value": "52.9 of 126.80 (gap 73.80)"
+                },
+                {
+                  "label": "Sweeping manpower (required/available)",
+                  "value": "30 / 30 (gap Nil)"
+                },
+                {
+                  "label": "Sweeping tools gap",
+                  "value": "Brooms 100 available vs 276 required; hand gloves 600 vs 1000; face masks 500 vs 600"
+                },
+                {
+                  "label": "Wards with 100% collection / door-to-door",
+                  "value": "31 of 31 / 31 of 31 (100%)"
+                },
+                {
+                  "label": "Bulk waste generators / with onsite composting",
+                  "value": "67 (Hotels-52, Marriage Hall-13, Markets-2) / 0"
+                },
+                {
+                  "label": "Wet-waste facilities (existing/functional)",
+                  "value": "1 / 1"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "1 (materials partially segregated, remainder landfilled)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "1 dumpsite (under litigation); required 1, available 0, gap 1"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "2200 Tonnes (DPR not prepared, not started)"
+                },
+                {
+                  "label": "NGOs required/available",
+                  "value": "3 / 0"
+                }
+              ],
+              "openActions": [
+                "Prepare legacy waste remediation DPR (2200 t; none prepared) and remediate - Channapatna CMC - 31-3-2023",
+                "Construct sanitary landfill (existing dumpsite under litigation) - Channapatna CMC - 31-3-2023",
+                "Achieve 100% source segregation in remaining 7 wards - Channapatna CMC - 31-12-2021",
+                "Procure sweeping tools to close broom/gloves/mask gaps - Channapatna CMC - 31-12-2021",
+                "Get onsite composting commissioned at all 67 bulk waste generators - Channapatna CMC - 31-3-2022",
+                "Tie up with 3 NGOs for SWM awareness - Channapatna CMC - 31-3-2022"
+              ],
+              "pages": [
+                12,
+                13,
+                15,
+                16,
+                17,
+                19,
+                20,
+                21,
+                22,
+                23,
+                25,
+                26,
+                28,
+                30,
+                31
+              ]
+            },
             {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
-              "citation": "Biomedical Waste section, p.41",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Channapatna CMC generates 0.2 TPD of plastic waste with 100% door-to-door dry waste collection and no recycler MOU.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "0.2 TPD"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "31 of 31 wards, 100%"
+                }
+              ],
+              "openActions": [
+                "Execute MOU with KSPCB-authorised plastic recyclers and set up collection centres - Channapatna CMC - 31-12-2021"
+              ],
+              "pages": [
+                33,
+                34
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Channapatna CMC reports 1.0 TPD of C&D waste, dumped in low-lying areas.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "1.0 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish separate C&D collection and deposition points - Channapatna CMC + District administration - 31-3-2022"
+              ],
+              "pages": [
+                41,
+                42
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Channapatna CMC-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Channapatna CMC has no STP; 8.8 MLD (6.4 MLD on p61) of sewage goes to individual septic tanks and soak pits, with UGD reported as 60% complete on p70/74 but 'under construction' on p69.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "8.8 MLD (p69,72) / 6.4 MLD (p61)"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "0 - Nil (No STP only Septic tank and Soak Pit)"
+                },
+                {
+                  "label": "UGD status",
+                  "value": "60% of UGD work completed (p70); 'UGD is under construction and No STP in the Town' (p69); 60% provided / 40% yet to be completed (p74)"
+                }
+              ],
+              "openActions": [
+                "Provide UGD system connected to a new STP (8.8 MLD untreated to septic tanks) - Channapatna CMC + KUWS&DB - 31-3-2023",
+                "Complete remaining 40% of UGD work - Channapatna CMC + KUWS&DB - 31-3-2022"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                71,
+                72,
+                74
+              ]
             }
           ]
         },
         {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 2.0,
-            "unit": "TPD"
+          "key": "kanakapura-cmc",
+          "name": "Kanakapura",
+          "type": "CMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "KANAKAPURA"
+            ]
           },
-          "summary": "Construction & demolition waste.",
-          "metrics": [
+          "themes": [
             {
-              "label": "C&D waste generated",
-              "value": "2.0 TPD (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Kanakapura CMC generates 24 (per day, unit not printed) of solid waste; it is the best-covered ULB for disposal with a functional sanitary landfill, but only 24 of 87 km of road is swept and 4200 tonnes of legacy waste have no remediation DPR.",
+              "metrics": [
+                {
+                  "label": "Wards / Households / Population",
+                  "value": "27 wards (p12; 31 on p13, 23 on p19) / 12421 (2011 Census) / 54014"
+                },
+                {
+                  "label": "Solid waste generated per day (unit not printed in table)",
+                  "value": "24"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "28 of 31 (gap 3)"
+                },
+                {
+                  "label": "Road length swept",
+                  "value": "24 of 87 (gap 63)"
+                },
+                {
+                  "label": "Sweeping manpower (required/available)",
+                  "value": "40 / 40 (gap Nil)"
+                },
+                {
+                  "label": "Sweeping tools gap",
+                  "value": "Brooms 348 available vs 500 required; hand gloves 200 vs 800; face masks 300 vs 800; gum boots 50 vs 100; push carts 14 vs 19"
+                },
+                {
+                  "label": "Wards with 100% collection / door-to-door",
+                  "value": "23 of 23 / 31 of 31 (100%)"
+                },
+                {
+                  "label": "Bulk waste generators / with onsite composting",
+                  "value": "80 (hotels & restaurants, lodges, bakeries, institutions) / 0"
+                },
+                {
+                  "label": "Wet-waste facilities (existing/functional)",
+                  "value": "1 / 1"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "2 (materials partially segregated, remainder landfilled)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "1 dumpsite; SLF required 01, available 01, gap Nil"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "4200 Tonnes (DPR not prepared, not started)"
+                },
+                {
+                  "label": "NGOs required/available",
+                  "value": "4 / 0"
+                }
+              ],
+              "openActions": [
+                "Prepare legacy waste remediation DPR (4200 t; none prepared) and remediate - Kanakapura CMC - 31-3-2023",
+                "Achieve 100% source segregation in remaining 3 wards - Kanakapura CMC - 31-12-2021",
+                "Close 63 km sweeping gap and procure missing tools (brooms, gloves, masks, boots) - Kanakapura CMC - 31-12-2021",
+                "Get onsite composting commissioned at all 80 bulk waste generators - Kanakapura CMC - 31-3-2022",
+                "Tie up with 4 NGOs for SWM awareness - Kanakapura CMC - 31-3-2022"
+              ],
+              "pages": [
+                12,
+                13,
+                15,
+                16,
+                17,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                28,
+                30,
+                31
+              ]
             },
             {
-              "label": "Recycling facility",
-              "value": "None in the district (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Kanakapura CMC generates 0.5 TPD of plastic waste (highest of the ULBs) with 100% door-to-door dry waste collection and no recycler MOU.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "0.5 TPD"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "31 of 31 wards, 100%"
+                }
+              ],
+              "openActions": [
+                "Execute MOU with KSPCB-authorised plastic recyclers and set up collection centres - Kanakapura CMC - 31-12-2021"
+              ],
+              "pages": [
+                33,
+                34
+              ]
+            },
             {
-              "source": "Ramanagara DEP 2021",
-              "says": "C&D waste generation (per ULB), Kanakapura: 2.0 MT/day. No C&D recycling facility in the district.",
-              "citation": "C&D Waste section, p.39",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Kanakapura CMC reports 2.0 TPD of C&D waste (highest in the district), dumped in low-lying areas.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "2.0 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish separate C&D collection and deposition points - Kanakapura CMC + District administration - 31-3-2022"
+              ],
+              "pages": [
+                41,
+                42
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Kanakapura CMC-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Kanakapura CMC's 6.29 MLD STP is adequate for its 4.4 MLD sewage, but 25% of UGD is incomplete and missing links bypass the STP, discharging untreated sewage indirectly to the river.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "4.4 MLD"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "6.29 MLD"
+                },
+                {
+                  "label": "STP adequacy",
+                  "value": "The existing STP is adequate"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "75% provided, 25% to be completed"
+                },
+                {
+                  "label": "Untreated discharge",
+                  "value": "Untreated sewage through missing links indirectly discharged to river"
+                }
+              ],
+              "openActions": [
+                "Complete remaining 25% of UGD work - Kanakapura CMC + KUWS&DB - 31-3-2022",
+                "Intercept and divert missing links bypassing the STP - Kanakapura CMC + KUWS&DB - 31-3-2023"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                71,
+                72,
+                74
+              ]
             }
           ]
         },
         {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "~510"
-            },
-            {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~200",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
-            }
-          ]
-        }
-      ]
-    },
-    "channapatna": {
-      "name": "Channapatna (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021 - not on the yearly-monitored Arkavathi stretch",
-      "headline": "8.8 MLD of sewage generated with no STP - essentially the whole load is untreated",
-      "streams": [
-        {
-          "stream": "Sewage",
-          "summary": "No operational STP; an STP is only now (2026) proposed, DPR under preparation",
-          "metrics": [
-            {
-              "label": "Sewage generated",
-              "value": "8.8 MLD (DEP 2021)"
-            },
-            {
-              "label": "STP capacity",
-              "value": "None operational (11.5 MLD proposed, 2026)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Treatment gap",
-              "value": "~8.8 MLD, whole load (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Channapatna sewage generation ~8.8 MLD with no STP installed (septic tanks only).",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 8.8,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "~36 TPD generated - the highest urban load in the district after Ramanagara",
-          "metrics": [
-            {
-              "label": "Generated",
-              "value": "~36 TPD (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Channapatna urban solid waste ~36 TPD.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 36.0,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 18.7,
-            "unit": "TPD",
-            "estimated": true
+          "key": "magadi-tmc",
+          "name": "Magadi",
+          "type": "TMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "MAGADI"
+            ]
           },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Magadi TMC generates 14.5 (per day, unit not printed) of solid waste with near-complete sweeping coverage (52 of 58 km) and a functional sanitary landfill, but carries by far the district's largest legacy dump at 46000 tonnes.",
+              "metrics": [
+                {
+                  "label": "Wards / Households / Population",
+                  "value": "23 wards (p12; 13 on p19) / 6637 (2011 Census) / 27605"
+                },
+                {
+                  "label": "Solid waste generated per day (unit not printed in table)",
+                  "value": "14.5"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "20 of 23 (gap 3)"
+                },
+                {
+                  "label": "Road length swept",
+                  "value": "52 of 58 (gap 6)"
+                },
+                {
+                  "label": "Sweeping manpower (required/available)",
+                  "value": "28 / 28 (gap Nil)"
+                },
+                {
+                  "label": "Wards with 100% collection / door-to-door",
+                  "value": "13 of 13 / 23 of 23 (100%)"
+                },
+                {
+                  "label": "Bulk waste generators / with onsite composting",
+                  "value": "66 (Hotel 23, restaurants 02, institutions 32, Marriage Hall-9) / 0"
+                },
+                {
+                  "label": "Wet-waste facilities (existing/functional)",
+                  "value": "1 / 1"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "1 (materials partially segregated, remainder landfilled)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "1 dumpsite; SLF required 01, available 01, gap Nil"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "46000 Tonnes"
+                },
+                {
+                  "label": "NGOs required/available",
+                  "value": "2 / 0"
+                }
+              ],
+              "openActions": [
+                "Prepare and implement CPCB-aligned remediation of the 46000-tonne legacy dumpsite - Magadi TMC - 31-3-2023",
+                "Achieve 100% source segregation in remaining 3 wards - Magadi TMC - 31-12-2021",
+                "Get onsite composting commissioned at all 66 bulk waste generators - Magadi TMC - 31-3-2022",
+                "Tie up with 2 NGOs for SWM awareness - Magadi TMC - 31-3-2022"
+              ],
+              "pages": [
+                12,
+                13,
+                15,
+                17,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                28,
+                30,
+                31
+              ]
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Magadi TMC generates 0.1 TPD of plastic waste with 100% door-to-door dry waste collection and no recycler MOU.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "0.1 TPD"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "23 of 23 wards, 100%"
+                }
+              ],
+              "openActions": [
+                "Execute MOU with KSPCB-authorised plastic recyclers and set up collection centres - Magadi TMC - 31-12-2021"
+              ],
+              "pages": [
+                33,
+                34
+              ]
             },
             {
-              "label": "Disposal facilities",
-              "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Magadi TMC reports 0.5 TPD of C&D waste, dumped in low-lying areas.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "0.5 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish separate C&D collection and deposition points - Magadi TMC + District administration - 31-3-2022"
+              ],
+              "pages": [
+                41,
+                42
+              ]
+            },
             {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
-              "citation": "Hazardous Waste section, p.46",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Magadi TMC-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Magadi TMC's STP (3.71 MLD on p69/71; 3.2 MLD on p61) is adequate for its sewage (2.29 MLD on p72; 2.9 MLD on p61), but missing UGD links (10-20% incomplete) bypass the STP.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "2.29 MLD (p72) / 2.9 MLD (p61)"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "3.71 MLD (p69,71,72) / 3.2 MLD (p61)"
+                },
+                {
+                  "label": "STP adequacy",
+                  "value": "The existing STP is adequate"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "90% covered (p69) / 80% provided, 20% yet to be completed (p74)"
+                }
+              ],
+              "openActions": [
+                "Complete remaining UGD work (10-20% per conflicting tables) - Magadi TMC + KUWS&DB - 31-3-2022",
+                "Intercept and divert missing links bypassing the STP - Magadi TMC + KUWS&DB - 31-3-2023"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                71,
+                72,
+                74
+              ]
             }
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.29,
-            "unit": "TPD",
-            "estimated": true
+          "key": "bidadi-tmc",
+          "name": "Bidadi",
+          "type": "TMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "BIDADI"
+            ]
           },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Bidadi TMC generates 15 (per day, unit not printed) of solid waste; it is the ULB with the most named pending works: a 20+12 sweeping-manpower recruitment, 2 vermicompost units under 15th Finance, an unstarted DWCC, no SWM site (proposal for 2.32 acres at Sheshagerihalli pending) and 3700 tonnes of legacy waste with no DPR.",
+              "metrics": [
+                {
+                  "label": "Wards / Households / Population",
+                  "value": "23 wards (p12; 11 on p19) / 6925 (2011 Census) / 29825"
+                },
+                {
+                  "label": "Solid waste generated per day (unit not printed in table)",
+                  "value": "15"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "20 of 23 (gap 3)"
+                },
+                {
+                  "label": "Road length swept",
+                  "value": "22 of 195 (gap 173)"
+                },
+                {
+                  "label": "Sweeping manpower (required/available)",
+                  "value": "20 / 20 (gap Nil per table; but manpower tender for 20 members plus 12-member proposal stated pending)"
+                },
+                {
+                  "label": "Wards with 100% collection / door-to-door",
+                  "value": "11 of 11 / 23 of 23 (100%)"
+                },
+                {
+                  "label": "Bulk waste truck",
+                  "value": "required 1, available 0, gap 1"
+                },
+                {
+                  "label": "Bulk waste generators / with onsite composting",
+                  "value": "75 (hotels, party halls, education institutions) / 0"
+                },
+                {
+                  "label": "Wet-waste facilities",
+                  "value": "existence 1, functional 1, needs upgradation 2, gap 2"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "1 per existence table (p28); '02 Nos Dry waste collection centers are constructed. Since shortage of manpower not able to start DWCC' (p27); waste dumped in private land"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "existing dumpsite 0 (p28) / 1 (p30); SLF required 1, available 0, gap 1"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "3700 Tonnes (no DPR; no SWM site)"
+                },
+                {
+                  "label": "NGOs required/available",
+                  "value": "2 / 0"
+                }
+              ],
+              "openActions": [
+                "Appoint 20 sweeping staff via manpower tender and send proposal for remaining 12 to DC Office - Bidadi TMC - 31.12.2021",
+                "Construct 02 vermicompost decentralization units under 15th Finance - Bidadi TMC - 31.03.2022",
+                "Start the 2 constructed but non-operational dry waste collection centres (manpower shortage) - Bidadi TMC - 31-3-2022",
+                "Obtain government approval for SWM site at Sy No. 77 Sheshagerihalli (2.32 acre) and construct SLF - Bidadi TMC - 31-3-2023",
+                "Prepare legacy-waste DPR after SWM site is handed over to TMC (3700 t) - Bidadi TMC - 31-3-2023",
+                "Procure 1 bulk waste truck (gap 1) - Bidadi TMC - 31-3-2022",
+                "Close 173 km regular-sweeping gap - Bidadi TMC - 31-12-2021",
+                "Get onsite composting commissioned at all 75 bulk waste generators - Bidadi TMC - 31-3-2022",
+                "Tie up with 2 NGOs for SWM awareness - Bidadi TMC - 31-3-2022"
+              ],
+              "pages": [
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                27,
+                28,
+                30,
+                31
+              ]
+            },
             {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
-              "citation": "Biomedical Waste section, p.41",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Bidadi TMC generates 0.05 TPD of plastic waste with 100% door-to-door dry waste collection and no recycler MOU.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "0.05 TPD"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "23 of 23 wards, 100%"
+                }
+              ],
+              "openActions": [
+                "Execute MOU with KSPCB-authorised plastic recyclers and set up collection centres - Bidadi TMC - 31-12-2021"
+              ],
+              "pages": [
+                33,
+                34
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Bidadi TMC reports 0.4 TPD of C&D waste, dumped in low-lying areas.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "0.4 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish separate C&D collection and deposition points - Bidadi TMC + District administration - 31-3-2022"
+              ],
+              "pages": [
+                41,
+                42
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Bidadi TMC-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Bidadi TMC has no STP and no functioning UGD (15% work completed per p70, 0% provided per p74); 3.2 MLD of sewage (3.7 MLD on p61) goes to individual septic tanks and soak pits.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "3.2 MLD (p72) / 3.7 MLD (p61)"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "0 - Nil (No STP only Septic tank and Soak Pit)"
+                },
+                {
+                  "label": "UGD status",
+                  "value": "15% UGD work completed (p70) / 0% provided, 85% yet to be completed (p74)"
+                }
+              ],
+              "openActions": [
+                "Provide UGD system connected to a new STP - Bidadi TMC + KUWS&DB - 31-3-2023",
+                "Complete UGD network (85% outstanding per p74) - Bidadi TMC + KUWS&DB - 31-3-2022"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                72,
+                74
+              ]
             }
           ]
         },
         {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 1.0,
-            "unit": "TPD"
+          "key": "harohalli-tp",
+          "name": "Harohalli",
+          "type": "TP",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "HAROHALLI"
+            ]
           },
-          "summary": "Construction & demolition waste.",
-          "metrics": [
+          "themes": [
             {
-              "label": "C&D waste generated",
-              "value": "1.0 TPD (DEP 2021)"
+              "theme": "waste-management",
+              "status": "not-covered",
+              "subtheme": "solid-waste",
+              "summary": "The document lists Harohalli in every ULB table but reports no data, stating 'Newly declared TP and DPR is yet to be prepared'. No solid waste quantity, ward, sweeping, collection or disposal data is given.",
+              "metrics": [
+                {
+                  "label": "Status in all solid waste tables",
+                  "value": "Newly declared TP and DPR is yet to be prepared"
+                }
+              ],
+              "openActions": [
+                "Prepare the Town Panchayat DPR so Harohalli enters all SWM gap tables - Harohalli TP (implied) - no timeline given"
+              ],
+              "pages": [
+                12,
+                13,
+                15,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                28,
+                30,
+                31
+              ]
             },
             {
-              "label": "Recycling facility",
-              "value": "None in the district (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "C&D waste generation (per ULB), Channapatna: 1.0 MT/day. No C&D recycling facility in the district.",
-              "citation": "C&D Waste section, p.39",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ]
-        },
-        {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "~80"
+              "theme": "waste-management",
+              "status": "not-covered",
+              "subtheme": "plastic-waste",
+              "summary": "Plastic waste for Harohalli is 'Newly declared TP and Not estimated'; no figures reported.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "Newly declared TP and Not estimated"
+                }
+              ],
+              "pages": [
+                33,
+                34
+              ]
             },
             {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~20",
-              "emphasis": "bad"
+              "theme": "waste-management",
+              "status": "not-covered",
+              "subtheme": "cd-waste",
+              "summary": "The C&D table shows a dash for TP-Harohalli; no quantity reported.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "- (blank)"
+                }
+              ],
+              "pages": [
+                41
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                45,
+                46,
+                47,
+                48,
+                49
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                50,
+                51,
+                52,
+                53
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section. (5 e-waste collection centres are attributed to 'ULBs' collectively, not named per ULB).",
+              "pages": [
+                53,
+                54,
+                55,
+                56
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                60,
+                61,
+                62,
+                63,
+                64,
+                65,
+                66,
+                67,
+                68
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                61,
+                76,
+                77,
+                78
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                57,
+                58,
+                59
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                79,
+                80
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Reported only district-wide; no Harohalli TP-specific data in this section.",
+              "pages": [
+                81,
+                82,
+                83
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Harohalli TP has no UGD and no STP; houses use individual septic tanks and soak pits, and its sewage quantity is not estimated.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "Not estimated"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "0 - Nil (No STP only Septic tank and Soak Pit)"
+                },
+                {
+                  "label": "UGD status",
+                  "value": "No UGD System implemented"
+                }
+              ],
+              "openActions": [
+                "Provide UGD system connected to STP - Harohalli TP + KUWS&DB - 31-3-2022 (network) / 31-3-2023 (STP)"
+              ],
+              "pages": [
+                61,
+                69,
+                70,
+                72,
+                75
+              ]
             }
           ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
-            }
-          ]
+          "note": "Newly declared TP at the time of the plan; most waste tables say a DPR is yet to be prepared."
         }
       ],
-      "caveats": [
-        "No industrial estate is mapped in this taluk, so there's no CETP analysis here. Channapatna's toy/lacquerware and silk industry isn't captured in this layer - a known coverage gap. The district reports no CETPs (DEP 2021)."
-      ]
-    },
-    "magadi": {
-      "name": "Magadi (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021 - not on the yearly-monitored Arkavathi stretch",
-      "headline": "Small STP, under-utilised and not yet complying; a large legacy-waste backlog",
-      "streams": [
+      "taluks": [
         {
-          "stream": "Sewage",
-          "summary": "STP runs well below capacity and is not yet complying",
-          "metrics": [
-            {
-              "label": "Sewage generated",
-              "value": "2.29 MLD (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Magadi sewage generation ~2.29 MLD; STP capacity 3.71 MLD.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 2.29,
-            "unit": "MLD"
+          "key": "ramanagara",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Ramanagara"
+            ]
+          },
+          "unit": {
+            "name": "Ramanagara (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021",
+            "headline": "Treatment gaps have held for 4+ years; a sanctioned upgrade is the lever to close them",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "2.62 MLD treatment gap on the DEP's own numbers; the plan calls the existing STP 'not adequate'",
+                "metrics": [
+                  {
+                    "label": "Sewage generated",
+                    "value": "10.12 MLD (DEP p.69, 72; 10.0 on p.61)"
+                  },
+                  {
+                    "label": "STP capacity",
+                    "value": "7.5 MLD (DEP p.69-72; 7.56 on p.61)"
+                  },
+                  {
+                    "label": "Treatment gap",
+                    "value": "2.62 MLD (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "UGD coverage",
+                    "value": "60% provided; 40% pending (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "STP adequacy",
+                    "value": "“Not adequate” for existing generation (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "~18.9-23.3 MLD generated vs 17.5 MLD installed STP capacity (district); Ramanagara STP 'not adequate'; treated/untreated volumes 'Not Estimated'.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 10.12,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "No common effluent treatment plant; the documents differ on whether that's a problem",
+                "metrics": [
+                  {
+                    "label": "Industrial areas mapped (basin)",
+                    "value": "4, all >5 km from a CETP (Neer Vazhvu estimate, 2026)"
+                  },
+                  {
+                    "label": "DEP position",
+                    "value": "Effluent \"fully recycled, zero discharge\"; 581 industries \"meeting standards\" (DEP 2021)"
+                  },
+                  {
+                    "label": "CAG finding",
+                    "value": "38 of 66 sampled KIADB areas had no CETP; ~2,571 ML/yr untreated (CAG 2017)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "\"There are no CETPs in the Ramanagara District.\" Trade effluent reported fully recycled with zero discharge; all 581 wastewater-discharging industries reported meeting standards.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  },
+                  {
+                    "source": "CAG Report No. 8 of 2017 (p.18)",
+                    "says": "In 38 of 66 sampled KIADB industrial areas, basic facilities including CETP/CSTP were not provided; 4,077 units operating without; ~2,571 million litres/yr untreated waste let off as surface discharge.",
+                    "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
+                    "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "~15 of 40 TPD processed (2025); 35 collected; the rest unprocessed, plus a district sanitary-landfill shortfall",
+                "metrics": [
+                  {
+                    "label": "Sanitary-landfill gap (district)",
+                    "value": "3 of 5 sites short; 2 under litigation (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "~129.66 TPD urban generated district-wide; legacy waste 58,600 t (Magadi alone 46,000 t); sanitary-landfill sites under litigation.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 35.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 18.7,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
+                    "citation": "Hazardous Waste section, p.46",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
+                    "citation": "Biomedical Waste section, p.41",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 1.0,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "1.0 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "C&D waste generation (per ULB), Ramanagara: 1.0 MT/day. No C&D recycling facility in the district.",
+                    "citation": "C&D Waste section, p.39",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "KSPCB's register of consented industries (Ramanagara Regional Office), by pollution-potential colour (Red/Orange = higher). The Regional Office's jurisdictional area does not coincide with the taluk boundary.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~650"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~380",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Ramanagara RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                  }
+                ]
+              }
+            ],
+            "conflicts": [
+              "The basin's share of the district hosts 6 KIADB industrial areas (Bidadi Phase 1, Phase 2 Sectors I & II; Harohalli Phases 1&2, 3, 4), yet the DEP records “There are no CETPs in the Ramanagara District” (p.76) and reports all 581 industries meeting standards - while CAG (Report No. 8 of 2017, p.28) holds that a typical KIADB industrial area should have a Common Effluent Treatment Plant (CETP)/Common Sewage Treatment Plant (CSTP).",
+              "The DEP's own district sewage-generation total is inconsistent: 18.87 MLD (p.61) vs the same page's table summing to 27.4 MLD vs 23.32 MLD (p.69) vs 28.81 MLD (p.72)."
+            ]
           }
         },
         {
-          "stream": "Municipal solid waste",
-          "summary": "~14.5 TPD generated, but a very large legacy dump",
+          "key": "channapatna",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Channapatna"
+            ]
+          },
+          "unit": {
+            "name": "Channapatna (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021 - not on the yearly-monitored Arkavathi stretch",
+            "headline": "8.8 MLD of sewage generated with no STP - essentially the whole load is untreated",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "No operational STP; an STP is only now (2026) proposed, DPR under preparation",
+                "metrics": [
+                  {
+                    "label": "Sewage generated",
+                    "value": "8.8 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "STP capacity",
+                    "value": "None operational (11.5 MLD proposed, 2026)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Treatment gap",
+                    "value": "~8.8 MLD, whole load (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Channapatna sewage generation ~8.8 MLD with no STP installed (septic tanks only).",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 8.8,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "~36 TPD generated - the highest urban load in the district after Ramanagara",
+                "metrics": [
+                  {
+                    "label": "Generated",
+                    "value": "~36 TPD (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Channapatna urban solid waste ~36 TPD.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 36.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 18.7,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
+                    "citation": "Hazardous Waste section, p.46",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
+                    "citation": "Biomedical Waste section, p.41",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 1.0,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "1.0 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "C&D waste generation (per ULB), Channapatna: 1.0 MT/day. No C&D recycling facility in the district.",
+                    "citation": "C&D Waste section, p.39",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "KSPCB's register of consented industries (Ramanagara Regional Office), by pollution-potential colour (Red/Orange = higher). The Regional Office's jurisdictional area does not coincide with the taluk boundary.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~80"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~20",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Ramanagara RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                  }
+                ]
+              }
+            ],
+            "caveats": [
+              "No industrial estate is mapped in this taluk, so there's no CETP analysis here. Channapatna's toy/lacquerware and silk industry isn't captured in this layer - a known coverage gap. The district reports no CETPs (DEP 2021)."
+            ]
+          }
+        },
+        {
+          "key": "kanakapura",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Kanakpura"
+            ]
+          },
+          "unit": {
+            "name": "Kanakapura (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021",
+            "headline": "Sewage roughly within STP capacity; the gaps here are no CETP for its industrial areas and unprocessed solid waste",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "Small treatment gap (0.6 MLD) - STP capacity exceeds the current load",
+                "metrics": [],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Kanakapura sewage generation ~4.4 MLD; STP capacity 6.29 MLD.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 4.4,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "Two mapped industrial areas, neither with a CETP nearby",
+                "metrics": [
+                  {
+                    "label": "Industrial areas mapped",
+                    "value": "2, incl. 1 KIADB (Paani layer, 2026)"
+                  },
+                  {
+                    "label": "With a CETP nearby",
+                    "value": "0 - both >5 km from the nearest CETP (Neer Vazhvu estimate, 2026)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "District CETPs",
+                    "value": "0 - \"no CETPs in the Ramanagara district\" (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Neer Vazhvu spatial estimate",
+                    "says": "Both mapped Kanakapura industrial areas sit >5 km from the nearest common effluent facility - a proximity estimate from the industrial-areas and common-facilities layers, not confirmed service connectivity."
+                  },
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "\"There are no CETPs in the Ramanagara District.\"",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  },
+                  {
+                    "source": "CAG Report No. 8 of 2017 (p.18)",
+                    "says": "38 of 66 sampled KIADB industrial areas had no CETP/CSTP.",
+                    "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
+                    "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "~24 TPD generated; district-wide processing and landfill gaps apply",
+                "metrics": [
+                  {
+                    "label": "Generated",
+                    "value": "~24 TPD (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Kanakapura urban solid waste ~24 TPD; district has 0 of 335 bulk generators composting onsite and a 3-site sanitary-landfill shortfall.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 24.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 18.7,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
+                    "citation": "Hazardous Waste section, p.46",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
+                    "citation": "Biomedical Waste section, p.41",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 2.0,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "2.0 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "C&D waste generation (per ULB), Kanakapura: 2.0 MT/day. No C&D recycling facility in the district.",
+                    "citation": "C&D Waste section, p.39",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "KSPCB's register of consented industries (Ramanagara Regional Office), by pollution-potential colour (Red/Orange = higher). The Regional Office's jurisdictional area does not coincide with the taluk boundary.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~510"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~200",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Ramanagara RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "magadi",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Magadi"
+            ]
+          },
+          "unit": {
+            "name": "Magadi (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021 - not on the yearly-monitored Arkavathi stretch",
+            "headline": "Small STP, under-utilised and not yet complying; a large legacy-waste backlog",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "STP runs well below capacity and is not yet complying",
+                "metrics": [
+                  {
+                    "label": "Sewage generated",
+                    "value": "2.29 MLD (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Magadi sewage generation ~2.29 MLD; STP capacity 3.71 MLD.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 2.29,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "~14.5 TPD generated, but a very large legacy dump",
+                "metrics": [
+                  {
+                    "label": "Generated",
+                    "value": "~14.5 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Legacy waste",
+                    "value": "46,000 t, largest in district (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Magadi urban solid waste ~14.5 TPD; legacy waste at Magadi ~46,000 tonnes (the bulk of the district's 58,600 t legacy backlog).",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 14.5,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 18.7,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
+                    "citation": "Hazardous Waste section, p.46",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
+                    "citation": "Biomedical Waste section, p.41",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 0.5,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "0.5 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "C&D waste generation (per ULB), Magadi: 0.5 MT/day. No C&D recycling facility in the district.",
+                    "citation": "C&D Waste section, p.39",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "KSPCB's register of consented industries (Ramanagara Regional Office), by pollution-potential colour (Red/Orange = higher). The Regional Office's jurisdictional area does not coincide with the taluk boundary.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~120"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~50",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Ramanagara RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                  }
+                ]
+              }
+            ],
+            "caveats": [
+              "No industrial estate is mapped in this taluk in the current layer, so there's no CETP analysis here. The district reports no CETPs (DEP 2021)."
+            ]
+          }
+        },
+        {
+          "key": "harohalli",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Harohalli"
+            ]
+          },
+          "unit": {
+            "name": "Harohalli (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "A major KIADB industrial cluster with no CETP and no STP - newly declared town, plans still on paper",
+            "streams": [
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "Large KIADB industrial cluster; the CAG audit found most sampled KIADB areas had no CETP, and there is none near Harohalli",
+                "metrics": [
+                  {
+                    "label": "KIADB phases",
+                    "value": "Harohalli 1st-4th phases (CAG 2017)"
+                  },
+                  {
+                    "label": "CAG audit finding",
+                    "value": "38 of 66 sampled KIADB areas had no CETP/CSTP (CAG 2017)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Nearest common ETP",
+                    "value": "None within ~20 km (Neer Vazhvu estimate, 2026)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "CAG Report No. 8 of 2017 (p.18)",
+                    "says": "In respect of 38 of 66 sampled KIADB industrial areas the basic facilities including CETP/CSTP were not provided; 4,077 units operating without.",
+                    "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
+                    "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
+                  },
+                  {
+                    "source": "Neer Vazhvu spatial estimate",
+                    "says": "Harohalli KIADB phases sit ~21-28 km from the nearest mapped common effluent facility - a proximity estimate from the basin's industrial-areas and common-facilities layers (our computation, not a CAG figure)."
+                  },
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "\"There are no CETPs in the Ramanagara District.\"",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Sewage",
+                "summary": "Still no STP - DPR not prepared (land issue) as of 2026; only a small faecal-sludge drying bed is under construction",
+                "metrics": [
+                  {
+                    "label": "STP capacity",
+                    "value": "None - 0 STP (DEP 2021)"
+                  },
+                  {
+                    "label": "Status",
+                    "value": "Newly declared town; DPR yet to be prepared (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Harohalli has 0 STP (Nil capacity); newly declared TP and DPR is yet to be prepared.",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "Processing facility still at DPR stage",
+                "metrics": [
+                  {
+                    "label": "Processing",
+                    "value": "DPR yet to be prepared (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP (31-03-2021)",
+                    "says": "Harohalli solid-waste processing DPR yet to be prepared (newly declared town).",
+                    "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 18.7,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
+                    "citation": "Hazardous Waste section, p.46",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Ramanagara DEP 2021",
+                    "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
+                    "citation": "Biomedical Waste section, p.41",
+                    "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "Harohalli became a separate taluk (carved from Kanakapura) only in 2022, so the 2019 F-register counts it within Kanakapura (~510 consented industries). The Harohalli KIADB estate is a major share of that.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "within Kanakapura (~510)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Ramanagara RO)",
+                    "says": "Harohalli not separated; counted within Kanakapura taluk (~510 consented industries as on 31-03-2019).",
+                    "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted; approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "industrialAreas": [
+        {
+          "name": "Bidadi 1st Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Bidadi 1st Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Bidadi 2nd Phase Sector I",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Bidadi 2nd Phase Sector I"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Bidadi 2nd Phase Sector II",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Bidadi 2nd Phase Sector II"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Harohalli 1st And 2nd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Harohalli 1st And 2nd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Harohalli 3rd  Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Harohalli 3rd  Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Harohalli 4th Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Harohalli 4th Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "key": "bengaluru-urban",
+      "name": "Bengaluru Urban",
+      "dep": {
+        "label": "Bengaluru Urban DEP 2022",
+        "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+      },
+      "pctInBasin": 45.9,
+      "counts": [
+        {
+          "label": "City Corporation",
+          "value": "1 - BBMP (now GBA, 2025)"
+        },
+        {
+          "label": "Other ULBs enumerated in the plan",
+          "value": "7 - Hebbagodi CMC + 6 TMCs (Anekal side, outside the basin)"
+        },
+        {
+          "label": "In-basin ULBs created after the plan",
+          "value": "2 - Madanayakanahalli CMC, Chikkabanavara TMC"
+        },
+        {
+          "label": "Gram Panchayats",
+          "value": "86 (per the plan)"
+        }
+      ],
+      "countsNote": "The plan claims “1 Municipal Corporation, 9 ULBs” but enumerates only 7 besides BBMP; the basin's two newer ULBs post-date it.",
+      "mapMatch": {
+        "family": "admin-district",
+        "prop": "name",
+        "values": [
+          "Bengaluru (Urban)"
+        ]
+      },
+      "districtThemes": [
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "solid-waste",
+          "summary": "District generates ~5,598.5 TPD urban MSW plus 296 TPD rural across 7 ULBs and 86 GPs, with near-complete urban collection but a 5-million-tonne legacy-waste backlog and only 1 of 14 required sanitary landfills.",
           "metrics": [
             {
-              "label": "Generated",
-              "value": "~14.5 TPD (DEP 2021)"
+              "label": "Urban solid waste generated (BBMP)",
+              "value": "5500 TPD"
+            },
+            {
+              "label": "Urban solid waste generated (CMC Hebbagodi)",
+              "value": "35 TPD"
+            },
+            {
+              "label": "Urban solid waste generated (TMCs Anekal/Attibele/Bommasandra/Chandapura/Jigani)",
+              "value": "20 / 11 / 12 / 8.5 / 12 TPD"
+            },
+            {
+              "label": "Rural solid waste generated (86 GPs, 5 blocks)",
+              "value": "296 Tons per day"
+            },
+            {
+              "label": "Wards with 100% source segregation",
+              "value": "328 of 348 (GPs: 18 of 86)"
+            },
+            {
+              "label": "Wards with 100% collection",
+              "value": "366 of 434 (all 68 gap wards are Gram Panchayats)"
+            },
+            {
+              "label": "Domestic-hazardous waste deposition centres",
+              "value": "151 available vs 290 required (gap 138)"
+            },
+            {
+              "label": "Sanitary landfills",
+              "value": "1 available vs 14 required; 5 existing dumpsites"
             },
             {
               "label": "Legacy waste",
-              "value": "46,000 t, largest in district (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Magadi urban solid waste ~14.5 TPD; legacy waste at Magadi ~46,000 tonnes (the bulk of the district's 58,600 t legacy backlog).",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 14.5,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 18.7,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
+              "value": "5,002,000 Tonnes (BBMP 5,000,000 at 4 dumpsites; Anekal 2,000)"
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
+              "label": "MRF/dry-waste facilities",
+              "value": "135 total, all functional (BBMP 129)"
             }
           ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
-              "citation": "Hazardous Waste section, p.46",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
+          "openActions": [
+            "100% source segregation via awareness + fines (BBMP+ULBs+TPs, 31.12.2022)",
+            "100% collection in 68 gap Gram Panchayats (BBMP+ULBs+TPs, 31.12.2023)",
+            "Establish waste deposition centres + MoU with TSDF for domestic hazardous waste (BBMP+ULBs+TPs, 31.12.2022)",
+            "Grant of land and construction of sanitary landfills (DC Bengaluru Urban, 31.03.2023)",
+            "Legacy dumpsite remediation per CPCB-compliant DPR (BBMP+ULBs, 31.12.2023)",
+            "Identify and authorize waste pickers with ID cards (BBMP+ULBs, 31.12.2022)"
+          ],
+          "pages": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            19,
+            20,
+            22,
+            28,
+            29,
+            30,
+            31
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.29,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "plastic-waste",
+          "summary": "District generates 430.7 TPD plastic waste; ULBs hand plastic to authorized recyclers (Saahas Zero Waste MoU) and BBMP routes it via M/s KK Plastics into road construction, but EPR is not followed by producers.",
           "metrics": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
+              "label": "Plastic waste generated (district)",
+              "value": "430.7 TPD"
+            },
+            {
+              "label": "Plastic waste generated (BBMP)",
+              "value": "420 TPD"
+            },
+            {
+              "label": "Decentralised Dry Waste Collection Centres (BBMP, ward level)",
+              "value": "141"
+            },
+            {
+              "label": "EPR status",
+              "value": "not been strictly followed by any of the major producers"
             }
           ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
-              "citation": "Biomedical Waste section, p.41",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
+          "openActions": [
+            "Achieve 100% door-to-door dry-waste collection in BBMP (98 gap wards) (BBMP+ULBs, 31.03.2022)",
+            "Aggregator/collection centres for low-value plastic at prominent places (BBMP+ULBs, 31.03.2022)",
+            "TMC Attibele and Chandapura to identify sites for dry waste collection centres (ULBs, 31.12.2022)",
+            "Mass awareness every 6 months + records to KSPCB; bar mesh in nallahs and drains to stop plastic entering water bodies (BBMP+ULBs+KSPCB)"
+          ],
+          "pages": [
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38
           ]
         },
         {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 0.5,
-            "unit": "TPD"
-          },
-          "summary": "Construction & demolition waste.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "cd-waste",
+          "summary": "District generates 2,507 TPD C&D waste, almost all in BBMP; one private 1,000 MTPD plant at Chikkajala operates and a 750 TPD BBMP plant at Kannur is being commissioned, while ULBs have no facility or user fee.",
           "metrics": [
             {
-              "label": "C&D waste generated",
-              "value": "0.5 TPD (DEP 2021)"
+              "label": "C&D waste generated (district)",
+              "value": "2507 TPD"
             },
-            {
-              "label": "Recycling facility",
-              "value": "None in the district (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "C&D waste generation (per ULB), Magadi: 0.5 MT/day. No C&D recycling facility in the district.",
-              "citation": "C&D Waste section, p.39",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ]
-        },
-        {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "KSPCB's register of consented industries in the taluk, by pollution-potential colour (Red/Orange = higher).",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "~120"
-            },
-            {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~50",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
-            }
-          ]
-        }
-      ],
-      "caveats": [
-        "No industrial estate is mapped in this taluk in the current layer, so there's no CETP analysis here. The district reports no CETPs (DEP 2021)."
-      ]
-    },
-    "bbmp": {
-      "name": "BBMP (Bengaluru city corporation; west/south = V-Valley / Vrishabhavathi)",
-      "level": "City",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "City sewage runs close to installed STP capacity on paper, but ~20% of the area has no sewer network (8-10% untreated), and the V-Valley's Peenya cluster is a CPCB Critically Polluted Area",
-      "streams": [
-        {
-          "stream": "Sewage",
-          "summary": "~1,440 MLD generated vs 1,522.5 MLD STP capacity, but ~20% of the area has no sewer network so 8-10% is untreated",
-          "metrics": [
-            {
-              "label": "Sewage generated (BBMP)",
-              "value": "1,440 MLD (DEP 2022)"
-            },
-            {
-              "label": "STP installed capacity",
-              "value": "1,522.5 MLD (DEP 2022)"
-            },
-            {
-              "label": "Actually treated",
-              "value": "1,050 MLD (DEP 2022)"
-            },
-            {
-              "label": "STP network (BBMP city-wide)",
-              "value": "34 STPs across all three valleys, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. City-wide; only the Vrishabhavathi valley drains into the Arkavathi (see below). DEP 2022's 1,522.5 MLD was sanctioned/under-construction."
-            },
-            {
-              "label": "Expansion, 2026 (city-wide)",
-              "value": "+26 STPs / +470 MLD targeted by end-2025 (to ~1,818 MLD); 20 of 34 plants being upgraded to NGT tertiary norms (BOD<=10) by 2026."
-            },
-            {
-              "label": "Monitoring mandate, 2026 (city-wide)",
-              "value": "KSPCB OCEMS order (Jan 2026): online continuous effluent monitoring required at every STP outlet >100 KLD across BWSSB + private plants in the Bengaluru Metropolitan Region."
-            },
-            {
-              "label": "Sewer-network gap",
-              "value": "~20% of area uncovered; 8-10% of sewage untreated (DEP 2022)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Fix plan",
-              "value": "124 MLD via 14 new WWTPs by 2024 (DEP 2022)"
-            },
-            {
-              "label": "In-basin share",
-              "value": "Of BBMP's 3 sewage valleys only the Vrishabhavathi valley drains into the Arkavathi; the Koramangala-Challaghatta (Bellandur/Varthur -> Ponnaiyar) and Hebbal (-> Pennar) valleys leave this basin. So the city-wide totals above are ~3x the catchment that reaches the Arkavathi."
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "BBMP ~1440 MLD sewage generated, 1522.5 MLD STP capacity, ~1050 MLD treated; ~20% of the UGD area uncovered, so 8-10% of sewage is untreated, to be addressed by 2024 via 14 WWTPs of 124 MLD total.",
-              "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.78, 87-90)",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            },
-            {
-              "source": "BWSSB / KSPCB (2026)",
-              "says": "34 STPs, 1,348.5 MLD installed and ~1,212.7 MLD treated as of Mar 2026; 26 new STPs (+470 MLD) targeted by end-2025; 20 of 34 plants being rehabilitated to NGT tertiary norms; KSPCB Jan 2026 board resolution mandates OCEMS at all STP outlets >100 KLD in the BMR.",
-              "citation": "BWSSB STP rehabilitation programme & KSPCB OCEMS directive, 2026; reported in Water Today / Deccan Herald",
-              "url": "https://www.deccanherald.com/india/karnataka/bengaluru/bengaluru-to-add-26-more-stps-by-june-2026-to-expand-treated-water-capacity-3397653"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 1440.0,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "25.34 MLD of trade effluent; the Peenya cluster is a CPCB Critically Polluted Area",
-          "metrics": [
-            {
-              "label": "Trade effluent (district)",
-              "value": "25.34 MLD (DEP 2022)"
-            },
-            {
-              "label": "Common ETPs (district)",
-              "value": "4 (DEP 2022)"
-            },
-            {
-              "label": "Peenya cluster (V-Valley)",
-              "value": "CPCB Critically Polluted Area, CEPI 78.12; NGT OA 1038/2018 (DEP 2022)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "District trade effluent 25.34 MLD with 4 Common Effluent Treatment Facilities; Peenya Industrial Cluster declared a CPCB Critically Polluted Area with CEPI score 78.12; NGT Suo Moto OA 1038/2018.",
-              "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.79, 93)",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 25.34,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "5,500 TPD generated; ~5 million tonnes of legacy waste and no functional sanitary landfill",
-          "metrics": [
-            {
-              "label": "Generated (BBMP)",
-              "value": "5,500 TPD (DEP 2022)"
-            },
-            {
-              "label": "Legacy waste",
-              "value": "~5,000,000 t at 4 dumpsites (DEP 2022)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Sanitary landfill",
-              "value": "None functional - SLF Nil (DEP 2022)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "BBMP ~5500 TPD solid waste; ~5,000,000 tonnes legacy waste at 4 dumpsites (district total 5,002,000 t); Nos. of Sanitary Landfill Facility (SLF): Nil.",
-              "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.7-8, 26-27)",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 5500.0,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 203.9,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
-            },
-            {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "12,963.63 / 16,429.380 / 45,023.44 MT/yr (DEP 2022)"
-            },
-            {
-              "label": "HW-generating industries (district)",
-              "value": "1718 (DEP 2022)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "KSPCB identified 1718 HW-generating industries (all authorised). Quantity of HW: 74416.29 MT/annum; Incinerable 12963.63; land-fillable 16429.38; recyclable/utilizable 45023.44. Integrated TSDF Nil; SLF Nil; standalone incinerators 02. Contaminated site: Mavallipura dumpsite, Yelahanka (Manganese exceeding standard).",
-              "citation": "V. Hazardous Waste Management, p.45",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 37.32,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
-            {
-              "label": "Biomedical waste generated (district)",
-              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
-            },
-            {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "5 (DEP 2022)"
-            },
-            {
-              "label": "Notes",
-              "value": "5 CBMWTF (all outside the district) serve it; 1,559 bedded + 8,877 non-bedded HCFs; 538.733 MT Covid-19 waste (2020-21). Generated = treated. (DEP 2022)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "Inventory of BMW: 1559 bedded + 8877 non-bedded HCF; 37.321 Tons/day generated and treated; 538.733 MT Covid-19 waste (2020-21); disposed through 5 CBMWTF (all outside the district).",
-              "citation": "(iv) Bio-Medical Waste Management, p.40",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 2500.0,
-            "unit": "TPD"
-          },
-          "summary": "Construction & demolition waste.",
-          "metrics": [
             {
               "label": "C&D waste generated (BBMP)",
-              "value": "2,500 TPD (DEP 2022)"
+              "value": "2500 TPD"
             },
             {
               "label": "Recycling capacity",
-              "value": "Rock Crystal 1,000 MTPD operational + Kannur 750 TPD under construction (DEP 2022)"
+              "value": "M/s Rock Crystal 1000 MT PD (private, Chikkajala); 750 TPD BBMP plant at Kannur being set up"
+            },
+            {
+              "label": "User fee",
+              "value": "Rs.134/- per Ton charged by BBMP; not fixed by ULBs"
             }
           ],
-          "sources": [
+          "openActions": [
+            "Separate C&D collection/transport vehicles and deposition points per taluk (BBMP+ULBs, 31.12.2023)",
+            "ULBs to fix and notify C&D user fee (BBMP+ULBs, 31.12.2022)",
+            "Common C&D waste recycling facility for ULBs - land identification (District Administration, 31.12.2023)",
+            "Frame district policy for use of recycled C&D waste in paving blocks and road layers (BBMP+ULBs, 31.12.2023)"
+          ],
+          "pages": [
+            39,
+            40,
+            41,
+            42
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "biomedical-waste",
+          "summary": "All 37.321 t/day of biomedical waste from 10,310 healthcare establishments is disposed through 5 CBMWTFs with barcode and GPS tracking, but 1,220 HCEs have not renewed authorization.",
+          "metrics": [
             {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "Total C&D waste generation: BBMP 2500 TPD (district total 2507). Recycling: M/s Rock Crystal 1000 MTPD (Chikkajala, existing) + 750 TPD plant at Kannur (under construction). User fee Rs.134/ton.",
-              "citation": "(iii) C&D Waste Management, p.36",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+              "label": "Bedded healthcare facilities",
+              "value": "1559"
+            },
+            {
+              "label": "Non-bedded HCF",
+              "value": "8877"
+            },
+            {
+              "label": "HCEs authorized under BMW Rules 2016",
+              "value": "9216 of 10310 (1220 not renewed)"
+            },
+            {
+              "label": "BMW generated per day",
+              "value": "37.321 Tons/day"
+            },
+            {
+              "label": "BMW treated per day",
+              "value": "37.321 Tons/day"
+            },
+            {
+              "label": "Covid-19 waste 2020-21",
+              "value": "538.733 MT"
+            },
+            {
+              "label": "CBMWTFs serving district",
+              "value": "5"
+            }
+          ],
+          "openActions": [
+            "Notices and inspection follow-up for 1220 unauthorized HCEs (Health Department+KSPCB)",
+            "Implement bar code system across all HCFs and CBWTFs (DHO+CBMWTF+HCEs+KSPCB, 31.12.2022)",
+            "Hospitals with 30+ beds to establish ETPs (DHO+HCEs+KSPCB)"
+          ],
+          "pages": [
+            43,
+            44,
+            45,
+            46,
+            47
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "hazardous-waste",
+          "summary": "1,718 authorized industries generate 74,416.29 MT/annum of hazardous waste disposed via out-of-district TSDFs (none in district) under an e-manifest system; one contaminated site at Mavallipura dumpsite, Yelahanka awaits BBMP remediation.",
+          "metrics": [
+            {
+              "label": "Industries generating HW",
+              "value": "1718"
+            },
+            {
+              "label": "HW quantity",
+              "value": "74416.29 MT/ANNUM"
+            },
+            {
+              "label": "Incinerable / land-fillable / recyclable HW",
+              "value": "12963.63 / 16429.38 / 45023.44 MT/ANNUM"
+            },
+            {
+              "label": "Integrated TSDF and SLF in district",
+              "value": "Nil (2 standalone incinerators)"
+            },
+            {
+              "label": "Contaminated sites",
+              "value": "1 (Mavallipura Dumpsite, Yelahanka; borewell Manganese exceeding standard, report dated 15.02.2022)"
+            }
+          ],
+          "openActions": [
+            "Hazardous waste collection corner at dry waste collection centres (BBMP+ULBs, 31.12.2022)",
+            "Remediation of Mavallipura contaminated site (BBMP+KSPCB, 31.12.2022)"
+          ],
+          "pages": [
+            48,
+            49,
+            50
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "e-waste",
+          "summary": "District inventories 7,810.887 MT/year of e-waste with 135 ULB collection points and 34 authorized recyclers/dismantlers; EMPRI inventorization of generators is under way and informal recycling remains to be identified.",
+          "metrics": [
+            {
+              "label": "E-waste inventory",
+              "value": "7810.887 MT/year"
+            },
+            {
+              "label": "Collection centres by ULBs",
+              "value": "135"
+            },
+            {
+              "label": "Collection centres by producers/PROs",
+              "value": "6"
+            },
+            {
+              "label": "Authorized recyclers/dismantlers",
+              "value": "34"
+            },
+            {
+              "label": "Bulk e-waste consumers identified (EMPRI)",
+              "value": "272"
+            }
+          ],
+          "openActions": [
+            "Complete EMPRI inventorization and generator awareness (KSPCB+EMPRI, 31.07.2022)",
+            "ULB e-waste channelized to authorized recyclers via MoU; act against illegal informal recyclers (KSPCB+BBMP+ULBs, 31.12.2022)",
+            "Integrate informal sector via producers/PROs (KSPCB/District Administration/local bodies, 31.12.2022)"
+          ],
+          "pages": [
+            50,
+            51,
+            52,
+            53
+          ]
+        },
+        {
+          "theme": "water-quality",
+          "status": "covered",
+          "summary": "KSPCB monitors 165 lakes (most Category E) among 238 in the district; groundwater hotspots are Peenya industrial cluster (CEPI 78.12, chromium/nitrates/hardness) and a hexavalent-chromium plume at Yelahanka, with no district environmental monitoring cell yet.",
+          "metrics": [
+            {
+              "label": "Rivers",
+              "value": "Kumadavathi, Arkavathi and Dakshina Pinakini with tributaries"
+            },
+            {
+              "label": "Lakes/ponds",
+              "value": "238"
+            },
+            {
+              "label": "Lakes monitored by KSPCB",
+              "value": "165 (most fall under Category E per CPCB classification)"
+            },
+            {
+              "label": "Borewells",
+              "value": "About 102190 in BBMP area (with permission) + 2500 outside BBMP"
+            },
+            {
+              "label": "Contaminated drinking-water borewells",
+              "value": "127 with high TDS and nitrates"
+            },
+            {
+              "label": "Minor Irrigation tanks",
+              "value": "46 (6 polluted, 14 partially polluted; DPR for rejuvenation of 25 tanks submitted 29-01-2021)"
+            },
+            {
+              "label": "Groundwater polluted areas",
+              "value": "Peenya Industrial Cluster (Chromium, Nitrates, Hardness; CEPI 78.12, NGT OA 1038/2018); Federal Mogul Goetze surroundings, Yelahanka (hexavalent chromium)"
+            },
+            {
+              "label": "Polluted river stretches (CPCB)",
+              "value": "None in the district"
+            },
+            {
+              "label": "Online lake water-quality monitoring",
+              "value": "Bellandur, Agara & Varthur (9 parameters, NGT OA 125/2017)"
+            },
+            {
+              "label": "Treated sewage reuse",
+              "value": "301 MLD from K&C Valley pumped to Kolar for rejuvenation of 126 lakes; 67 Anekal taluk lakes planned"
+            }
+          ],
+          "openActions": [
+            "Constitute Environmental Monitoring Cell and inventory all water bodies (Minor Irrigation+GW authority+ZP+KSPCB+PRED, 31.03.2023)",
+            "Identify and plug wastewater drains joining water bodies (ULBs, by 31-3-2023)",
+            "District-level water quality monitoring cell (31.03.2022)",
+            "Hotspot restoration action plans under implementation (RWSSB+GW authority+KSPCB+ULBs+PRED, 31.12.2021)",
+            "Rain water harvesting enforcement (Ground Water authority, 31.03.2022)"
+          ],
+          "pages": [
+            81,
+            82,
+            83,
+            84,
+            85,
+            86,
+            87,
+            88,
+            89
+          ]
+        },
+        {
+          "theme": "domestic-sewage",
+          "status": "covered",
+          "summary": "District generates ~1,457.6 MLD sewage against 1,529 MLD installed STP capacity, but capacity sits almost wholly in BBMP: 5 of 7 ULBs have no STP (gap 15.35 MLD) and named lakes including Madanayakanahalli lake receive sewage.",
+          "metrics": [
+            {
+              "label": "Sewage generated (district)",
+              "value": "1458.6 MLD (BBMP 1440; other ULBs 17.6)"
+            },
+            {
+              "label": "Installed STP capacity",
+              "value": "Total 1529.15 MLD (BBMP 1522.5; TMC-Anekal 6.4; TMC-Bommasandra 0.25; others NIL)"
+            },
+            {
+              "label": "STP gap in non-BBMP ULBs",
+              "value": "15.35 MLD (Attibele 2, Bommasandra 1.35, Chandapura 2.5, Hebbagodi 8, Jigani 1.5)"
+            },
+            {
+              "label": "Untreated sewage (BBMP)",
+              "value": "8 to 10% due to sewer network gap"
+            },
+            {
+              "label": "UGD coverage",
+              "value": "BBMP 80%; Anekal 90%; Attibele 75%; Bommasandra 60%; Chandapura 30%; Hebbagodi 30%; Jigani 80%"
+            },
+            {
+              "label": "Lakes receiving sewage",
+              "value": "Bommasandra, Chandapura, Hebbagodi, Jigani, Madanayakanahalli, Hennagara, Zuzu, Bidaruguppe, Kammasandra lakes"
+            },
+            {
+              "label": "Completely polluted lakes (Minor Irrigation dept)",
+              "value": "Rampura, Yallamallappa Shetty, Vaderahalli, Hoodi Palya, Bommasandra & Addevishvanathapura Lakes"
+            }
+          ],
+          "openActions": [
+            "BBMP sewer gap to be fulfilled by 2024: UGD to 110 villages + 14 WWTPs of 124 MLD total",
+            "DPRs for UGD & STP at CMC Hebbagodi and TMC Jigani to government for approval and funds",
+            "Lay sewerage networks across ULBs (ULBs+KUWS&DB+Urban Development, 31.12.2025)"
+          ],
+          "pages": [
+            81,
+            82,
+            90,
+            91,
+            92,
+            93,
+            94,
+            95
+          ]
+        },
+        {
+          "theme": "industrial-wastewater",
+          "status": "covered",
+          "summary": "2,018 of ~9,715 industries discharge 25.34 MLD of wastewater, all treated on-site and reused with nil discharge to nalas/rivers per the plan; 27 industries do not meet discharge standards and face KSPCB enforcement.",
+          "metrics": [
+            {
+              "label": "Industries by category",
+              "value": "Red 1025; Orange 2268; Green 5441; White 981"
+            },
+            {
+              "label": "Industries discharging wastewater",
+              "value": "2018"
+            },
+            {
+              "label": "Industrial wastewater generated",
+              "value": "25.34 MLD"
+            },
+            {
+              "label": "Treated industrial wastewater discharged to Nalas/Rivers",
+              "value": "NIL"
+            },
+            {
+              "label": "Common Effluent Treatment Facilities",
+              "value": "4"
+            },
+            {
+              "label": "Industries meeting / not meeting discharge standards",
+              "value": "1178 / 27"
+            }
+          ],
+          "openActions": [
+            "KSPCB inspection, sampling and show-cause/closure action against non-complying industries (KSPCB, ongoing)"
+          ],
+          "pages": [
+            96,
+            97
+          ]
+        },
+        {
+          "theme": "air-quality",
+          "status": "covered",
+          "summary": "22 monitored locations (14 CAAQMS + 15 manual stations) show PM10 exceeding the 60 ug/m3 limit at 14 locations in 2020-21; a 44-point District Task Force plan targets vehicles, dust and 16 notified industrial areas including Peenya.",
+          "metrics": [
+            {
+              "label": "CAAQM stations",
+              "value": "14 (7 KSPCB, 3 CPCB, 4 industry) + 4 more under installation by July 2022"
+            },
+            {
+              "label": "Manual AAQ stations (KSPCB)",
+              "value": "15"
+            },
+            {
+              "label": "Air polluting industries",
+              "value": "4515 (348 Red + 594 Orange identified for monitoring; 27 with OCEMS)"
+            },
+            {
+              "label": "Notified industrial areas",
+              "value": "16 (incl. Peenya I-IV, Bommasandra, Jigani, Electronic City, Attibele)"
+            },
+            {
+              "label": "PM10 exceedance 2020-21",
+              "value": "exceeded national limit (60.0 ug/M3) in 14 locations"
+            },
+            {
+              "label": "PM2.5 exceedance 2020-21",
+              "value": "exceeded national limit (40.0 ug/M3) in only one location"
+            },
+            {
+              "label": "AQI Dec 2021 (7 stations)",
+              "value": "1 good, 5 moderate, 1 poor (Kavika, Mysore Road)"
+            },
+            {
+              "label": "Vehicle emission checks 2020-21",
+              "value": "231951 vehicles checked; 16880 exceeding; Rs.1,07,34,800 fine"
+            },
+            {
+              "label": "District Task Force action points",
+              "value": "44 (3 meetings held)"
+            },
+            {
+              "label": "Source apportionment",
+              "value": "CSTEP emission inventory & source apportionment study, report launched 04.02.2022"
+            }
+          ],
+          "openActions": [
+            "Inventory of air pollution sources; convert unpaved to paved roads (DTF+Mines&Geology+KSPCB+PWD, 31.12.2025)",
+            "Commission 4 additional CAAQM stations - RTO Kasturinagar, Jigani, RV College Mysore Road, Peenya NTTF (KSPCB, 31.07.2022)",
+            "Implement 44-point district air action plan: e-buses, metro reaches, truck terminals, dust suppression, green cover (multi-agency, 31.12.2025)",
+            "Identify localized air-pollution hotspots and mitigation plans (Forest+ULBs+Agriculture+Mines&Geology+KSPCB)"
+          ],
+          "pages": [
+            54,
+            55,
+            56,
+            57,
+            58,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80
+          ]
+        },
+        {
+          "theme": "mining",
+          "status": "covered",
+          "summary": "Only open-cast building-stone quarrying (156 licences, 0.01% of district area, no sand mining) with an active District Task Force that filed 250 FIR/PCRs in 2020-22 collecting Rs.133.360 lakh in penalties.",
+          "metrics": [
+            {
+              "label": "Type of mining",
+              "value": "Open cast mining (Building Stone)"
+            },
+            {
+              "label": "Licensed mining operations",
+              "value": "156"
+            },
+            {
+              "label": "% area under mining",
+              "value": "0.01%"
+            },
+            {
+              "label": "Sand mining",
+              "value": "NIL"
+            },
+            {
+              "label": "Enforcement 2020-2022 (to November)",
+              "value": "250 FIR/PCR filed; penalty Rs.133.360 lakhs; check post on NH-07"
+            }
+          ],
+          "openActions": [
+            "District Level Task Force (Mines) regular meetings and patrolling to curb illegal mining (Mines & Geology Department, ongoing)",
+            "DMFT monitoring of environmental compliance; 30% of DMF fund for mining-affected areas (Mines & Geology Department)"
+          ],
+          "pages": [
+            98,
+            99,
+            100
+          ]
+        },
+        {
+          "theme": "noise",
+          "status": "covered",
+          "summary": "Only KSPCB has noise instruments (14 portable meters, 10 fixed stations); ULBs and police have none, and RTO checks found 3,288 of 185,406 vehicles exceeding noise limits in 2020-21.",
+          "metrics": [
+            {
+              "label": "Noise level meters",
+              "value": "KSPCB 14; ULBs, SHOs, Traffic Police: none"
+            },
+            {
+              "label": "Fixed ambient noise monitoring stations (KSPCB)",
+              "value": "10 (2 industrial, 2 sensitive, 3 commercial, 3 residential), display on KSPCB website"
+            },
+            {
+              "label": "Vehicle noise checks 2020-21",
+              "value": "185406 checked; 3288 exceeding; Rs.40,65,100 fine"
+            }
+          ],
+          "openActions": [
+            "ULBs, SHOs and Traffic Police to procure portable noise meters (ULBs+Police+District admin+KSPCB, 31.12.2022)",
+            "ULBs to install fixed ambient noise monitoring stations (District admin+KSPCB+ULBs, 31.03.2023)"
+          ],
+          "pages": [
+            101,
+            102,
+            103,
+            104
+          ]
+        }
+      ],
+      "ulbs": [
+        {
+          "key": "bbmp",
+          "name": "BBMP / GBA",
+          "type": "CC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "BBMP"
+            ]
+          },
+          "themes": [
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "BBMP generates 5,500 TPD with 100% ward-level segregation and collection claimed, 13,990 km of roads fully swept, but 5 million tonnes of legacy waste at 4 dumpsites and 7 of 8 required sanitary landfills missing.",
+              "metrics": [
+                {
+                  "label": "Solid waste generated",
+                  "value": "5500 TPD (198 wards; 31,83,000 households; population 84,00,000)"
+                },
+                {
+                  "label": "Source segregation",
+                  "value": "198 of 198 wards, gap 0"
+                },
+                {
+                  "label": "Collection",
+                  "value": "198 of 198 wards 100%; door-to-door 100%"
+                },
+                {
+                  "label": "Road sweeping",
+                  "value": "13,990 km covered of 13,990 km; 1000 Km lane of arterial/sub-arterial identified for mechanical sweeping"
+                },
+                {
+                  "label": "Manpower",
+                  "value": "17,400 available vs 18,000 required per DPR (gap 600)"
+                },
+                {
+                  "label": "Collection fleet",
+                  "value": "6000 trolleys with separate compartments; 611 compactors (no gap)"
+                },
+                {
+                  "label": "Waste deposition centres",
+                  "value": "129 available vs 198 required (gap 69)"
+                },
+                {
+                  "label": "Dry waste collection centres / MRF",
+                  "value": "129 functional (29 need upgradation); 141 and 130 also quoted elsewhere"
+                },
+                {
+                  "label": "Wet-waste facilities",
+                  "value": "Compost 8 (4 functional); Bio-methanation 13 (5 functional, 8 need upgradation)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "1 available vs 8 required; 4 existing dumpsites"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "5000000 Tonnes at 4 dumpsites"
+                },
+                {
+                  "label": "Waste pickers",
+                  "value": "identified and issued authorization"
+                },
+                {
+                  "label": "NGO involvement",
+                  "value": "50 of 198 wards (gap 148)"
+                }
+              ],
+              "openActions": [
+                "Letter written to DC for grant of land for processing & disposal facility (DC Bengaluru Urban, 31.03.2023)",
+                "Bio-methanation plant upgradation tenders (compost facilities stopped due to local public protest) (31.12.2022)",
+                "Legacy waste remediation DPR per CPCB guidelines (31.12.2023)",
+                "Achieve 100% door-to-door dry-waste collection (currently 100 of 198 wards) (31.03.2022)"
+              ],
+              "pages": [
+                11,
+                12,
+                15,
+                16,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                26,
+                28,
+                29,
+                30,
+                31,
+                32
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "BBMP generates 420 TPD plastic waste under mandatory 3-way source segregation since Feb 2017; plastic separated at 141 ward DWCCs goes to M/s KK Plastics for hot-mix road construction, with regular raids on banned plastic.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "420 TPD"
+                },
+                {
+                  "label": "Segregation regime",
+                  "value": "3-way segregation at source mandatory since Feb-2017; dry waste collected twice a week"
+                },
+                {
+                  "label": "DWCCs",
+                  "value": "141 decentralised ward-level centres"
+                },
+                {
+                  "label": "Disposal channel",
+                  "value": "M/s KK Plastics supplies material to Hot Mix plants for road construction"
+                }
+              ],
+              "openActions": [
+                "Achieve 100% D2D dry waste collection - 98 gap wards (31.03.2022)",
+                "Aggregator centre for low-value plastic (31.03.2022)"
+              ],
+              "pages": [
+                32,
+                33,
+                34,
+                35,
+                36,
+                37
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "BBMP generates 2,500 TPD C&D waste, charges Rs.134/ton, and routes government and builder waste to the 1,000 MTPD Chikkajala plant while its own 750 TPD Kannur plant (pavers, bricks, sand) comes online.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "2500 TPD"
+                },
+                {
+                  "label": "User fee",
+                  "value": "Rs.134/- per Ton"
+                },
+                {
+                  "label": "Processing",
+                  "value": "M/s Rock Crystal 1000 MT PD at Chikkajala; 750 TPD BBMP plant at Kannur operational in ~6 months"
+                },
+                {
+                  "label": "Enforcement",
+                  "value": "Covering of C&D transport vehicles enforced with Bengaluru Traffic Police; C&D waste dumped in lakes (e.g. Kengeri) being removed"
+                }
+              ],
+              "openActions": [
+                "Purchase separate vehicles for C&D transport (31.12.2023)",
+                "Notification to agencies/builders to supply C&D waste to Chikkajala facility"
+              ],
+              "pages": [
+                39,
+                40,
+                41,
+                68,
+                71
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "Biomedical waste is regulated district-wide by KSPCB/DHO; BBMP-specific roles are limited to authorizing animal houses and pourakarmika awareness on BMW handling.",
+              "metrics": [
+                {
+                  "label": "Animal houses authorized",
+                  "value": "0 (has to obtain from BBMP)"
+                }
+              ],
+              "openActions": [
+                "Awareness to pourakarmikas on BMW handling through BBMP & ULBs"
+              ],
+              "pages": [
+                43,
+                44,
+                46
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "hazardous-waste",
+              "summary": "BBMP's hazardous-waste exposure in the plan is the Mavallipura dumpsite contaminated site (Yelahanka), where BBMP is the designated remediation agency; household hazardous waste rides on its DWCC network.",
+              "metrics": [
+                {
+                  "label": "Contaminated site",
+                  "value": "Mavallipura Dumpsite, Yelahanka-560064; borewell Manganese exceeding standard (report 15.02.2022)"
+                }
+              ],
+              "openActions": [
+                "Remediation of Mavallipura site by BBMP (BBMP+KSPCB, 31.12.2022)",
+                "Hazardous waste collection corner at dry waste collection centres (31.12.2022)"
+              ],
+              "pages": [
+                48,
+                49,
+                50
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "E-waste data is district-level only; BBMP's role is channelizing household e-waste segregated at dry waste collection centres to authorized recyclers via MoUs.",
+              "openActions": [
+                "Execute MoUs with authorized recyclers/dismantlers for household e-waste (KSPCB+BBMP+ULBs)"
+              ],
+              "pages": [
+                50,
+                51,
+                52
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "covered",
+              "summary": "BBMP-area water quality issues centre on ~102,190 permitted borewells, sewage in storm drains (addressed by the 28 km K-100 waterway project across 31 wards) and BWSSB's penalty-backed rainwater harvesting mandate.",
+              "metrics": [
+                {
+                  "label": "Borewells in BBMP area",
+                  "value": "About 102190 with permission from Ground Water authority, BWSSB, CGWA"
+                },
+                {
+                  "label": "K-100 Water ways project",
+                  "value": "28 kms, 31 wards; primary canal from K.R. Market to Bellandur Lake, to stop sewage entering storm water drains"
+                },
+                {
+                  "label": "RWH mandate",
+                  "value": "BWSSB mandatory for existing buildings on 216 sq.mtr+ sites and new buildings on 108 sq.mtr+ (GO UDD 19 MNI 2009, 27 Aug 2009); penalties 50-200% of water and sanitary charges"
+                }
+              ],
+              "openActions": [
+                "Prohibit sewage entry into storm water drains via K-100 project (GoK)",
+                "ULB identification of wastewater joining points into water bodies (by 31-3-2023)"
+              ],
+              "pages": [
+                82,
+                84,
+                85,
+                88
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "BBMP generates 1,440 MLD sewage against 1,522.5 MLD STP capacity (1,050 MLD present inflow) with 80% UGD coverage; the 8-10% untreated share is to be closed by 2024 via UGD to 110 villages and 14 new WWTPs totalling 124 MLD.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "1440 MLD"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "1522.5 MLD"
+                },
+                {
+                  "label": "Present sewage inflow rate",
+                  "value": "1050 MLD"
+                },
+                {
+                  "label": "Untreated sewage",
+                  "value": "8 to 10% due to gap in sewer network"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "640 Sq.km provided of 800 Sq.Km (80%)"
+                },
+                {
+                  "label": "Treated sewage reuse",
+                  "value": "301 MLD from K&C Valley pumped to Kolar District for rejuvenation of 126 lakes"
+                }
+              ],
+              "openActions": [
+                "Provide UGD facilities to 110 villages of BBMP and construct 14 Waste Water Treatment Plants of total 124 MLD by 2024 (BWSSB/BBMP)"
+              ],
+              "pages": [
+                82,
+                90,
+                92,
+                93,
+                94,
+                89
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "No BBMP-specific industrial wastewater breakdown; figures (25.34 MLD, 4 CETFs, 27 non-complying industries) are district-level under KSPCB.",
+              "pages": [
+                96,
+                97
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "covered",
+              "summary": "BBMP owns many of the 44 district air-action points: pothole filling across 198 wards, blacktopping, 3 multilevel parkings, marshals penalizing open burning, dust-sprinkler tenders and road-widening; the poor-AQI station (Kavika, Mysore Road) lies in its area.",
+              "metrics": [
+                {
+                  "label": "AQI Dec 2021 in BBMP area",
+                  "value": "1 station poor (Kavika, Mysore Road), 5 moderate, 1 good"
+                },
+                {
+                  "label": "Pothole filling",
+                  "value": "3 methods incl. BBMP batch mix plant and Python machine for all 198 wards; Rs 10 lakh per ward roads"
+                },
+                {
+                  "label": "Multilevel parking",
+                  "value": "3 constructed"
+                },
+                {
+                  "label": "Open burning enforcement",
+                  "value": "Marshals appointed by BBMP to identify and levy penalty"
+                },
+                {
+                  "label": "Dust suppression",
+                  "value": "Tenders under progress for 05 sprinkler machines using treated BWSSB water"
+                }
+              ],
+              "openActions": [
+                "Convert unpaved roads to paved roads (BBMP & PWD, 31.12.2025)",
+                "Road widening (Sarjapur, Bannerghatta, Tannery, Bellary, Jayamahal roads) and flyovers/underpasses for decongestion",
+                "Create green buffers along traffic corridors and greening of open areas (tendering)"
+              ],
+              "pages": [
+                56,
+                64,
+                65,
+                68,
+                70,
+                71,
+                74,
+                77
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "No BBMP-specific mining data; the 156 licensed building-stone quarries are handled district-wide by Mines & Geology.",
+              "pages": [
+                98,
+                99,
+                100
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "No BBMP-specific noise data; KSPCB's 10 fixed stations cover city zones but ULBs including BBMP have no noise meters.",
+              "openActions": [
+                "ULBs to procure portable noise meters (31.12.2022) and install fixed stations (31.03.2023)"
+              ],
+              "pages": [
+                101,
+                102
+              ]
+            }
+          ],
+          "note": "City corporation; only its west/south (Vrishabhavathi valley) and Yelahanka drain to the Arkavathi."
+        },
+        {
+          "key": "madanayakanahalli-cmc",
+          "name": "Madanayakanahalli",
+          "type": "CMC",
+          "note": "Created after the 2022 plan was prepared; verified: the ULB appears nowhere in it. District-wide figures apply.",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "MADANAYAKANAHALLI"
+            ]
+          },
+          "themes": [
+            {
+              "theme": "waste-management",
+              "status": "district-level"
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level"
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "district-level"
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level"
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level"
+            },
+            {
+              "theme": "mining",
+              "status": "district-level"
+            },
+            {
+              "theme": "noise",
+              "status": "district-level"
             }
           ]
         },
         {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "Consented industries across the Peenya + Dasarahalli ROs - the Vrishabhavathi valley, the basin's industrial core - by pollution-potential colour.",
-          "metrics": [
+          "key": "chikkabanavara-tmc",
+          "name": "Chikkabanavara",
+          "type": "TMC",
+          "note": "Created after the 2022 plan was prepared; verified: the ULB appears nowhere in it. District-wide figures apply.",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "CHIKKABANAVARA"
+            ]
+          },
+          "themes": [
             {
-              "label": "Consented industries (2019)",
-              "value": "~7,000"
+              "theme": "waste-management",
+              "status": "district-level"
             },
             {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~2,600",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
+              "theme": "water-quality",
+              "status": "district-level"
+            },
             {
-              "source": "KSPCB F-register (Peenya + Dasarahalli RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Peenya + Dasarahalli RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Peenya.pdf"
+              "theme": "domestic-sewage",
+              "status": "district-level"
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level"
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level"
+            },
+            {
+              "theme": "mining",
+              "status": "district-level"
+            },
+            {
+              "theme": "noise",
+              "status": "district-level"
             }
           ]
         }
       ],
-      "conflicts": [
-        "The DEP records a '0 MLD' treatment-capacity gap on paper, yet states ~20% of the area has no sewer network and 8-10% of sewage is untreated.",
-        "The DEP's own BBMP sewage-generation figure differs between tables (1,440 vs 1,458.6 MLD)."
-      ]
-    },
-    "harohalli": {
-      "name": "Harohalli (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "A major KIADB industrial cluster with no CETP and no STP - newly declared town, plans still on paper",
-      "streams": [
+      "taluks": [
         {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "Large KIADB industrial cluster; the CAG audit found most sampled KIADB areas had no CETP, and there is none near Harohalli",
-          "metrics": [
-            {
-              "label": "KIADB phases",
-              "value": "Harohalli 1st-4th phases (CAG 2017)"
-            },
-            {
-              "label": "CAG audit finding",
-              "value": "38 of 66 sampled KIADB areas had no CETP/CSTP (CAG 2017)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Nearest common ETP",
-              "value": "None within ~20 km (Neer Vazhvu estimate, 2026)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "CAG Report No. 8 of 2017 (p.18)",
-              "says": "In respect of 38 of 66 sampled KIADB industrial areas the basic facilities including CETP/CSTP were not provided; 4,077 units operating without.",
-              "citation": "CAG Report No. 8 of 2017, Economic Sector, Govt. of Karnataka, p.18",
-              "url": "https://cag.gov.in/uploads/download_audit_report/2017/Report_No_8_of_2017_-_Economic_Sector_Government_of_Karnataka.pdf"
-            },
-            {
-              "source": "Neer Vazhvu spatial estimate",
-              "says": "Harohalli KIADB phases sit ~21-28 km from the nearest mapped common effluent facility - a proximity estimate from the basin's industrial-areas and common-facilities layers (our computation, not a CAG figure)."
-            },
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "\"There are no CETPs in the Ramanagara District.\"",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "taluk"
-        },
-        {
-          "stream": "Sewage",
-          "summary": "Still no STP - DPR not prepared (land issue) as of 2026; only a small faecal-sludge drying bed is under construction",
-          "metrics": [
-            {
-              "label": "STP capacity",
-              "value": "None - 0 STP (DEP 2021)"
-            },
-            {
-              "label": "Status",
-              "value": "Newly declared town; DPR yet to be prepared (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Harohalli has 0 STP (Nil capacity); newly declared TP and DPR is yet to be prepared.",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk"
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "Processing facility still at DPR stage",
-          "metrics": [
-            {
-              "label": "Processing",
-              "value": "DPR yet to be prepared (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP (31-03-2021)",
-              "says": "Harohalli solid-waste processing DPR yet to be prepared (newly declared town).",
-              "citation": "District Environmental Plan, Ramanagara / Bengaluru South",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk"
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 18.7,
-            "unit": "TPD",
-            "estimated": true
+          "key": "bbmp",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Bengaluru North"
+            ]
           },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "6,827.95 MT/yr ≈ 18.7 t/day (DEP 2021)"
-            },
-            {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "2,021.73 / 1,377.847 / 3,323.60 MT/yr (DEP 2021)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "Disposal-facility status not separately recorded in this DEP. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of HW in the District: 6827.95 MT/Annum; Incinerable 2021.73; land-fillable 1377.847; recyclable/utilizable 3323.6 MT/Annum.",
-              "citation": "Hazardous Waste section, p.46",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ]
-        },
-        {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.29,
-            "unit": "TPD",
-            "estimated": true
+          "unit": {
+            "name": "BBMP (Bengaluru city corporation; west/south = V-Valley / Vrishabhavathi)",
+            "level": "City",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "City sewage runs close to installed STP capacity on paper, but ~20% of the area has no sewer network (8-10% untreated), and the V-Valley's Peenya cluster is a CPCB Critically Polluted Area",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "~1,440 MLD generated vs 1,522.5 MLD STP capacity, but ~20% of the area has no sewer network so 8-10% is untreated",
+                "metrics": [
+                  {
+                    "label": "Sewage generated (BBMP)",
+                    "value": "1,440 MLD (DEP 2022)"
+                  },
+                  {
+                    "label": "STP installed capacity",
+                    "value": "1,522.5 MLD (DEP 2022)"
+                  },
+                  {
+                    "label": "Actually treated",
+                    "value": "1,050 MLD (DEP 2022)"
+                  },
+                  {
+                    "label": "STP network (BBMP city-wide)",
+                    "value": "34 STPs across all three valleys, 1,348.5 MLD installed, ~1,212.7 MLD treated (~90% utilisation) - BWSSB, Mar 2026. City-wide; only the Vrishabhavathi valley drains into the Arkavathi (see below). DEP 2022's 1,522.5 MLD was sanctioned/under-construction."
+                  },
+                  {
+                    "label": "Expansion, 2026 (city-wide)",
+                    "value": "+26 STPs / +470 MLD targeted by end-2025 (to ~1,818 MLD); 20 of 34 plants being upgraded to NGT tertiary norms (BOD<=10) by 2026."
+                  },
+                  {
+                    "label": "Monitoring mandate, 2026 (city-wide)",
+                    "value": "KSPCB OCEMS order (Jan 2026): online continuous effluent monitoring required at every STP outlet >100 KLD across BWSSB + private plants in the Bengaluru Metropolitan Region."
+                  },
+                  {
+                    "label": "Sewer-network gap",
+                    "value": "~20% of area uncovered; 8-10% of sewage untreated (DEP 2022)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Fix plan",
+                    "value": "124 MLD via 14 new WWTPs by 2024 (DEP 2022)"
+                  },
+                  {
+                    "label": "In-basin share",
+                    "value": "Of BBMP's 3 sewage valleys only the Vrishabhavathi valley drains into the Arkavathi; the Koramangala-Challaghatta (Bellandur/Varthur -> Ponnaiyar) and Hebbal (-> Pennar) valleys leave this basin. So the city-wide totals above are ~3x the catchment that reaches the Arkavathi."
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "BBMP ~1440 MLD sewage generated, 1522.5 MLD STP capacity, ~1050 MLD treated; ~20% of the UGD area uncovered, so 8-10% of sewage is untreated, to be addressed by 2024 via 14 WWTPs of 124 MLD total.",
+                    "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.78, 87-90)",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  },
+                  {
+                    "source": "BWSSB / KSPCB (2026)",
+                    "says": "34 STPs, 1,348.5 MLD installed and ~1,212.7 MLD treated as of Mar 2026; 26 new STPs (+470 MLD) targeted by end-2025; 20 of 34 plants being rehabilitated to NGT tertiary norms; KSPCB Jan 2026 board resolution mandates OCEMS at all STP outlets >100 KLD in the BMR.",
+                    "citation": "BWSSB STP rehabilitation programme & KSPCB OCEMS directive, 2026; reported in Water Today / Deccan Herald",
+                    "url": "https://www.deccanherald.com/india/karnataka/bengaluru/bengaluru-to-add-26-more-stps-by-june-2026-to-expand-treated-water-capacity-3397653"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 1440.0,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "25.34 MLD of trade effluent; the Peenya cluster is a CPCB Critically Polluted Area",
+                "metrics": [
+                  {
+                    "label": "Trade effluent (district)",
+                    "value": "25.34 MLD (DEP 2022)"
+                  },
+                  {
+                    "label": "Common ETPs (district)",
+                    "value": "4 (DEP 2022)"
+                  },
+                  {
+                    "label": "Peenya cluster (V-Valley)",
+                    "value": "CPCB Critically Polluted Area, CEPI 78.12; NGT OA 1038/2018 (DEP 2022)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "District trade effluent 25.34 MLD with 4 Common Effluent Treatment Facilities; Peenya Industrial Cluster declared a CPCB Critically Polluted Area with CEPI score 78.12; NGT Suo Moto OA 1038/2018.",
+                    "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.79, 93)",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 25.34,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "5,500 TPD generated; ~5 million tonnes of legacy waste and no functional sanitary landfill",
+                "metrics": [
+                  {
+                    "label": "Generated (BBMP)",
+                    "value": "5,500 TPD (DEP 2022)"
+                  },
+                  {
+                    "label": "Legacy waste",
+                    "value": "~5,000,000 t at 4 dumpsites (DEP 2022)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Sanitary landfill",
+                    "value": "None functional - SLF Nil (DEP 2022)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "BBMP ~5500 TPD solid waste; ~5,000,000 tonnes legacy waste at 4 dumpsites (district total 5,002,000 t); Nos. of Sanitary Landfill Facility (SLF): Nil.",
+                    "citation": "Bengaluru Urban District Environmental Plan, 2022 (p.7-8, 26-27)",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 5500.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 203.9,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "12,963.63 / 16,429.380 / 45,023.44 MT/yr (DEP 2022)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "1718 (DEP 2022)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "KSPCB identified 1718 HW-generating industries (all authorised). Quantity of HW: 74416.29 MT/annum; Incinerable 12963.63; land-fillable 16429.38; recyclable/utilizable 45023.44. Integrated TSDF Nil; SLF Nil; standalone incinerators 02. Contaminated site: Mavallipura dumpsite, Yelahanka (Manganese exceeding standard).",
+                    "citation": "V. Hazardous Waste Management, p.45",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 37.32,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "5 (DEP 2022)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "5 CBMWTF (all outside the district) serve it; 1,559 bedded + 8,877 non-bedded HCFs; 538.733 MT Covid-19 waste (2020-21). Generated = treated. (DEP 2022)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "Inventory of BMW: 1559 bedded + 8877 non-bedded HCF; 37.321 Tons/day generated and treated; 538.733 MT Covid-19 waste (2020-21); disposed through 5 CBMWTF (all outside the district).",
+                    "citation": "(iv) Bio-Medical Waste Management, p.40",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 2500.0,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated (BBMP)",
+                    "value": "2,500 TPD (DEP 2022)"
+                  },
+                  {
+                    "label": "Recycling capacity",
+                    "value": "Rock Crystal 1,000 MTPD operational + Kannur 750 TPD under construction (DEP 2022)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "Total C&D waste generation: BBMP 2500 TPD (district total 2507). Recycling: M/s Rock Crystal 1000 MTPD (Chikkajala, existing) + 750 TPD plant at Kannur (under construction). User fee Rs.134/ton.",
+                    "citation": "(iii) C&D Waste Management, p.36",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "Consented industries across the Peenya + Dasarahalli ROs - the Vrishabhavathi valley, the basin's industrial core - by pollution-potential colour.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~7,000"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~2,600",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Peenya + Dasarahalli RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Peenya + Dasarahalli RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Peenya.pdf"
+                  }
+                ]
+              }
+            ],
+            "conflicts": [
+              "The DEP records a '0 MLD' treatment-capacity gap on paper, yet states ~20% of the area has no sewer network and 8-10% of sewage is untreated.",
+              "The DEP's own BBMP sewage-generation figure differs between tables (1,440 vs 1,458.6 MLD)."
+            ]
           },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
-            {
-              "label": "Biomedical waste generated (district)",
-              "value": "1.3 t/day ≈ 1.29 t/day (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Ramanagara DEP 2021",
-              "says": "Quantity of biomedical waste generated per day: 1290 kg/day.",
-              "citation": "Biomedical Waste section, p.41",
-              "url": "https://bengalurusouth.nic.in/en/district-environmental-plan-ramanagara/"
-            }
-          ]
+          "label": "BBMP city-wide"
         },
         {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "Harohalli became a separate taluk (carved from Kanakapura) only in 2022, so the 2019 F-register counts it within Kanakapura (~510 consented industries). The Harohalli KIADB estate is a major share of that.",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "within Kanakapura (~510)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Ramanagara RO)",
-              "says": "Harohalli not separated; counted within Kanakapura taluk (~510 consented industries as on 31-03-2019).",
-              "citation": "KSPCB F-register, Ramanagara RO, 2019 (OCR-extracted; approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Ramanagara.pdf"
-            }
-          ]
-        }
-      ]
-    },
-    "doddaballapura": {
-      "name": "Doddaballapura (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "Doddaballapura CMC generates ~5.0 MLD of sewage against a 12 MLD STP, but an incomplete UGD network (20% still uncovered) means sewage bypasses the plant; it is the district's largest solid-waste generator at 35 TPD",
-      "streams": [
-        {
-          "stream": "Sewage",
-          "summary": "STP works at 7 of 12 MLD but is directed to upgrade to meet PCB standards; 20% of the sewer network is still incomplete",
-          "metrics": [
-            {
-              "label": "Wastewater generated",
-              "value": "5.0 MLD (DEP 2021)"
-            },
-            {
-              "label": "Existing STP capacity",
-              "value": "12 MLD (DEP 2021)"
-            },
-            {
-              "label": "Present sewage flow rate",
-              "value": "5 MLD (DEP 2021)"
-            },
-            {
-              "label": "STP capacity vs generation",
-              "value": "Adequate on paper; no MLD shortfall stated (DEP 2021)"
-            },
-            {
-              "label": "UGD (sewer) network coverage",
-              "value": "80% provided, 20% yet to be completed (DEP 2021)"
-            },
-            {
-              "label": "Compliance / treatment gap",
-              "value": "Incomplete UGD -> sewage bypasses STP via missing links (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Domestic sewage gap & action plan table (p.55)",
-              "says": "City Municipal Council, Doddaballapura: Quantity of waste water present 5.0 MLD; Existing STP Capacity 12 MLD; Present Sewage Flow rate 5 MLD. Gap Analysis: 'Due to incomplete UGD network connected to STP there is a missing links bypassing the STP. Thus, these missing links must be intercepted and diverted to existing STP for treatment and Disposal. The existing STP is adequate.'",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Domestic Sewage gap analysis table, p.55",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            },
-            {
-              "source": "Bengaluru Rural DEP 2021 - Underground sewerage network table (p.57)",
-              "says": "City Municipal Council, Doddaballapura: Status of Sewerage Network 'Provided with UGD System'; % Sewerage network provided 80%; % yet to be completed 20%. Gap Analysis: '20% of the UGD work needs to be completed.'",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Underground sewerage network table, p.57",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 5.0,
-            "unit": "MLD"
+          "key": "yelahanka",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Yelahanka"
+            ]
+          },
+          "unit": {
+            "name": "Yelahanka (taluk; BBMP/BWSSB)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "STP operational and complying, with a second plant being added - one of the better-served parts of the basin",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "STP complying with capacity to spare; per-ULB generation isn't separately reported (BBMP city-wide)",
+                "metrics": [
+                  {
+                    "label": "Per-ULB sewage generated",
+                    "value": "Not separately reported - BBMP city-wide (DEP 2022)"
+                  }
+                ],
+                "sources": [],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk"
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 203.9,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, district-wide. Bengaluru Urban's one recorded contaminated site - the Mavallipura dumpsite (manganese in groundwater) - is in Yelahanka.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "12,963.63 / 16,429.380 / 45,023.44 MT/yr (DEP 2022)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "1718 (DEP 2022)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "KSPCB identified 1718 HW-generating industries (all authorised). Quantity of HW: 74416.29 MT/annum; Incinerable 12963.63; land-fillable 16429.38; recyclable/utilizable 45023.44. Integrated TSDF Nil; SLF Nil; standalone incinerators 02. Contaminated site: Mavallipura dumpsite, Yelahanka (Manganese exceeding standard).",
+                    "citation": "V. Hazardous Waste Management, p.45",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 37.32,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "5 (DEP 2022)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "5 CBMWTF (all outside the district) serve it; 1,559 bedded + 8,877 non-bedded HCFs; 538.733 MT Covid-19 waste (2020-21). Generated = treated. (DEP 2022)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Urban DEP 2022",
+                    "says": "Inventory of BMW: 1559 bedded + 8877 non-bedded HCF; 37.321 Tons/day generated and treated; 538.733 MT Covid-19 waste (2020-21); disposed through 5 CBMWTF (all outside the district).",
+                    "citation": "(iv) Bio-Medical Waste Management, p.40",
+                    "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+                  }
+                ]
+              }
+            ]
           }
-        },
-        {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "The KIADB Apparel Park CETP, built in 2021 for dyeing-unit effluent, is non-operational",
-          "metrics": [
-            {
-              "label": "District industries discharging",
-              "value": "151 (DEP 2021)"
-            },
-            {
-              "label": "District trade effluent",
-              "value": "14.354 MLD; 2 common facilities; 26 of 160 non-compliant (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "District-wide: 151 industries discharge wastewater, 14.354 MLD, 2 common effluent treatment facilities, 26 of 160 monitored non-compliant.",
-              "citation": "Bengaluru Rural DEP 2021, p.58",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 14.354,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "Doddaballapura CMC is the district's largest urban solid-waste generator at 35 tons/day (31 wards, ~93,105 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage; its downstream tables are collection/segregation gap percentages only.",
-          "metrics": [
-            {
-              "label": "Solid waste generated",
-              "value": "35 tons/day (DEP 2021)"
-            },
-            {
-              "label": "Wards / population (Doddaballapura CMC)",
-              "value": "31 wards; ~93,105 population (DEP 2021)"
-            },
-            {
-              "label": "Solid waste processed",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            },
-            {
-              "label": "Legacy / dumpsite waste",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
-              "says": "City Municipal Council Doddaballapura: No. of House holds 26059; Population 93105; Solid Waste Generated 35 Tons per day. (Other ULBs: Hoskote CMC 25 TPD; Nelamangala CMC 30 TPD; Devanahalli Town MC 17 TPD; Vijayapura Town MC 18 TPD. Village/Gram Panchayats 198.184 MT/day theoretical at 200 gm/head/day; actual not available.)",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 35.0,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 23.2,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
-            },
-            {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
-            },
-            {
-              "label": "HW-generating industries (district)",
-              "value": "286 (DEP 2021)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
-              "citation": "V. Hazardous Waste Management, p.38",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 2.29,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
-            {
-              "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
-            },
-            {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "3 (DEP 2021)"
-            },
-            {
-              "label": "Notes",
-              "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
-              "citation": "(iv) Bio-Medical Waste Management, p.35",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "district",
-          "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
-          "metrics": [
-            {
-              "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
-            },
-            {
-              "label": "Recycling facility",
-              "value": "None in the district; no C&D reuse policy (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
-              "citation": "(iii) C&D Waste Management, p.30-32",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~22% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "~1,450"
-            },
-            {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~580+",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Doddaballapura RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Doddaballapura RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Doddaballapura.pdf"
-            }
-          ]
         }
       ],
-      "caveats": [
-        "The STP has spare capacity (12 MLD vs ~5 MLD generated), but 20% of the area has no sewer line - so that share of sewage isn't collected or treated. Adequate capacity doesn't mean full treatment."
+      "industrialAreas": [
+        {
+          "name": "Peenya Industrial Area",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Peenya Industrial Area"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Kumbalagodu  1st Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Kumbalagodu  1st Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Kumbalagodu  2nd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Kumbalagodu  2nd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        }
       ]
     },
-    "nelamangala": {
-      "name": "Nelamangala (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "Nelamangala CMC has no operating STP (capacity and flow both 0 MLD) against 2.9 MLD of wastewater; the DEP says an STP is 'to be established' though it reports the UGD network as 100% provided; 30 TPD solid waste",
-      "streams": [
+    {
+      "key": "bengaluru-rural",
+      "name": "Bengaluru Rural",
+      "dep": {
+        "label": "Bengaluru Rural DEP 2021 (scanned)",
+        "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+      },
+      "pctInBasin": 39.7,
+      "counts": [
         {
-          "stream": "Sewage",
-          "summary": "No STP and effectively no sewer network laid - the full 2.9 MLD is untreated",
-          "metrics": [
-            {
-              "label": "Sewage generated",
-              "value": "2.9 MLD (DEP 2021)"
-            },
-            {
-              "label": "STP capacity",
-              "value": "0 MLD - no STP (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "UGD network",
-              "value": "Nominally 'provided' but 0% laid; 100% of UGD work yet to be completed (DEP 2021, p.57)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Action plan",
-              "value": "'STP to be established' (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 (p.55,57, image-verified)",
-              "says": "Nelamangala CMC: 2.9 MLD generated, 0 MLD STP, 0 MLD treated; sewerage network 0% provided / 100% of UGD work yet to be completed; action plan 'STP to be established'.",
-              "citation": "Bengaluru Rural DEP 2021, p.55, 57",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 2.9,
-            "unit": "MLD"
-          }
+          "label": "City Municipal Councils (CMC)",
+          "value": "2 in-basin - Doddaballapura, Nelamangala"
         },
         {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "Reported district-wide only (all of Bengaluru Rural), not per taluk. District-wide: 151 industries discharge wastewater generating 14.354 MLD; NIL treated industrial wastewater discharged to nalas/rivers; 2 Common Effluent Treatment Facilities; 134 industries compliant, 26 non-compliant. Note Nelamangala hosts one of KSPCB's two regional F-Register offices for the district.",
-          "metrics": [
-            {
-              "label": "Industries discharging wastewater (district-wide, not taluk-level)",
-              "value": "151 Nos. (DEP 2021)"
-            },
-            {
-              "label": "Industrial wastewater generated (district-wide, not taluk-level)",
-              "value": "14.354 MLD (DEP 2021)"
-            },
-            {
-              "label": "Common Effluent Treatment Facilities (district-wide)",
-              "value": "2 Nos. (DEP 2021)"
-            },
-            {
-              "label": "Industries NOT meeting discharge standards (district-wide)",
-              "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Operating industries by KSPCB category (district-wide)",
-              "value": "Red 174 / Orange 275 / Green 681 / White 97 (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Industrial waste water management (p.58)",
-              "says": "As per the F-Reg maintained in the Regional office Hoskote, Regional office Nelamangala, KSPCB as on 31-03-2021: Red 174; Orange 275; Green 681; White 97. No of Industries discharging waste water 151 Nos.; Total Quantity of industrial waste water generated 14.354 MLD; Quantity of treated industrial waste water discharged into Nalas/Rivers NIL; Common Effluent Treatment Facilities 2 Nos.; Industries meeting discharge Standards 134 Nos.; Industries not meeting discharge Standards 26 Nos.",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Industrial Wastewater Management section, p.58 (KSPCB F-Register as on 31-03-2021)",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 14.354,
-            "unit": "MLD"
-          }
+          "label": "Town Municipal Councils (TMC)",
+          "value": "1 basin-edge - Devanahalli"
         },
         {
-          "stream": "Municipal solid waste",
-          "summary": "Nelamangala CMC generates 30 tons/day (31 wards, ~70,393 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage.",
-          "metrics": [
-            {
-              "label": "Solid waste generated",
-              "value": "30 tons/day (DEP 2021)"
-            },
-            {
-              "label": "Wards / population (Nelamangala CMC)",
-              "value": "31 wards; ~70,393 population (DEP 2021)"
-            },
-            {
-              "label": "Solid waste processed",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            },
-            {
-              "label": "Legacy / dumpsite waste",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
-              "says": "City Municipal Council Nelamanagala: No. of House holds 17604; Population 70393; Solid Waste Generated 30 Tons per day.",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 30.0,
-            "unit": "TPD"
-          }
+          "label": "Town Panchayats (TP)",
+          "value": "1 in-basin - Bashettihalli (not in the plan)"
         },
         {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 23.2,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, district-wide. The district's only integrated TSDF (treatment-storage-disposal) is sited in Nelamangala taluk, at Dabaspet.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
-            },
-            {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
-            },
-            {
-              "label": "HW-generating industries (district)",
-              "value": "286 (DEP 2021)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
-              "citation": "V. Hazardous Waste Management, p.38",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 2.29,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
-            {
-              "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
-            },
-            {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "3 (DEP 2021)"
-            },
-            {
-              "label": "Notes",
-              "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
-              "citation": "(iv) Bio-Medical Waste Management, p.35",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "district",
-          "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
-          "metrics": [
-            {
-              "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
-            },
-            {
-              "label": "Recycling facility",
-              "value": "None in the district; no C&D reuse policy (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
-              "citation": "(iii) C&D Waste Management, p.30-32",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Industrial register (KSPCB, 2019)",
-          "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~29% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
-          "metrics": [
-            {
-              "label": "Consented industries (2019)",
-              "value": "~1,950"
-            },
-            {
-              "label": "Red + Orange (higher pollution)",
-              "value": "~560+",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
-            {
-              "source": "KSPCB F-register (Nelamangala RO)",
-              "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
-              "citation": "KSPCB F-register, Nelamangala RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
-              "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Nelamangala.pdf"
-            }
-          ]
+          "label": "Gram Panchayats",
+          "value": "101 (per the plan)"
         }
       ],
-      "conflicts": [
-        "The DEP labels the sewerage status 'Provided with UGD System', yet the same table records 0% of the network actually laid (100% still to be completed) and there is no STP."
-      ]
-    },
-    "devanahalli": {
-      "name": "Devanahalli (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "Devanahalli Town MC has no UGD sewer system at all (0% implemented) and 0 MLD STP against 1.0 MLD wastewater; the DEP records a sanctioned Sludge Treatment Plant in lieu of UGD; 17 TPD solid waste",
-      "streams": [
-        {
-          "stream": "Sewage",
-          "summary": "No UGD network and no conventional STP; relies on a faecal sludge treatment plant - the DEP's own tables disagree on what's needed",
-          "metrics": [
-            {
-              "label": "Sewage generated",
-              "value": "1.0 MLD (DEP 2021)"
-            },
-            {
-              "label": "Conventional STP",
-              "value": "0 MLD - no STP (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "UGD network",
-              "value": "None implemented (DEP 2021, p.57)"
-            },
-            {
-              "label": "Faecal sludge",
-              "value": "Devanahalli FSTP - CDD Society / BORDA, 6 KLD, operational since Nov 2015. India's first municipal-scale FSTP (625 m2, ~4,000 households); treats ~100% of collected septage via screening, solid-liquid separation, anaerobic baffled reactor, planted gravel filter and co-composting.",
-              "emphasis": "good"
-            },
-            {
-              "label": "Plan inconsistency",
-              "value": "p.55-56 says 'provide UGD+STP'; p.57 says 'FSTP provided, no UGD needed' (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 (p.55-57, image-verified)",
-              "says": "Devanahalli TMC: 1.0 MLD generated, 0 MLD STP, houses on septic tanks/soak pits. p.57 sewerage table: 'There is no UGD System implemented'; gap analysis 'Provided faecal Sludge Treatment Plant and Using. No Need to provide UGD system' - while p.55-56 lists 'Need to provide UGD system connected to STP'.",
-              "citation": "Bengaluru Rural DEP 2021, p.55-57",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            },
-            {
-              "source": "FSM Toolbox / CSE / WRI India - Devanahalli FSTP case study",
-              "says": "Devanahalli Town Municipal Council, with CDD Society and BORDA, set up a 6,000 L/day faecal sludge treatment plant operational since Nov 2015 - India's first municipal FSTP - serving ~4,000 households and treating 100% of the town's collected septage.",
-              "citation": "Devanahalli FSTP case study (CDD/BORDA); WRI India, CSE India",
-              "url": "https://wri-india.org/blogs/lessons-devanahalli-urban-faecal-sludge-management"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 1.0,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "Reported district-wide only (all of Bengaluru Rural), not per taluk. District-wide: 151 industries discharge wastewater generating 14.354 MLD; NIL treated industrial wastewater discharged to nalas/rivers; 2 Common Effluent Treatment Facilities; 134 industries compliant, 26 non-compliant. (Devanahalli taluk also hosts the BIAL airport/KIADB industrial cluster, but the DEP does not give a taluk-level effluent split.)",
-          "metrics": [
-            {
-              "label": "Industries discharging wastewater (district-wide, not taluk-level)",
-              "value": "151 Nos. (DEP 2021)"
-            },
-            {
-              "label": "Industrial wastewater generated (district-wide, not taluk-level)",
-              "value": "14.354 MLD (DEP 2021)"
-            },
-            {
-              "label": "Common Effluent Treatment Facilities (district-wide)",
-              "value": "2 Nos. (DEP 2021)"
-            },
-            {
-              "label": "Industries NOT meeting discharge standards (district-wide)",
-              "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "Operating industries by KSPCB category (district-wide)",
-              "value": "Red 174 / Orange 275 / Green 681 / White 97 (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Industrial waste water management (p.58)",
-              "says": "As per the F-Reg maintained in the Regional office Hoskote, Regional office Nelamangala, KSPCB as on 31-03-2021: Red 174; Orange 275; Green 681; White 97. No of Industries discharging waste water 151 Nos.; Total Quantity of industrial waste water generated 14.354 MLD; Quantity of treated industrial waste water discharged into Nalas/Rivers NIL; Common Effluent Treatment Facilities 2 Nos.; Industries meeting discharge Standards 134 Nos.; Industries not meeting discharge Standards 26 Nos.",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Industrial Wastewater Management section, p.58 (KSPCB F-Register as on 31-03-2021)",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 14.354,
-            "unit": "MLD"
-          }
-        },
-        {
-          "stream": "Municipal solid waste",
-          "summary": "Devanahalli Town MC generates 17 tons/day (the smallest of the five district ULBs; ~28,051 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage.",
-          "metrics": [
-            {
-              "label": "Solid waste generated",
-              "value": "17 tons/day (DEP 2021)"
-            },
-            {
-              "label": "Wards / population (Devanahalli Town MC)",
-              "value": "~6,397 households; ~28,051 population (DEP 2021)"
-            },
-            {
-              "label": "Solid waste processed",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            },
-            {
-              "label": "Legacy / dumpsite waste",
-              "value": "Not tabulated per ULB in this DEP (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
-              "says": "Town Municipal Council Devanahalli: No. of House holds 6397; Population 28051; Solid Waste Generated 17 Tons per day.",
-              "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 17.0,
-            "unit": "TPD"
-          }
-        },
-        {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 23.2,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
-            {
-              "label": "Hazardous waste generated (district)",
-              "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
-            },
-            {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
-            },
-            {
-              "label": "HW-generating industries (district)",
-              "value": "286 (DEP 2021)"
-            },
-            {
-              "label": "Disposal facilities",
-              "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
-              "citation": "V. Hazardous Waste Management, p.38",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 2.29,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
-            {
-              "label": "Biomedical waste generated (district)",
-              "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
-            },
-            {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "3 (DEP 2021)"
-            },
-            {
-              "label": "Notes",
-              "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
-              "citation": "(iv) Bio-Medical Waste Management, p.35",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        },
-        {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "district",
-          "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
-          "metrics": [
-            {
-              "label": "C&D waste generated",
-              "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
-            },
-            {
-              "label": "Recycling facility",
-              "value": "None in the district; no C&D reuse policy (DEP 2021)"
-            }
-          ],
-          "sources": [
-            {
-              "source": "Bengaluru Rural DEP 2021",
-              "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
-              "citation": "(iii) C&D Waste Management, p.30-32",
-              "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
-            }
-          ]
-        }
-      ],
-      "conflicts": [
-        "The DEP differ froms itself: the sewerage table (p.55-56) says 'provide UGD system connected to STP', while the gap-analysis table (p.57) says a faecal sludge treatment plant is already provided and 'no need to provide UGD system'."
-      ]
-    },
-    "chikkaballapura": {
-      "name": "Chikkaballapura (taluk)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "Chikkaballapura town (Arkavathi headwaters near Nandi Hills) has a 10 MLD STP against ~3.5 MLD generated, but its underground sewerage network is only ~91% complete (9% gap) and ~40,000 tonnes of legacy waste sit at its dumpsite; the district has no CETP and most industrial effluent is handled by in-premises ETPs.",
-      "_provenance": {
-        "document_title": "DISTRICT ENVIRONMENT PLAN FOR CHIKKABALLAPURA DISTRICT, KARNATAKA STATE",
-        "source_page": "https://chikkaballapur.nic.in/en/about-district/district-environmental-plan/",
-        "document_url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf",
-        "data_as_on": "No explicit 'data as on' date is printed in the DEP. Dating evidence: PDF uploaded Nov 2021 (s3waas path /uploads/2021/11/); action-plan timelines are dated 30/11/2021, 31/12/2021 with completion targets to 2025; population is 2011 Census; HN Valley treated-water reuse cited 'from the year 2019-20'. Referenced throughout as 'DEP 2021'.",
-        "extraction_method": "PDF is image-only / scanned (116 pages; pdftotext -layout and pypdf both returned zero text on all pages). Extracted via pdftoppm at 200 dpi + tesseract 5.5.2 OCR. Figures below transcribed from OCR; minor OCR artefacts corrected against context but all numeric values reproduced verbatim from the OCR'd tables.",
-        "extraction_caveats": [
-          "The DEP reports almost everything at district level across its 6 ULBs (CMC Chikkaballapura, CMC Chinthamani, CMC Sidlaghatta, CMC Gowribidanur, TMC Bagepalli, TP Gudibande) and 157 gram panchayats. Town/taluk-specific rows for Chikkaballapura CMC are extracted where the DEP breaks them out; sewage-per-ULB and solid-waste-per-ULB tables do break out Chikkaballapura, but industrial effluent and CETP status are reported district-wide only (no taluk split).",
-          "The Domestic Sewage section is internally inconsistent on Chikkaballapura's generated volume: the per-ULB sewage-generated table lists 3.5 MLD, while the later waste-water/gap-analysis table lists 'The work has been taken up by KMRP and maintained by ULB' instead of a number for Chikkaballapura. The 3.5 MLD figure is the only printed numeric value and is used here.",
-          "Total district urban sewage generated is stated as 13.01 MLD; total available STP treatment capacity 15.10 MLD (CMC Chikkaballapura 10 + CMC Chinthamani 2 + CMC Sidlaghatta 3.1). 3 of 6 towns have STPs.",
-          "No explicit 'quantity processed' figure is printed for municipal solid waste; the DEP records 100% collection and that composting is practised in all ULBs, with legacy-waste tonnages given per ULB. Chikkaballapura CMC legacy waste = 40,000 tonnes; district total = 1,46,250 tonnes.",
-          "OCR rendered the C&D-waste district total as '72' which is inconsistent with the row sum (3+2+0.5+1+0.5+0.2 = 7.2 TPD); the intended total is 7.2 TPD. Not central to the three requested streams."
+      "countsNote": "The plan is a scanned document; figures were read via OCR and are approximate where flagged. Its ULB roster also covers Hoskote CMC and Vijayapura TMC, outside the basin.",
+      "mapMatch": {
+        "family": "admin-district",
+        "prop": "name",
+        "values": [
+          "Bengaluru (Rural)"
         ]
       },
-      "streams": [
+      "districtThemes": [
         {
-          "stream": "Sewage",
-          "summary": "Chikkaballapura CMC (31 wards) generates ~3.5 MLD of sewage and has a 10 MLD STP, so installed treatment capacity exceeds current generation. The binding gap is collection, not capacity: the underground sewerage network is ~91% complete with a 9% gap, and the DEP's own action plan notes the existing oxidation pond is inadequate and an upgraded STP plus completion of UGD missing links is required. The town sits in the Arkavathi headwaters zone near Nandi Hills.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "solid-waste",
+          "summary": "Five ULBs generate 125 TPD municipal solid waste and 101 gram panchayats an estimated 198.184 MT/day (theoretical at 200 g/head/day), with 102 of 139 ULB wards achieving 100% source segregation and 71,100 tonnes of legacy waste at 4 old dumpsites.",
           "metrics": [
             {
-              "label": "Sewage generated, CMC Chikkaballapura",
-              "value": "3.5 MLD (DEP 2021)"
+              "label": "ULB solid waste generated (sum of 5 ULBs)",
+              "value": "125 TPD (Hoskote 25, Doddaballapura 35, Nelamangala 30, Devanahalli 17, Vijayapura 18)"
             },
             {
-              "label": "Existing STP capacity, CMC Chikkaballapura",
-              "value": "10 MLD (DEP 2021)"
+              "label": "GP solid waste (theoretical, 200 g/head/day)",
+              "value": "198.184 MT/day across 101 GPs (pop 990,923)"
             },
             {
-              "label": "Underground sewerage network coverage / gap, CMC Chikkaballapura",
-              "value": "91% covered, 9% gap (DEP 2021)",
-              "emphasis": "bad"
+              "label": "Wards with 100% source segregation",
+              "value": "102 of 139"
             },
             {
-              "label": "District urban sewage generated (6 ULBs, Class-II towns and above)",
-              "value": "13.01 MLD (DEP 2021)"
+              "label": "Road length swept regularly",
+              "value": "424.49 of 727.78 km (gap 303.30 km)"
             },
             {
-              "label": "District total available STP treatment capacity (3 of 6 towns have STPs)",
-              "value": "15.10 MLD (DEP 2021)"
+              "label": "Sweeping manpower",
+              "value": "543 available vs 573 required per DPR"
             },
             {
-              "label": "Treated/untreated sewage flowing to rivers or lakes (district)",
-              "value": "Nil reported (DEP 2021)"
+              "label": "Wards with 100% collection / door-to-door",
+              "value": "139 of 139 (100%)"
+            },
+            {
+              "label": "Bulk waste generators with onsite composting",
+              "value": "2 of 40 identified"
+            },
+            {
+              "label": "Sanitary landfills available",
+              "value": "1 of 5 required"
+            },
+            {
+              "label": "Legacy waste at old dumpsites",
+              "value": "71,100 tonnes at 4 dumpsites"
+            },
+            {
+              "label": "Authorized informal waste pickers with ID cards",
+              "value": "19"
             }
           ],
-          "sources": [
-            {
-              "source": "Chikkaballapura DEP 2021, Domestic Sewage section",
-              "says": "ULB's Existing STP Capacity (MLD) / Total Quantity of sewage generated in MLD: CMC. Chikkaballapura 10 / 3.5; CMC Chinthamani 2 / 3.4; CMC - Sidlaghatta 3.1 / 2.1; CMC - Gowribidanur Not existing / 2.2; TMC- Bagepalli 0 / 1; TP Gudibande 0 / 0.8. Total Quantity of Sewage generated in District From Class II cities and above [MLD]: 13.01 MLD.",
-              "citation": "DEP 2021, Domestic Sewage, p.99 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Domestic Sewage section (UGD coverage table)",
-              "says": "No of ULBs having partial underground Sewerage network [Nos]: 3 Nos. ULB's Existing STP Capacity / % area covered / Existing UGD Gap Analysis: CMC. Chikkaballapura 10 / 91% / 9%; CMC Chinthamani 2 / 98% / 2%; CMC - Sidlaghatta 3.1 / 70% / 30%.",
-              "citation": "DEP 2021, Domestic Sewage, p.98 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Domestic Sewage treatment-capacity table",
-              "says": "Total available Treatment Capacity [MLD]: 15.10 MLD. CMC. Chikkaballapura 10; CMC Chinthamani 2; CMC - Sidlaghatta 3.1; CMC - Gowribidanur No STP, discharged to ST & SP; TMC- Bagepalli No STP, discharged to ST & SP; TP - Gudibande No STP, discharged to ST & SP; Total 15.1.",
-              "citation": "DEP 2021, Domestic Sewage, p.100 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Domestic Sewage action plan",
-              "says": "Existing STP (oxidation pond) is inadequate to treat the sewage generated from the town. Due to incomplete UGD connection missing link exists, the completion of UGD work and connection shall be made. Note: The existing oxidation pond to be upgraded to STP of new technology in case of CMC - Chikkaballapura, Chinthamani & Shidlaghatta.",
-              "citation": "DEP 2021, Domestic Sewage action plan, p.103 and p.97 (PDF labels)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            }
+          "openActions": [
+            "Achieve 100% source segregation via daily local-language announcements, fines and awards | ULB's | 31-03-2022",
+            "Close 303 km sweeping gap using full manpower/outsourcing within 6 months | ULB's | 31-03-2022",
+            "DPR for centralized tendering of SWM equipment (trolleys, mini-trucks) | ULB's | 31-3-2022",
+            "Bulk generators to install onsite composters; stop collecting their wet waste after notice | ULB's | 31-3-2022",
+            "Establish waste deposition centres for domestic hazardous waste; MOU with TSDF | ULB's | 31-3-2022",
+            "Construct sanitary landfills / make existing SLF functional | ULB's | 31-3-2023",
+            "Remediate 71,100 t legacy waste per CPCB guidelines (Doddaballapura biomining under tender) | ULB's | 31-3-2023",
+            "Upgrade wet-waste composting facilities and set up leachate treatment | ULB's | 31-3-2022"
           ],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 3.5,
-            "unit": "MLD"
-          }
+          "pages": [
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24
+          ]
         },
         {
-          "stream": "Industrial effluent (CETP)",
-          "summary": "The DEP reports industrial effluent at district scale only (no separate Chikkaballapura-taluk figure). The district has 196 operating industries (16 Red, 59 Orange, 113 Green, 8 White); 39 discharge waste water, generating 2.15 MLD of which 1.61 MLD is treated. There is no CETP anywhere in Chikkaballapura district - effluent is handled by in-premises ETPs and no industry is permitted to discharge to nalas/rivers.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "plastic-waste",
+          "summary": "ULBs generate 8.75 TPD of plastic waste (GP quantities not inventoried); plastic is segregated at decentralized dry-waste collection centres but ULBs have no executed linkage with KSPCB-authorized recyclers.",
           "metrics": [
             {
-              "label": "Operating industries in district (Red/Orange/Green/White)",
-              "value": "196 total - 16 Red, 59 Orange, 113 Green, 8 White (DEP 2021)"
+              "label": "ULB plastic waste generated",
+              "value": "8.75 TPD (Hoskote 1.75, Doddaballapura 2.45, Nelamangala 2.10, Devanahalli 1.19, Vijayapura 1.26)"
             },
             {
-              "label": "Industries discharging waste water (district)",
-              "value": "39 (DEP 2021)"
+              "label": "GP plastic waste",
+              "value": "Details not available"
             },
             {
-              "label": "Industrial trade effluent generated (district)",
-              "value": "2.15 MLD (DEP 2021)"
+              "label": "Producers / brand owners in district",
+              "value": "2 producers, 3 brand owners"
             },
             {
-              "label": "Industrial waste water treated (district)",
-              "value": "1.61 MLD (DEP 2021)"
-            },
-            {
-              "label": "CETP status (district)",
-              "value": "No CETP established in Chikkaballapura district (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "ETP status (district)",
-              "value": "Effluent treated in in-premises ETPs; 39 of 39 discharging industries meeting standards, 0 not meeting (DEP 2021)",
-              "emphasis": "good"
+              "label": "Door-to-door dry waste collection",
+              "value": "100% in all 139 wards"
             }
           ],
-          "sources": [
-            {
-              "source": "Chikkaballapura DEP 2021, Industrial Waste Water Management section",
-              "says": "Total number of operating industries in the district is 196 ... [Nos. of Red industries]: 16; [Nos. of Orange industries]: 59; [Nos. of Green industries]: 113; [Nos. of White industries]: 8. No of Industries discharging waste water 39 Nos. Total Quantity of industrial waste water generated [MLD]: 2.15. Quantity of treated industrial waste water discharged in to Nalas/ Rivers [MLD]: 1.61. None of the industries are permitted to discharge either treated industrial wastewater into water bodies like Nalas /Rivers by KSPCB.",
-              "citation": "DEP 2021, Industrial Waste Water Management, p.107 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Industrial Waste Water Management - CETP / standards",
-              "says": "Common Effluent Treatment Facilities: There is no CETP's established in Chikkaballapura district. No of Industries meeting Standards Nos - 39. No of Industries not meeting discharge Standards Nil. As per the CPCB inspection policy the industries were inspected and sampling is carried out. If the samples are not confirming, the Show cause notice is served.",
-              "citation": "DEP 2021, Industrial Waste Water Management, p.107 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            }
+          "openActions": [
+            "Establish plastic waste collection centres at each ULB/village panchayat and execute recycler linkage | ULB's + KSPCB | 31-3-2022",
+            "Inventorise plastic waste generation at each GP/block/municipality | ULB's + local panchayats | 31-3-2022",
+            "Mass awareness programmes every 6 months with records to KSPCB | ULB's + KSPCB | 31-3-2022",
+            "Identify nearby cement industries for co-processing of segregated plastic; report to KSPCB every 6 months | ULB's | not stated (page partly unreadable)"
           ],
-          "medium": "liquid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 2.15,
-            "unit": "MLD"
-          }
+          "pages": [
+            24,
+            25,
+            26,
+            27,
+            30
+          ],
+          "ocrUncertain": true
         },
         {
-          "stream": "Municipal solid waste",
-          "summary": "Chikkaballapura CMC (31 wards, ~63,652 population) generates 26 TPD of municipal solid waste with 100% door-to-door collection reported; composting is practised in all ULBs. The DEP prints no separate 'quantity processed' tonnage but records ~40,000 tonnes of legacy waste at the Chikkaballapura CMC dumpsite (district legacy total 1,46,250 tonnes), with remediation via screening machines targeted by 31/12/2025. There is no C&D recycling facility in the district.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "cd-waste",
+          "summary": "ULBs report only 3.6 TPD of C&D waste, currently dumped in low-lying areas with no C&D recycling facility, user-fee bylaws or bulk-generator permission system in the district.",
           "metrics": [
             {
-              "label": "MSW generated, CMC Chikkaballapura",
-              "value": "26 TPD (DEP 2021)"
+              "label": "C&D waste generated (ULBs)",
+              "value": "3.6 TPD (Hoskote 0.5, Doddaballapura 1.5, Nelamangala 0.5, Devanahalli 0.1, Vijayapura 1.0)"
             },
             {
-              "label": "Door-to-door collection, CMC Chikkaballapura",
-              "value": "100% of 31 wards (DEP 2021)",
-              "emphasis": "good"
+              "label": "C&D recycling facility",
+              "value": "None in district"
             },
             {
-              "label": "Legacy / historic dumpsite waste, CMC Chikkaballapura",
-              "value": "40,000 tonnes (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "District legacy waste total (6 ULBs)",
-              "value": "1,46,250 tonnes (DEP 2021)",
-              "emphasis": "bad"
-            },
-            {
-              "label": "District urban MSW generated (6 ULBs)",
-              "value": "112.5 TPD (DEP 2021)"
-            },
-            {
-              "label": "Processing / disposal status (district)",
-              "value": "100% collection; composting in all ULBs; no separate processed-tonnage printed; legacy remediation by screening machine targeted 31/12/2025 (DEP 2021)"
+              "label": "User fee / bulk generator permission system",
+              "value": "No local by-laws framed"
             }
           ],
-          "sources": [
-            {
-              "source": "Chikkaballapura DEP 2021, Solid Waste Management current status",
-              "says": "Urban Local bodies / No. of Wards / No. of House holds / Population / Solid Waste Generated per day (TPD): CMC. Chikkaballapura 31 / 14806 / 63652 / 26; CMC Chinthamani 31 / 17841 / 76068 / 28; CMC - Sidlaghatta 31 / 10169 / 51159 / 23; CMC - Gowribidanur 31 / 10256 / 53290 / 23; TMC- Bagepalli 23 / 4263 / 27011 / 10; TP Gudibande 11 / 2250 / 9441 / 2.5. Total 280621 population / 112.5 TPD.",
-              "citation": "DEP 2021, Solid Waste Management current status, p.9 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Solid Waste Management - 100% collection table",
-              "says": "Whether 100% collection achieved? CMC. Chikkaballapura 31 wards / 100% collection of solid waste; ... Total 158 wards / 100%. Door to door collection: CMC. Chikkaballapura 31 wards / 31 having arrangement / 100% achieved / Nil gap.",
-              "citation": "DEP 2021, Solid Waste Management, p.24-25 (PDF labels)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, Remediation of historic/legacy dumpsite",
-              "says": "Whether existing old dumpsite if any required remediation as per rules? No. of existing old dump site / Total Quantity of legacy waste dumped at dump site in Tonnes: CMC. Chikkaballapura 1 / 40000; CMC Chinthamani 1 / 43000; CMC - Sidlaghatta 1 / 31000; CMC - Gowribidanur 20500; TMC- Bagepalli 10200; TP Gudibande 1550; Total 146250. Screening machines have been purchased and installed in 5 ULB's and tendered in CMC-Gowribidanur. Legacy waste will be disposed using screening machine. Timeline 31/12/2025.",
-              "citation": "DEP 2021, Solid Waste Management gap analysis (v), p.37-38 (PDF labels)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            },
-            {
-              "source": "Chikkaballapura DEP 2021, C&D Waste section",
-              "says": "Quantity of C&D waste generated in TPD: CMC. Chikkaballapura 3; CMC Chinthamani 2; CMC - Sidlaghatta 0.5; CMC - Gowribidanur 1; TMC- Bagepalli 0.5; TP Gudibande 0.2. Does the District has access to C&D waste recycling facility? No facility exist to process C & D waste in the district.",
-              "citation": "DEP 2021, C&D Waste section, p.62 (PDF label)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
-            }
+          "openActions": [
+            "Identify bulk generators, designate collection points per taluk and deposition points at district HQ | ULB's + District administration | 31-3-2022",
+            "Frame and implement user-fee by-laws and bulk-generator permission system | ULB's | 31-3-2022",
+            "Identify land and set up common C&D waste recycling facility | ULB's + District administration + Town Planning | 31-3-2022",
+            "Frame district policy for reuse of recycled C&D material in roads/paving with PWD | ULB's + District administration + PWD | 31-3-2022",
+            "C&D IEC training via KSPCB once in 6 months | ULB's + KSPCB | 31-3-2022"
           ],
-          "medium": "solid",
-          "sector": "public",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 26.0,
-            "unit": "TPD"
-          }
+          "pages": [
+            30,
+            31,
+            32
+          ]
         },
         {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 1.1,
-            "unit": "TPD",
-            "estimated": true
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "biomedical-waste",
+          "summary": "All 2,092.52 kg/day of biomedical waste from 680 authorized HCFs is treated through 3 in-district CBWTFs, with 45 deep-burial pits in remote areas and bar-coding initiated but not yet 100%.",
+          "metrics": [
+            {
+              "label": "Bedded healthcare facilities",
+              "value": "120"
+            },
+            {
+              "label": "Non-bedded HCFs",
+              "value": "452"
+            },
+            {
+              "label": "HCFs authorized by KSPCB",
+              "value": "680"
+            },
+            {
+              "label": "Common BMW treatment facilities (CBWTFs)",
+              "value": "3 (Medicare 4000 kg/day; Ramky 1500 kg/hr; Anu Autoclave 8000 kg/day)"
+            },
+            {
+              "label": "Deep burial pits",
+              "value": "45 (18 Nelamangala, 27 Doddaballapura)"
+            },
+            {
+              "label": "BMW generated per day",
+              "value": "2092.52 kg/day (p33); annual report 2020-21 figure 2292.96 kg/day (p35)"
+            },
+            {
+              "label": "BMW treated per day",
+              "value": "2092.52 kg/day (100% of generated)"
+            },
+            {
+              "label": "Awareness programmes conducted 2020-21",
+              "value": "45"
+            }
+          ],
+          "openActions": [
+            "Ensure 100% bar-code implementation by all HCFs and CBWTFs | District Health Officer + CBMWTF + HCEs + KSPCB | 31-12-2022",
+            "Ensure no untreated HCF wastewater discharged; >30-bed HCEs covered under Water Act with ETPs | District Health Officer + KSPCB | 31-03-2022",
+            "Regular district-level monitoring committee inspections for 100% compliance | DHO + KSPCB | ongoing"
+          ],
+          "pages": [
+            33,
+            34,
+            35,
+            36,
+            37,
+            38
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "hazardous-waste",
+          "summary": "286 industries generate 8,453.57 MT/annum of hazardous waste handled through one integrated TSDF at Dabaspet (Nelamangala taluk) and authorized recyclers/incinerators, with no contaminated sites and no domestic hazardous waste collection centres yet.",
+          "metrics": [
+            {
+              "label": "Industries generating hazardous waste",
+              "value": "286 (p38; p39 narrative says 7, inconsistent)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Hazardous waste quantity",
+              "value": "8453.57 MT/annum (incinerable 4070.89; landfillable 2190.73; recyclable 2187.84)"
+            },
+            {
+              "label": "Integrated TSDF",
+              "value": "1 (Dabaspet, Nelamangala taluk); SLF Nil"
+            },
+            {
+              "label": "Contaminated sites",
+              "value": "Nil"
+            },
+            {
+              "label": "HW industries authorized under HWM Rules with TSDF/recycler MOU",
+              "value": "95%"
+            }
+          ],
+          "openActions": [
+            "Establish domestic hazardous waste collection centres per CPCB annual inventory guidelines | ULB's | 31-12-2022",
+            "Train workers handling/recycling/disposing HW with KSPCB support | ULB's | 31.03.2022",
+            "Execute MOUs with common recycling/incineration facilities for domestic hazardous waste | ULB's | 31.03.2022"
+          ],
+          "pages": [
+            38,
+            39
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "e-waste",
+          "summary": "The district inventories 25 MT/year of e-waste with one ULB collection centre (Doddaballapura CMC), 16 authorized recyclers/dismantlers but no producers or producer-run collection centres, and bulk-generator inventorisation still in progress.",
+          "metrics": [
+            {
+              "label": "E-waste inventory",
+              "value": "25 MT/year"
+            },
+            {
+              "label": "Collection centres by ULBs",
+              "value": "1 (Doddaballapura CMC)"
+            },
+            {
+              "label": "Collection centres by producers/PROs",
+              "value": "Nil (no producers in district)"
+            },
+            {
+              "label": "Authorized e-waste recyclers/dismantlers",
+              "value": "16"
+            },
+            {
+              "label": "Illegal recycling/dismantling records",
+              "value": "None recorded"
+            }
+          ],
+          "openActions": [
+            "Complete inventorisation of e-waste and bulk waste generators | ULB's + KSPCB | 30.06.2022",
+            "Establish e-waste collection centres in each ULB jurisdiction with public notification | ULB's | 31-12-2021",
+            "Execute MOUs linking ULBs with authorized recyclers/dismantlers to channelize e-waste | ULB's | 31-12-2021",
+            "Mechanism to bring informal sector into mainstream collection/recycling via producers/PROs | ULB's + KSPCB | 31.03.2022"
+          ],
+          "pages": [
+            40,
+            41,
+            42
+          ]
+        },
+        {
+          "theme": "water-quality",
+          "status": "covered",
+          "summary": "Three rivers (Kumudavathi 45.03 km, Arkavathi 28.17 km, Dakshina Pinakini 68.44 km) and 98 lakes cross the district with ~340 drains joining the rivers; KSPCB monitors only 16 lakes, no environmental monitoring cell exists, and the plan reports no polluted river stretches or groundwater hotspots.",
+          "metrics": [
+            {
+              "label": "Rivers",
+              "value": "Kumudavathi 45.03 km, Arkavathi 28.17 km, Dakshina Pinakini 68.44 km"
+            },
+            {
+              "label": "Drains joining rivers",
+              "value": "~100 to Kumudavathi, ~100 to Arkavathi, ~140 to Dakshina Pinakini (Shivaganga hills to Thippagondanahalli side)"
+            },
+            {
+              "label": "Lakes/ponds",
+              "value": "98 lakes (40-2000 ha)"
+            },
+            {
+              "label": "Lakes monitored by KSPCB",
+              "value": "16; lake-wise water quality data otherwise unavailable"
+            },
+            {
+              "label": "Total ULB sewage",
+              "value": "13.2 MLD"
+            },
+            {
+              "label": "Industrial wastewater",
+              "value": "12.554 MLD from 161 industries (p47; p58 states 14.354 MLD)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Untreated sewage",
+              "value": "62.12%"
+            },
+            {
+              "label": "Borewell drilling permissions 2017-2021",
+              "value": "239; NOCs for groundwater extraction 5"
+            },
+            {
+              "label": "Groundwater polluted areas / polluted river stretches",
+              "value": "Nil / No (as claimed by the plan)"
+            }
+          ],
+          "openActions": [
+            "Constitute environmental monitoring cell and inventorise all water bodies with quality data | Minor Irrigation + Groundwater authority + ZP + KSPCB + Watershed dept | 31-3-2022",
+            "Lake owners (ULB/GP/TP) to monitor lake water quality per CPCB frequency, report quarterly | ULBs/panchayats | 31-3-2022",
+            "Identify wastewater-carrying drains and plug them from joining water bodies | ULB's + KSPCB | 31-3-2022",
+            "Inventory of domestic sewage and storm water drains discharging to water bodies | ULBs/GPs/TPs | 31-3-2022",
+            "District mobile app / helpline for water pollution complaints | District administration | 31-3-2022",
+            "Groundwater rejuvenation and rain water harvesting monitoring in all establishments | Groundwater authority | 31-3-2022"
+          ],
+          "pages": [
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52
+          ]
+        },
+        {
+          "theme": "domestic-sewage",
+          "status": "covered",
+          "summary": "Only 1 of 5 ULBs has an STP (Doddaballapura 12 MLD) against 13.2 MLD generated district-wide, with Nelamangala (16 MLD CFE) and Hoskote (8.5 MLD CFE) yet to start construction and Devanahalli running a 6 KLD faecal sludge treatment plant instead of UGD.",
+          "metrics": [
+            {
+              "label": "Class-II towns",
+              "value": "3 (Hoskote, Doddaballapura, Nelamangala)"
+            },
+            {
+              "label": "Towns with STP",
+              "value": "1 (Doddaballapura 12 MLD; p53 prints '12 KLD', 12 MLD per pp.47,54,55)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Towns needing STPs",
+              "value": "4 (Hoskote, Nelamangala, Devanahalli, Vijayapura)"
+            },
+            {
+              "label": "Sewage generated (all 5 ULBs)",
+              "value": "13.2 MLD; Class-II cities 9.3 MLD"
+            },
+            {
+              "label": "Total treatment capacity",
+              "value": "12 MLD"
+            },
+            {
+              "label": "UGD coverage",
+              "value": "Hoskote 60%, Doddaballapura 80%, Nelamangala 0%, Devanahalli none (FSTP-based), Vijayapura 30%"
+            },
+            {
+              "label": "Devanahalli FSTP",
+              "value": "6 KLD"
+            },
+            {
+              "label": "Sewage flowing into rivers/lakes",
+              "value": "Nil (as claimed by the plan)"
+            }
+          ],
+          "openActions": [
+            "Establish STP at Hoskote (CFE for 8.5 MLD obtained) and adequate-capacity STPs in remaining ULBs | ULB's + KUWS&DB + KUIDFC | 31-3-2023",
+            "Start construction of Nelamangala 16 MLD STP (CFE obtained, work not started) | ULB + KUWS&DB | 31-3-2023",
+            "Complete UGD network gaps (Hoskote 40%, Doddaballapura 20%, Nelamangala 100%, Vijayapura 60%) and connect households | ULB's + KUWS&DB + Dept of Urban Development | 31-3-2022",
+            "Intercept and divert missing sewer links bypassing Doddaballapura STP | ULB | 31-3-2023",
+            "I&D-model tapping of high-sewage drains, bio/phyto-remediation in rural areas, reuse plan for treated water | ULB's + KUWS&DB | 31-3-2023"
+          ],
+          "pages": [
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58
+          ]
+        },
+        {
+          "theme": "industrial-wastewater",
+          "status": "covered",
+          "summary": "1,227 operating industries (174 red, 275 orange, 681 green, 97 white) include 161 discharging 14.354 MLD of wastewater that is treated in in-house ETPs and recycled or used on land, with 26 industries not meeting discharge standards under KSPCB enforcement.",
+          "metrics": [
+            {
+              "label": "Industries by category (F-Reg 31-03-2021)",
+              "value": "Red 174, Orange 275, Green 681, White 97"
+            },
+            {
+              "label": "Industries discharging wastewater",
+              "value": "161"
+            },
+            {
+              "label": "Industrial wastewater generated",
+              "value": "14.354 MLD (p58; p47 states 12.554 MLD)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Treated industrial wastewater discharged to nalas/rivers",
+              "value": "Nil"
+            },
+            {
+              "label": "Common effluent treatment facilities",
+              "value": "2"
+            },
+            {
+              "label": "Industries meeting / not meeting standards",
+              "value": "134 / 26"
+            }
+          ],
+          "openActions": [
+            "Periodic inspection, sampling and enforcement against 26 non-complying industries (show-cause, closure directions under Water/Air Acts) | KSPCB | continuous",
+            "Complaint redressal via KSPCB Integrated Command Centre app and district phone-in programme | KSPCB + District administration | existing/ongoing"
+          ],
+          "pages": [
+            58,
+            59,
+            60
+          ]
+        },
+        {
+          "theme": "air-quality",
+          "status": "covered",
+          "summary": "The district has no KSPCB-operated ambient air quality station (only one private CAAQM at Bangalore International Airport) despite 950 air-polluting industries, with quarrying/blasting, stone crushers, industrial areas, vehicles and unpaved roads named as the main sources.",
+          "metrics": [
+            {
+              "label": "CAAQM stations by KSPCB/Govt",
+              "value": "0; 1 private CAAQM at BIAL airport premises"
+            },
+            {
+              "label": "Manual monitoring stations by KSPCB",
+              "value": "0"
+            },
+            {
+              "label": "Towns failing NAAQ standards",
+              "value": "Nil (no NAAQM stations in district)"
+            },
+            {
+              "label": "Air polluting industries",
+              "value": "950"
+            },
+            {
+              "label": "Prominent sources",
+              "value": "Industrial areas, quarrying with blasting, stone crushers, vehicles, unpaved roads"
+            }
+          ],
+          "openActions": [
+            "Inventory of air pollution sources including hotspots; 6-monthly AAQ review around mining areas | District task force + Mines & Geology + KSPCB + PWD | 31-3-2022",
+            "Install ambient air quality monitoring stations (phase-wise, at least one manual per city) | District administration + KSPCB | 31.03.2023",
+            "Multi-sectoral air action plan: cleaner fuels, public transport, plantation, paving roads, phasing out unfit vehicles, BS6 | District administration + RTO + PWD + Social Forestry | 31-3-2022",
+            "Prohibit open waste/stubble burning; dust suppression and green belts at crushers/m-sand units and SWM sites | Forest + ULB's + Agriculture + Mines & Geology + KSPCB | not stated"
+          ],
+          "pages": [
+            43,
+            44,
+            45
+          ]
+        },
+        {
+          "theme": "mining",
+          "status": "covered",
+          "summary": "The district reports 120 running quarry leases (74 building stone, 52 ornamental stone per component rows) and 35 crushers with no sand mining, no identified illegal mining, and a functioning district-level task force reviewing environmental compliance.",
+          "metrics": [
+            {
+              "label": "Running mining leases",
+              "value": "120 total (Building stone 74, Ornamental stone 52; components sum to 126)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Expired / idle leases",
+              "value": "59 expired; 45 idle (35 ornamental + 10 OBS)"
+            },
+            {
+              "label": "Stone crushers",
+              "value": "35"
+            },
+            {
+              "label": "% district area under mining",
+              "value": "0.000576% (as printed; implausibly small)",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Sand mining area",
+              "value": "Not applicable"
+            },
+            {
+              "label": "Illegal mining identified",
+              "value": "None"
+            }
+          ],
+          "openActions": [
+            "District task force continues monitoring mining activity and environmental-clearance compliance | Mines & Geology Department | ongoing (marked Not Applicable, committee already in force)"
+          ],
+          "pages": [
+            61,
+            62
+          ],
+          "ocrUncertain": true
+        },
+        {
+          "theme": "noise",
+          "status": "covered",
+          "summary": "KSPCB (3) and Karnataka State Police BRD (16) hold portable noise meters but the district has no fixed ambient noise monitoring stations, with complaints handled through KSPCB's integrated command centre and police.",
+          "metrics": [
+            {
+              "label": "Portable noise analyzers",
+              "value": "KSPCB 3, Karnataka State Police BRD 16"
+            },
+            {
+              "label": "Fixed ambient noise monitoring stations",
+              "value": "0 (identified gap)"
+            },
+            {
+              "label": "Sign boards in noise-sensitive zones",
+              "value": "Adequate per Police/RTO"
+            }
+          ],
+          "openActions": [
+            "Install fixed ambient noise level monitoring stations in cities and towns | District Administration + KSPCB + ULB's | 31-12-2023"
+          ],
+          "pages": [
+            62,
+            63,
+            64
+          ]
+        }
+      ],
+      "ulbs": [
+        {
+          "key": "doddaballapura-cmc",
+          "name": "Doddaballapura",
+          "type": "CMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "DODDABALLAPUR"
+            ]
           },
-          "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Hazardous waste generated (district)",
-              "value": "398.82 MT/yr ≈ 1.1 t/day (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Doddaballapura CMC (26,059 households, 35 TPD) is the district's best performer with 100% source segregation in all 31 wards, full sweeping manpower, the district's only adopted SWM by-laws, but 25,500 t of legacy waste partially capped with biomining under tender.",
+              "metrics": [
+                {
+                  "label": "Solid waste generated",
+                  "value": "35 TPD (26,059 households, pop 93,105)"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "31 of 31"
+                },
+                {
+                  "label": "Road sweeping",
+                  "value": "129.41 of 169.41 km (gap 40 km); manpower 195 of 195"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "100% (25 auto-tippers incl. slums; 2 tipper trucks commercial)"
+                },
+                {
+                  "label": "Wet-waste facility",
+                  "value": "1 existing, functional, needs composting upgrade"
+                },
+                {
+                  "label": "Dry waste collection centres",
+                  "value": "2 (partial segregation, remainder landfilled)"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "1 available"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "25,500 t at 1 old dumpsite; partial scientific capping done, biomining under tender"
+                },
+                {
+                  "label": "Bulk generators with onsite composting",
+                  "value": "2 of 9"
+                },
+                {
+                  "label": "SWM by-laws",
+                  "value": "Karnataka model by-laws adopted 08-11-2019 (only ULB in district)"
+                }
+              ],
+              "openActions": [
+                "Complete biomining/remediation of 25,500 t legacy dumpsite | ULB | 31-3-2023",
+                "Upgrade composting facility | ULB | 31-3-2022",
+                "Get remaining 7 bulk generators to compost onsite | ULB | 31-3-2022"
+              ],
+              "pages": [
+                7,
+                8,
+                9,
+                10,
+                15,
+                18,
+                19,
+                20,
+                21,
+                22,
+                24
+              ]
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "143.90 / 194.290 / 60.63 MT/yr (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Generates 2.45 TPD plastic waste, the district's highest, segregated at its dry-waste centres with 100% door-to-door collection but no executed recycler linkage.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "2.45 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish PW collection centre and recycler linkage | ULB + KSPCB | 31-3-2022"
+              ],
+              "pages": [
+                24,
+                25,
+                26
+              ]
             },
             {
-              "label": "HW-generating industries (district)",
-              "value": "38 (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Reports 1.5 TPD of C&D waste, the district's highest, dumped in low-lying areas pending district collection/deposition points.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "1.5 TPD"
+                }
+              ],
+              "openActions": [
+                "District C&D collection/deposition points and recycling facility | ULB + District administration | 31-3-2022"
+              ],
+              "pages": [
+                30,
+                31,
+                32
+              ]
             },
             {
-              "label": "Disposal facilities",
-              "value": "No TSDF, no SLF, no standalone incinerator in the district; HW sent off-district under MoU. One in-district used-oil recycler (Gowribidanur). (DEP 2021)",
-              "emphasis": "bad"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "biomedical-waste",
+              "summary": "Hosts 27 of the district's 45 deep-burial pits for BMW from remote areas; otherwise served by the district's 3 CBWTFs.",
+              "metrics": [
+                {
+                  "label": "Deep burial pits",
+                  "value": "27"
+                }
+              ],
+              "pages": [
+                33
+              ]
+            },
             {
-              "source": "Chikkaballapura DEP 2021",
-              "says": "No of Industries generating HW: 38. Quantity of HW: 398.82 MT/Annum; Incinerable 143.90; land-fillable 194.29; recyclable/utilizable 60.63 (sub-totals sum exactly). TSDF/SLF/standalone incinerator: Nil.",
-              "citation": "V. Hazardous Waste Management, p.72 (printed)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Hazardous waste is reported only at district level (KSPCB Regional Office Doddaballapura is one of three F-Reg offices).",
+              "pages": [
+                38,
+                39,
+                58
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "e-waste",
+              "summary": "Runs the district's only ULB e-waste collection centre, with e-waste segregated separately at its dry waste collection centre.",
+              "metrics": [
+                {
+                  "label": "ULB e-waste collection centre",
+                  "value": "1 (only one in district)"
+                }
+              ],
+              "pages": [
+                40,
+                41
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "No ULB-specific water quality data; covered by district river/lake monitoring narrative.",
+              "pages": [
+                46,
+                47,
+                48
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "The only ULB with an STP (12 MLD, adequate for its 5.0 MLD sewage) but 20% of the UGD network is incomplete so missing links bypass the STP.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "5.0 MLD"
+                },
+                {
+                  "label": "Existing STP capacity",
+                  "value": "12 MLD (p53 prints '12 KLD')",
+                  "ocr-uncertain": true
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "80% (gap 20%)"
+                }
+              ],
+              "openActions": [
+                "Complete remaining 20% UGD and intercept missing links bypassing the STP | ULB + KUWS&DB | 31-3-2022"
+              ],
+              "pages": [
+                47,
+                53,
+                54,
+                55,
+                57
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Industrial wastewater reported only district-wide from the three KSPCB regional offices including RO Doddaballapura.",
+              "pages": [
+                58
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "No ULB-level air quality data or station.",
+              "pages": [
+                43
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Mining reported only at district level.",
+              "pages": [
+                61
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Noise reported only at district level; no fixed station in any ULB.",
+              "pages": [
+                62,
+                63
+              ]
             }
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 0.38,
-            "unit": "TPD",
-            "estimated": true
+          "key": "nelamangala-cmc",
+          "name": "Nelamangala",
+          "type": "CMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "NELMANGALA"
+            ]
           },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
-          "metrics": [
+          "themes": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "378.221 kg/day ≈ 0.38 t/day (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Nelamangala CMC (17,604 households, 30 TPD) has the district's biggest gaps: only 18 of 31 wards source-segregate, only main roads are swept, manpower DPR is outdated after its TMC-to-CMC upgrade (120 available vs 162 needed), and it has 14,600 t of legacy waste and no functional wet-waste facility.",
+              "metrics": [
+                {
+                  "label": "Solid waste generated",
+                  "value": "30 TPD (17,604 households, pop 70,393)"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "18 of 31 (gap 13)"
+                },
+                {
+                  "label": "Road sweeping",
+                  "value": "120.87 of 145.87 km; only main roads swept, outskirts not covered"
+                },
+                {
+                  "label": "Sweeping manpower",
+                  "value": "120 available vs 162 needed for 2021 population (DPR prepared for TMC, revision needed)"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "100% of 31 wards; 20 pushcarts and 5 auto-tippers to be procured"
+                },
+                {
+                  "label": "Wet-waste facility",
+                  "value": "2 required, 0 functional"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "None; needs to establish SLF"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "14,600 t at 1 old dumpsite"
+                },
+                {
+                  "label": "Bulk generators with onsite composting",
+                  "value": "0 of 8"
+                },
+                {
+                  "label": "Domestic hazardous waste deposition centre",
+                  "value": "1 of 2 (1 to be set up)"
+                }
+              ],
+              "openActions": [
+                "Revise DPR for CMC-level manpower and close 42-worker gap | ULB | 31-03-2022",
+                "Achieve 100% source segregation in remaining 13 wards; complete segregated collection | ULB | 31-03-2022",
+                "Establish sanitary landfill | ULB | 31-3-2023",
+                "Remediate 14,600 t legacy dumpsite | ULB | 31-3-2023",
+                "Set up functional wet-waste composting facility | ULB | 31-3-2022"
+              ],
+              "pages": [
+                7,
+                8,
+                9,
+                10,
+                15,
+                16,
+                19,
+                21,
+                22
+              ]
             },
             {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "2 (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Generates 2.10 TPD plastic waste with 100% door-to-door dry-waste collection but no recycler linkage.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "2.10 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish PW collection centre and recycler linkage | ULB + KSPCB | 31-3-2022"
+              ],
+              "pages": [
+                24,
+                25,
+                26
+              ]
             },
             {
-              "label": "Notes",
-              "value": "2 CBWTFs (one in-district at Gowribidanur, one at Kolar within 75 km); 100% treated. The DEP's own gaps table elsewhere prints 378.58 kg/day. (DEP 2021)"
-            }
-          ],
-          "sources": [
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Reports 0.5 TPD C&D waste dumped in low-lying areas pending district facilities.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "0.5 TPD"
+                }
+              ],
+              "openActions": [
+                "District C&D collection/deposition points | ULB + District administration | 31-3-2022"
+              ],
+              "pages": [
+                30,
+                31
+              ]
+            },
             {
-              "source": "Chikkaballapura DEP 2021",
-              "says": "Inventory of BMW: 225 bedded + 353 non-bedded HCF; 378.221 kg/day generated and treated; 2 CBWTFs (Prajwal, Gowribidanur in-district; Meera Envirotech, Kolar). Gaps table (p.68) prints 378.58 kg/day.",
-              "citation": "(iv) Bio-Medical Waste Management, p.66 (printed)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "biomedical-waste",
+              "summary": "Hosts 18 of the district's 45 BMW deep-burial pits; Nelamangala taluk also hosts the Dabaspet TSDF used for hazardous waste.",
+              "metrics": [
+                {
+                  "label": "Deep burial pits",
+                  "value": "18"
+                }
+              ],
+              "pages": [
+                33
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "District-level only, though the district's single integrated TSDF sits at Dabaspet in Nelamangala taluk.",
+              "metrics": [
+                {
+                  "label": "Integrated TSDF at Dabaspet (taluk-level fact)",
+                  "value": "1"
+                }
+              ],
+              "pages": [
+                38
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "No ULB-specific e-waste data; no collection centre in this ULB.",
+              "pages": [
+                40,
+                41
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "No ULB-specific water quality data.",
+              "pages": [
+                46
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Generates 2.9 MLD sewage with no STP and 0% UGD coverage; CFE for a 16 MLD STP is obtained but work has not started.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "2.9 MLD"
+                },
+                {
+                  "label": "STP",
+                  "value": "None; CFE obtained for 16 MLD STP, work not yet started"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "0% (100% gap)"
+                }
+              ],
+              "openActions": [
+                "Build 16 MLD STP (CFE obtained) | ULB + KUWS&DB | 31-3-2023",
+                "Lay 100% of UGD network | ULB + KUWS&DB + Dept of Urban Development | 31-3-2022"
+              ],
+              "pages": [
+                47,
+                53,
+                54,
+                55,
+                57
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Industrial wastewater reported district-wide from three KSPCB regional offices including RO Nelamangala.",
+              "pages": [
+                58
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "No ULB-level air quality data or station.",
+              "pages": [
+                43
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Mining reported only at district level.",
+              "pages": [
+                61
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Noise reported only at district level.",
+              "pages": [
+                62,
+                63
+              ]
             }
           ]
         },
         {
-          "stream": "Construction & demolition waste",
-          "medium": "solid",
-          "sector": "construction",
-          "granularity": "taluk",
-          "magnitude": {
-            "perDay": 3.0,
-            "unit": "TPD"
+          "key": "devanahalli-tmc",
+          "name": "Devanahalli",
+          "type": "TMC",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "DEVANAHALLI"
+            ]
           },
-          "summary": "Construction & demolition waste.",
-          "metrics": [
+          "themes": [
             {
-              "label": "C&D waste generated",
-              "value": "3.0 TPD (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "solid-waste",
+              "summary": "Devanahalli TMC (6,397 households, 17 TPD) source-segregates in 15 of 23 wards, sweeps only 80 of 159.3 km of roads with a 17-worker manpower deficit, and has 18,000 t of legacy waste at its single old dumpsite.",
+              "metrics": [
+                {
+                  "label": "Solid waste generated",
+                  "value": "17 TPD (6,397 households, pop 28,051)"
+                },
+                {
+                  "label": "Wards with 100% source segregation",
+                  "value": "15 of 23 (gap 8)"
+                },
+                {
+                  "label": "Road sweeping",
+                  "value": "80 of 159.30 km (gap 79.30 km)"
+                },
+                {
+                  "label": "Sweeping manpower",
+                  "value": "65 available vs 82 required (gap -17)"
+                },
+                {
+                  "label": "Door-to-door collection",
+                  "value": "100% of 23 wards"
+                },
+                {
+                  "label": "Wet-waste facility",
+                  "value": "2 existing, needs upgradation"
+                },
+                {
+                  "label": "MRF",
+                  "value": "2 existing, 1 functional, 1 needs upgradation"
+                },
+                {
+                  "label": "Sanitary landfill",
+                  "value": "None (1 required)"
+                },
+                {
+                  "label": "Legacy waste",
+                  "value": "18,000 t at 1 old dumpsite"
+                },
+                {
+                  "label": "Bulk generators with onsite composting",
+                  "value": "0 of 7"
+                },
+                {
+                  "label": "Domestic hazardous waste deposition centre",
+                  "value": "0 of 1"
+                }
+              ],
+              "openActions": [
+                "Close manpower gap of 17 sweepers | ULB | 31-03-2022",
+                "Achieve 100% source segregation in remaining 8 wards | ULB | 31-03-2022",
+                "Construct sanitary landfill | ULB | 31-3-2023",
+                "Remediate 18,000 t legacy dumpsite | ULB | 31-3-2023"
+              ],
+              "pages": [
+                7,
+                8,
+                9,
+                10,
+                15,
+                16,
+                18,
+                19,
+                20,
+                21,
+                22
+              ]
             },
             {
-              "label": "Recycling facility",
-              "value": "None in the district (DEP 2021)"
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "plastic-waste",
+              "summary": "Generates 1.19 TPD plastic waste with 100% door-to-door dry-waste collection.",
+              "metrics": [
+                {
+                  "label": "Plastic waste generated",
+                  "value": "1.19 TPD"
+                }
+              ],
+              "openActions": [
+                "Establish PW collection centre and recycler linkage | ULB + KSPCB | 31-3-2022"
+              ],
+              "pages": [
+                24,
+                25
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "covered",
+              "subtheme": "cd-waste",
+              "summary": "Reports 0.1 TPD C&D waste, the district's lowest.",
+              "metrics": [
+                {
+                  "label": "C&D waste generated",
+                  "value": "0.1 TPD"
+                }
+              ],
+              "openActions": [
+                "District C&D collection/deposition points | ULB + District administration | 31-3-2022"
+              ],
+              "pages": [
+                30,
+                31
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "biomedical-waste",
+              "summary": "No Devanahalli-specific BMW data; served by district CBWTFs.",
+              "pages": [
+                33
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "hazardous-waste",
+              "summary": "Hazardous waste reported only at district level.",
+              "pages": [
+                38,
+                39
+              ]
+            },
+            {
+              "theme": "waste-management",
+              "status": "district-level",
+              "subtheme": "e-waste",
+              "summary": "No ULB-specific e-waste data; no collection centre in this ULB.",
+              "pages": [
+                40,
+                41
+              ]
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level",
+              "summary": "No ULB-specific water quality data.",
+              "pages": [
+                46
+              ]
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "covered",
+              "summary": "Generates 1.0 MLD sewage handled by individual septic tanks/soak pits plus a 6 KLD faecal sludge treatment plant; the plan contradicts itself on whether UGD is still needed.",
+              "metrics": [
+                {
+                  "label": "Sewage generated",
+                  "value": "1.0 MLD"
+                },
+                {
+                  "label": "STP",
+                  "value": "None; FSTP of 6 KLD provided"
+                },
+                {
+                  "label": "UGD coverage",
+                  "value": "0% (p56 says 'Need to provide UGD'; p57 says FSTP established so 'No Need to provide UGD')",
+                  "ocr-uncertain": true
+                }
+              ],
+              "openActions": [
+                "Provide UGD system connected to an STP (per gap analysis p56) | ULB + KUWS&DB | 31-3-2023"
+              ],
+              "pages": [
+                47,
+                53,
+                54,
+                56,
+                57
+              ]
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level",
+              "summary": "Industrial wastewater reported only at district level.",
+              "pages": [
+                58
+              ]
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level",
+              "summary": "No ULB station; the district's only CAAQM is at BIAL airport premises (Devanahalli taluk), operated privately.",
+              "metrics": [
+                {
+                  "label": "CAAQM at BIAL airport (taluk-level fact)",
+                  "value": "1, operated by Bangalore International Airport Ltd"
+                }
+              ],
+              "pages": [
+                43,
+                44
+              ]
+            },
+            {
+              "theme": "mining",
+              "status": "district-level",
+              "summary": "Mining reported only at district level.",
+              "pages": [
+                61
+              ]
+            },
+            {
+              "theme": "noise",
+              "status": "district-level",
+              "summary": "Noise reported only at district level.",
+              "pages": [
+                62,
+                63
+              ]
             }
           ],
-          "sources": [
+          "note": "Basin-edge ULB; the taluk drains partly to the Arkavathi's Kumudavathi flank."
+        },
+        {
+          "key": "bashettihalli-tp",
+          "name": "Bashettihalli",
+          "type": "TP",
+          "note": "Verified: this TP appears nowhere in the plan (its ULB roster stops at 5 ULBs). District-wide figures apply.",
+          "mapMatch": {
+            "family": "admin-town",
+            "prop": "name",
+            "values": [
+              "BASHETTIHALLI"
+            ]
+          },
+          "themes": [
             {
-              "source": "Chikkaballapura DEP 2021",
-              "says": "C&D waste generation (per ULB), Chikkaballapura: 3.0 MT/day. No C&D recycling facility in the district.",
-              "citation": "(iii) C&D Waste, p.62 (printed)",
-              "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+              "theme": "waste-management",
+              "status": "district-level"
+            },
+            {
+              "theme": "water-quality",
+              "status": "district-level"
+            },
+            {
+              "theme": "domestic-sewage",
+              "status": "district-level"
+            },
+            {
+              "theme": "industrial-wastewater",
+              "status": "district-level"
+            },
+            {
+              "theme": "air-quality",
+              "status": "district-level"
+            },
+            {
+              "theme": "mining",
+              "status": "district-level"
+            },
+            {
+              "theme": "noise",
+              "status": "district-level"
             }
           ]
         }
       ],
-      "conflicts": [
-        "The DEP's sewage-generation figure for Chikkaballapura is inconsistent - one table gives 3.5 MLD while another replaces the number with 'work taken up by KMRP'."
+      "taluks": [
+        {
+          "key": "doddaballapura",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Doddaballapura"
+            ]
+          },
+          "unit": {
+            "name": "Doddaballapura (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "Doddaballapura CMC generates ~5.0 MLD of sewage against a 12 MLD STP, but an incomplete UGD network (20% still uncovered) means sewage bypasses the plant; it is the district's largest solid-waste generator at 35 TPD",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "STP works at 7 of 12 MLD but is directed to upgrade to meet PCB standards; 20% of the sewer network is still incomplete",
+                "metrics": [
+                  {
+                    "label": "Wastewater generated",
+                    "value": "5.0 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Existing STP capacity",
+                    "value": "12 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Present sewage flow rate",
+                    "value": "5 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "STP capacity vs generation",
+                    "value": "Adequate on paper; no MLD shortfall stated (DEP 2021)"
+                  },
+                  {
+                    "label": "UGD (sewer) network coverage",
+                    "value": "80% provided, 20% yet to be completed (DEP 2021)"
+                  },
+                  {
+                    "label": "Compliance / treatment gap",
+                    "value": "Incomplete UGD -> sewage bypasses STP via missing links (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Domestic sewage gap & action plan table (p.55)",
+                    "says": "City Municipal Council, Doddaballapura: Quantity of waste water present 5.0 MLD; Existing STP Capacity 12 MLD; Present Sewage Flow rate 5 MLD. Gap Analysis: 'Due to incomplete UGD network connected to STP there is a missing links bypassing the STP. Thus, these missing links must be intercepted and diverted to existing STP for treatment and Disposal. The existing STP is adequate.'",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Domestic Sewage gap analysis table, p.55",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  },
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Underground sewerage network table (p.57)",
+                    "says": "City Municipal Council, Doddaballapura: Status of Sewerage Network 'Provided with UGD System'; % Sewerage network provided 80%; % yet to be completed 20%. Gap Analysis: '20% of the UGD work needs to be completed.'",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Underground sewerage network table, p.57",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 5.0,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "The KIADB Apparel Park CETP, built in 2021 for dyeing-unit effluent, is non-operational",
+                "metrics": [
+                  {
+                    "label": "District industries discharging",
+                    "value": "151 (DEP 2021)"
+                  },
+                  {
+                    "label": "District trade effluent",
+                    "value": "14.354 MLD; 2 common facilities; 26 of 160 non-compliant (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "District-wide: 151 industries discharge wastewater, 14.354 MLD, 2 common effluent treatment facilities, 26 of 160 monitored non-compliant.",
+                    "citation": "Bengaluru Rural DEP 2021, p.58",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 14.354,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "Doddaballapura CMC is the district's largest urban solid-waste generator at 35 tons/day (31 wards, ~93,105 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage; its downstream tables are collection/segregation gap percentages only.",
+                "metrics": [
+                  {
+                    "label": "Solid waste generated",
+                    "value": "35 tons/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Wards / population (Doddaballapura CMC)",
+                    "value": "31 wards; ~93,105 population (DEP 2021)"
+                  },
+                  {
+                    "label": "Solid waste processed",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  },
+                  {
+                    "label": "Legacy / dumpsite waste",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
+                    "says": "City Municipal Council Doddaballapura: No. of House holds 26059; Population 93105; Solid Waste Generated 35 Tons per day. (Other ULBs: Hoskote CMC 25 TPD; Nelamangala CMC 30 TPD; Devanahalli Town MC 17 TPD; Vijayapura Town MC 18 TPD. Village/Gram Panchayats 198.184 MT/day theoretical at 200 gm/head/day; actual not available.)",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 35.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 23.2,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "286 (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
+                    "citation": "V. Hazardous Waste Management, p.38",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 2.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "3 (DEP 2021)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
+                    "citation": "(iv) Bio-Medical Waste Management, p.35",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "district",
+                "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district; no C&D reuse policy (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
+                    "citation": "(iii) C&D Waste Management, p.30-32",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~22% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~1,450"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~580+",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Doddaballapura RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Doddaballapura RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Doddaballapura.pdf"
+                  }
+                ]
+              }
+            ],
+            "caveats": [
+              "The STP has spare capacity (12 MLD vs ~5 MLD generated), but 20% of the area has no sewer line - so that share of sewage isn't collected or treated. Adequate capacity doesn't mean full treatment."
+            ]
+          }
+        },
+        {
+          "key": "nelamangala",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Nelamangala"
+            ]
+          },
+          "unit": {
+            "name": "Nelamangala (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "Nelamangala CMC has no operating STP (capacity and flow both 0 MLD) against 2.9 MLD of wastewater; the DEP says an STP is 'to be established' though it reports the UGD network as 100% provided; 30 TPD solid waste",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "No STP and effectively no sewer network laid - the full 2.9 MLD is untreated",
+                "metrics": [
+                  {
+                    "label": "Sewage generated",
+                    "value": "2.9 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "STP capacity",
+                    "value": "0 MLD - no STP (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "UGD network",
+                    "value": "Nominally 'provided' but 0% laid; 100% of UGD work yet to be completed (DEP 2021, p.57)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Action plan",
+                    "value": "'STP to be established' (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 (p.55,57, image-verified)",
+                    "says": "Nelamangala CMC: 2.9 MLD generated, 0 MLD STP, 0 MLD treated; sewerage network 0% provided / 100% of UGD work yet to be completed; action plan 'STP to be established'.",
+                    "citation": "Bengaluru Rural DEP 2021, p.55, 57",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 2.9,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "Reported district-wide only (all of Bengaluru Rural), not per taluk. District-wide: 151 industries discharge wastewater generating 14.354 MLD; NIL treated industrial wastewater discharged to nalas/rivers; 2 Common Effluent Treatment Facilities; 134 industries compliant, 26 non-compliant. Note Nelamangala hosts one of KSPCB's two regional F-Register offices for the district.",
+                "metrics": [
+                  {
+                    "label": "Industries discharging wastewater (district-wide, not taluk-level)",
+                    "value": "151 Nos. (DEP 2021)"
+                  },
+                  {
+                    "label": "Industrial wastewater generated (district-wide, not taluk-level)",
+                    "value": "14.354 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Common Effluent Treatment Facilities (district-wide)",
+                    "value": "2 Nos. (DEP 2021)"
+                  },
+                  {
+                    "label": "Industries NOT meeting discharge standards (district-wide)",
+                    "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Operating industries by KSPCB category (district-wide)",
+                    "value": "Red 174 / Orange 275 / Green 681 / White 97 (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Industrial waste water management (p.58)",
+                    "says": "As per the F-Reg maintained in the Regional office Hoskote, Regional office Nelamangala, KSPCB as on 31-03-2021: Red 174; Orange 275; Green 681; White 97. No of Industries discharging waste water 151 Nos.; Total Quantity of industrial waste water generated 14.354 MLD; Quantity of treated industrial waste water discharged into Nalas/Rivers NIL; Common Effluent Treatment Facilities 2 Nos.; Industries meeting discharge Standards 134 Nos.; Industries not meeting discharge Standards 26 Nos.",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Industrial Wastewater Management section, p.58 (KSPCB F-Register as on 31-03-2021)",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 14.354,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "Nelamangala CMC generates 30 tons/day (31 wards, ~70,393 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage.",
+                "metrics": [
+                  {
+                    "label": "Solid waste generated",
+                    "value": "30 tons/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Wards / population (Nelamangala CMC)",
+                    "value": "31 wards; ~70,393 population (DEP 2021)"
+                  },
+                  {
+                    "label": "Solid waste processed",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  },
+                  {
+                    "label": "Legacy / dumpsite waste",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
+                    "says": "City Municipal Council Nelamanagala: No. of House holds 17604; Population 70393; Solid Waste Generated 30 Tons per day.",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 30.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 23.2,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, district-wide. The district's only integrated TSDF (treatment-storage-disposal) is sited in Nelamangala taluk, at Dabaspet.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "286 (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
+                    "citation": "V. Hazardous Waste Management, p.38",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 2.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "3 (DEP 2021)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
+                    "citation": "(iv) Bio-Medical Waste Management, p.35",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "district",
+                "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district; no C&D reuse policy (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
+                    "citation": "(iii) C&D Waste Management, p.30-32",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Industrial register (KSPCB, 2019)",
+                "summary": "Consented industries on KSPCB's F-register, by pollution-potential colour. ~29% of colour codes were unreadable in the scan, so the Red/Orange count is a floor.",
+                "metrics": [
+                  {
+                    "label": "Consented industries (2019)",
+                    "value": "~1,950"
+                  },
+                  {
+                    "label": "Red + Orange (higher pollution)",
+                    "value": "~560+",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "KSPCB F-register (Nelamangala RO)",
+                    "says": "Regional-Office register of industries holding Water/Air Act consent, as on 31-03-2019, listed by size and colour category.",
+                    "citation": "KSPCB F-register, Nelamangala RO, 2019 (OCR-extracted from scanned PDF; counts approximate)",
+                    "url": "https://kspcb.karnataka.gov.in/sites/default/files/inline-files/Nelamangala.pdf"
+                  }
+                ]
+              }
+            ],
+            "conflicts": [
+              "The DEP labels the sewerage status 'Provided with UGD System', yet the same table records 0% of the network actually laid (100% still to be completed) and there is no STP."
+            ]
+          }
+        },
+        {
+          "key": "devanahalli",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Devanahalli"
+            ]
+          },
+          "unit": {
+            "name": "Devanahalli (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "Devanahalli Town MC has no UGD sewer system at all (0% implemented) and 0 MLD STP against 1.0 MLD wastewater; the DEP records a sanctioned Sludge Treatment Plant in lieu of UGD; 17 TPD solid waste",
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "No UGD network and no conventional STP; relies on a faecal sludge treatment plant - the DEP's own tables disagree on what's needed",
+                "metrics": [
+                  {
+                    "label": "Sewage generated",
+                    "value": "1.0 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Conventional STP",
+                    "value": "0 MLD - no STP (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "UGD network",
+                    "value": "None implemented (DEP 2021, p.57)"
+                  },
+                  {
+                    "label": "Faecal sludge",
+                    "value": "Devanahalli FSTP - CDD Society / BORDA, 6 KLD, operational since Nov 2015. India's first municipal-scale FSTP (625 m2, ~4,000 households); treats ~100% of collected septage via screening, solid-liquid separation, anaerobic baffled reactor, planted gravel filter and co-composting.",
+                    "emphasis": "good"
+                  },
+                  {
+                    "label": "Plan inconsistency",
+                    "value": "p.55-56 says 'provide UGD+STP'; p.57 says 'FSTP provided, no UGD needed' (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 (p.55-57, image-verified)",
+                    "says": "Devanahalli TMC: 1.0 MLD generated, 0 MLD STP, houses on septic tanks/soak pits. p.57 sewerage table: 'There is no UGD System implemented'; gap analysis 'Provided faecal Sludge Treatment Plant and Using. No Need to provide UGD system' - while p.55-56 lists 'Need to provide UGD system connected to STP'.",
+                    "citation": "Bengaluru Rural DEP 2021, p.55-57",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  },
+                  {
+                    "source": "FSM Toolbox / CSE / WRI India - Devanahalli FSTP case study",
+                    "says": "Devanahalli Town Municipal Council, with CDD Society and BORDA, set up a 6,000 L/day faecal sludge treatment plant operational since Nov 2015 - India's first municipal FSTP - serving ~4,000 households and treating 100% of the town's collected septage.",
+                    "citation": "Devanahalli FSTP case study (CDD/BORDA); WRI India, CSE India",
+                    "url": "https://wri-india.org/blogs/lessons-devanahalli-urban-faecal-sludge-management"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 1.0,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "Reported district-wide only (all of Bengaluru Rural), not per taluk. District-wide: 151 industries discharge wastewater generating 14.354 MLD; NIL treated industrial wastewater discharged to nalas/rivers; 2 Common Effluent Treatment Facilities; 134 industries compliant, 26 non-compliant. (Devanahalli taluk also hosts the BIAL airport/KIADB industrial cluster, but the DEP does not give a taluk-level effluent split.)",
+                "metrics": [
+                  {
+                    "label": "Industries discharging wastewater (district-wide, not taluk-level)",
+                    "value": "151 Nos. (DEP 2021)"
+                  },
+                  {
+                    "label": "Industrial wastewater generated (district-wide, not taluk-level)",
+                    "value": "14.354 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Common Effluent Treatment Facilities (district-wide)",
+                    "value": "2 Nos. (DEP 2021)"
+                  },
+                  {
+                    "label": "Industries NOT meeting discharge standards (district-wide)",
+                    "value": "26 Nos. of 160 monitored (134 compliant) (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "Operating industries by KSPCB category (district-wide)",
+                    "value": "Red 174 / Orange 275 / Green 681 / White 97 (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Industrial waste water management (p.58)",
+                    "says": "As per the F-Reg maintained in the Regional office Hoskote, Regional office Nelamangala, KSPCB as on 31-03-2021: Red 174; Orange 275; Green 681; White 97. No of Industries discharging waste water 151 Nos.; Total Quantity of industrial waste water generated 14.354 MLD; Quantity of treated industrial waste water discharged into Nalas/Rivers NIL; Common Effluent Treatment Facilities 2 Nos.; Industries meeting discharge Standards 134 Nos.; Industries not meeting discharge Standards 26 Nos.",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Industrial Wastewater Management section, p.58 (KSPCB F-Register as on 31-03-2021)",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 14.354,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "Devanahalli Town MC generates 17 tons/day (the smallest of the five district ULBs; ~28,051 population). The DEP does not publish a per-ULB processed-quantity or legacy-waste tonnage.",
+                "metrics": [
+                  {
+                    "label": "Solid waste generated",
+                    "value": "17 tons/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Wards / population (Devanahalli Town MC)",
+                    "value": "~6,397 households; ~28,051 population (DEP 2021)"
+                  },
+                  {
+                    "label": "Solid waste processed",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  },
+                  {
+                    "label": "Legacy / dumpsite waste",
+                    "value": "Not tabulated per ULB in this DEP (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021 - Solid Waste Management current-status table (p.7)",
+                    "says": "Town Municipal Council Devanahalli: No. of House holds 6397; Population 28051; Solid Waste Generated 17 Tons per day.",
+                    "citation": "District Environmental Plan for Bengaluru Rural District, Solid Waste Management current status, p.7",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 17.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 23.2,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "8,453.57 MT/yr ≈ 23.2 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "4,070.89 / 2,190.730 / 2,187.84 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "286 (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "01 integrated TSDF in the district, at Dabaspet (Nelamangala taluk); no SLF, no standalone incinerators, no contaminated sites. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "No of Industries generating HW: 286. Quantity of HW in the District: 8453.57 MT/Annum; Incinerable 4070.89; land-fillable 2190.73; recyclable/utilizable 2187.84. Integrated TSDF 01 (Dabaspet, Nelamangala Taluk); SLF Nil; standalone incinerators NIL; contaminated sites NIL.",
+                    "citation": "V. Hazardous Waste Management, p.38",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 2.29,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "2.3 t/day ≈ 2.29 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "3 (DEP 2021)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "03 CBMWTF serve the district (within 75 km); generated = disposed. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "Total BMW generated in the District (Annual report 2019): 2292.96 kg/day; disposed 2292.96 kg/day; 03 Nos. CBMWTF within 75 km.",
+                    "citation": "(iv) Bio-Medical Waste Management, p.35",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "district",
+                "summary": "Construction & demolition waste - the DEP's table is left blank, so no quantity is on record.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "Not furnished - the per-ULB quantity column is blank in the DEP table (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district; no C&D reuse policy (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Bengaluru Rural DEP 2021",
+                    "says": "The C&D current-status table lists the 5 ULBs and a Total row but every quantity cell is blank ('As per the information furnished by the ULB's' - none furnished). 'There is no C & D Recycling facility in the District.'",
+                    "citation": "(iii) C&D Waste Management, p.30-32",
+                    "url": "https://cdn.s3waas.gov.in/s3aba3b6fd5d186d28e06ff97135cade7f/uploads/2022/04/2022040179.pdf"
+                  }
+                ]
+              }
+            ],
+            "conflicts": [
+              "The DEP differ froms itself: the sewerage table (p.55-56) says 'provide UGD system connected to STP', while the gap-analysis table (p.57) says a faecal sludge treatment plant is already provided and 'no need to provide UGD system'."
+            ]
+          }
+        }
+      ],
+      "industrialAreas": [
+        {
+          "name": "Doddaballapura General",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Doddaballapura General"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Doddaballapura Industrial Area 3rd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Doddaballapura Industrial Area 3rd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Doddaballapura Industrial Area 4th Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Doddaballapura Industrial Area 4th Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Apparel Park 1st Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Apparel Park 1st Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Apparel Park 2nd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Apparel Park 2nd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Dobaspet 1st and 2nd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Dobaspet 1st and 2nd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Dabaspet 4th Phase Avverahalli",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Dabaspet 4th Phase Avverahalli"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Dabaspete 5th Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Dabaspete 5th Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        },
+        {
+          "name": "Sompura 1st and 2nd Phase",
+          "mapMatch": {
+            "family": "pressures-industrial",
+            "prop": "name",
+            "values": [
+              "Sompura 1st and 2nd Phase"
+            ],
+            "kinds": [
+              "industrial-area"
+            ]
+          }
+        }
       ]
     },
-    "yelahanka": {
-      "name": "Yelahanka (taluk; BBMP/BWSSB)",
-      "level": "Taluk",
-      "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
-      "headline": "STP operational and complying, with a second plant being added - one of the better-served parts of the basin",
-      "streams": [
+    {
+      "key": "chikkaballapura",
+      "name": "Chikkaballapura",
+      "dep": {
+        "label": "Chikkaballapura DEP 2021 (scanned)",
+        "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+      },
+      "pctInBasin": 0.2,
+      "counts": [
         {
-          "stream": "Sewage",
-          "summary": "STP complying with capacity to spare; per-ULB generation isn't separately reported (BBMP city-wide)",
-          "metrics": [
-            {
-              "label": "Per-ULB sewage generated",
-              "value": "Not separately reported - BBMP city-wide (DEP 2022)"
-            }
-          ],
-          "sources": [],
-          "medium": "liquid",
-          "sector": "public",
-          "granularity": "taluk"
+          "label": "ULBs inside the basin",
+          "value": "None - only a headwater sliver (2 gram panchayats) drains this way"
         },
         {
-          "stream": "Industrial hazardous waste",
-          "medium": "solid",
-          "sector": "industry",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 203.9,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Industrial hazardous waste, district-wide. Bengaluru Urban's one recorded contaminated site - the Mavallipura dumpsite (manganese in groundwater) - is in Yelahanka.",
+          "label": "Gram Panchayats (district-wide)",
+          "value": "157 (per the plan)"
+        }
+      ],
+      "countsNote": "Only ~0.2% of the district (the Arkavathi's headwater flank near Nandi Hills) is in the basin, so this plan is district-level context only. Scanned document; OCR-read figures.",
+      "mapMatch": {
+        "family": "admin-district",
+        "prop": "name",
+        "values": [
+          "Chikkaballapura"
+        ]
+      },
+      "districtThemes": [
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "solid-waste",
+          "summary": "Gram panchayats generate 279.2 TPD of solid waste (GP-wise table for all 157 GPs) and the 6 ULBs achieve 100% door-to-door collection with 137 of 158 wards at 100% source segregation, supported by street-category-wise sweeping plans.",
           "metrics": [
             {
-              "label": "Hazardous waste generated (district)",
-              "value": "74,416.29 MT/yr ≈ 203.9 t/day (DEP 2022)"
+              "label": "GP solid waste generated",
+              "value": "279.2 TPD (total row: 1,499 villages, 235,557 households, pop 1,118,172)"
             },
             {
-              "label": "Incinerable / land-fillable / recyclable",
-              "value": "12,963.63 / 16,429.380 / 45,023.44 MT/yr (DEP 2022)"
+              "label": "ULB wards with 100% source segregation",
+              "value": "137 of 158 (Chikkaballapura 31/31, Chinthamani 31/31, Sidlaghatta 30/31, Gowribidanur 25/31, Bagepalli 19/23, Gudibande 11/11)"
             },
             {
-              "label": "HW-generating industries (district)",
-              "value": "1718 (DEP 2022)"
+              "label": "Door-to-door collection",
+              "value": "100% in all 158 wards of 6 ULBs"
             },
             {
-              "label": "Disposal facilities",
-              "value": "No integrated TSDF and no SLF in the district; 02 standalone incinerators; HW sent to authorised facilities outside the district under MoU. 1 contaminated site: Mavallipura dumpsite, Yelahanka (manganese exceeding standard, 15.02.2022). (DEP 2022)",
-              "emphasis": "bad"
+              "label": "Road sweeping (A/B/C/D category streets)",
+              "value": "Chikkaballapura 137 km, Chinthamani 105 km, Sidlaghatta 71 km, Gowribidanur 72 km, Bagepalli 36 km, Gudibande 26 km"
             }
           ],
-          "sources": [
+          "openActions": [
+            "Achieve 100% source segregation via IEC, SHGs/NGOs door-to-door awareness and household awards; complete segregated collection in Sidlaghatta, Gowribidanur and Bagepalli | ULB's | 30/11/2021 (printed 'bo/11/2021')",
+            "Reduce sweeping gaps by category-wise street frequency plans | ULB's | NA"
+          ],
+          "pages": [
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47
+          ],
+          "ocrUncertain": true
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "plastic-waste",
+          "summary": "ULBs generate 4.44 TPD of plastic waste with dry-waste collection centres in 5 of 6 ULBs and 151 of 157 village panchayat PW collection centres in place, backed by spot-fine enforcement that has collected about Rs 3 lakh.",
+          "metrics": [
             {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "KSPCB identified 1718 HW-generating industries (all authorised). Quantity of HW: 74416.29 MT/annum; Incinerable 12963.63; land-fillable 16429.38; recyclable/utilizable 45023.44. Integrated TSDF Nil; SLF Nil; standalone incinerators 02. Contaminated site: Mavallipura dumpsite, Yelahanka (Manganese exceeding standard).",
-              "citation": "V. Hazardous Waste Management, p.45",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
+              "label": "ULB plastic waste generated",
+              "value": "4.44 TPD (Chikkaballapura 1.5, Chinthamani 1.5, Sidlaghatta 0.8, Gowribidanur 0.5, Bagepalli 0.09, Gudibande 0.05)"
+            },
+            {
+              "label": "GP plastic waste generated (as printed)",
+              "value": "167.52 TPD total across GP-wise table (per-GP ~0.4-1.5 'TPD'); implausibly high vs 4.44 TPD for ULBs - unit likely kg/day in reality",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "Dry waste collection centres",
+              "value": "Set up in 5 ULBs; CMC Gowribidanur tender invited"
+            },
+            {
+              "label": "Village panchayat PW collection centres",
+              "value": "151 of 157 (balance 6)"
+            },
+            {
+              "label": "Fines collected for banned plastic",
+              "value": "~Rs 3 lakh via spot-fine machines, all ULBs"
             }
+          ],
+          "openActions": [
+            "Set up two dry-waste collection centres in CMC Gowribidanur; partition all DWCCs | ULB's | 31/12/2021",
+            "Set up PW collection centres at remaining village panchayats | ULB's + concerned village panchayats | 31/12/2021",
+            "Continue IEC via mass media, schools, producer/brand-owner campaigns; KSPCB monitoring of PWM Rules | ULB's + KSPCB | NA"
+          ],
+          "pages": [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59,
+            60,
+            61,
+            62
           ]
         },
         {
-          "stream": "Biomedical (healthcare) waste",
-          "medium": "solid",
-          "sector": "institutional",
-          "granularity": "district",
-          "magnitude": {
-            "perDay": 37.32,
-            "unit": "TPD",
-            "estimated": true
-          },
-          "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "cd-waste",
+          "summary": "ULBs generate 7.2 TPD of C&D waste with no processing or recycling facility in the district, though user fees have been fixed by Deputy Commissioner order.",
           "metrics": [
             {
-              "label": "Biomedical waste generated (district)",
-              "value": "37.3 t/day ≈ 37.32 t/day (DEP 2022)"
+              "label": "C&D waste generated (ULBs)",
+              "value": "7.2 TPD (Chikkaballapura 3, Chinthamani 2, Sidlaghatta 0.5, Gowribidanur 1, Bagepalli 0.5, Gudibande 0.2); total verified visually at 300 dpi"
             },
             {
-              "label": "Treatment facilities (CBMWTF)",
-              "value": "5 (DEP 2022)"
+              "label": "C&D processing/recycling facility",
+              "value": "None in district"
             },
             {
-              "label": "Notes",
-              "value": "5 CBMWTF (all outside the district) serve it; 1,559 bedded + 8,877 non-bedded HCFs; 538.733 MT Covid-19 waste (2020-21). Generated = treated. (DEP 2022)"
+              "label": "User fee on C&D waste",
+              "value": "Fixed per Deputy Commissioner order"
             }
           ],
-          "sources": [
-            {
-              "source": "Bengaluru Urban DEP 2022",
-              "says": "Inventory of BMW: 1559 bedded + 8877 non-bedded HCF; 37.321 Tons/day generated and treated; 538.733 MT Covid-19 waste (2020-21); disposed through 5 CBMWTF (all outside the district).",
-              "citation": "(iv) Bio-Medical Waste Management, p.40",
-              "url": "https://cdn.s3waas.gov.in/s33621f1454cacf995530ea53652ddf8fb/uploads/2022/05/2022050419.pdf"
-            }
+          "openActions": [
+            "Identify and develop separate land for C&D processing; identify bulk generators; collection points per taluk, deposition points at district HQ | ULB's + District Administration | 31/08/2022 (printed '1/08/2022' at p64)",
+            "Set up C&D recycling facility | ULB's + District administration + Town Planning Department | 31/08/2022",
+            "Frame usage of recycled C&D material in non-structural works with PWD | ULB's + District administration + PWD | 31/08/2022",
+            "C&D awareness IEC | ULB's + KSPCB | 31/12/2021"
+          ],
+          "pages": [
+            63,
+            64,
+            65,
+            66
           ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "biomedical-waste",
+          "summary": "All 378.221 kg/day of biomedical waste from 578 healthcare facilities is treated via 2 CBWTFs (Prajwal Gowribidanur and Meera Envirotech Kolar), but 91 of 197 lapsed HCE authorizations under BMW Rules 2016 remain unrenewed.",
+          "metrics": [
+            {
+              "label": "Bedded / non-bedded HCFs",
+              "value": "225 / 353"
+            },
+            {
+              "label": "HCFs authorized by KSPCB",
+              "value": "382 (status table p67); action table p68 lists 578 authorized HCEs by category",
+              "ocr-uncertain": true
+            },
+            {
+              "label": "CBWTFs",
+              "value": "2 (M/s Prajwal BMW, Gowribidanur: incinerator 200 kg/hr, autoclave 400 L/cycle; M/s Meera Envirotech, Kolar: 100 kg/hr, 350 L)"
+            },
+            {
+              "label": "BMW generated = treated",
+              "value": "378.221 kg/day"
+            },
+            {
+              "label": "Deep burial pits",
+              "value": "None in Govt HCFs"
+            },
+            {
+              "label": "HCEs with lapsed authorization",
+              "value": "197 expired; 106 renewed with lifetime authorization, 91 pending under inspection/notices"
+            }
+          ],
+          "openActions": [
+            "Renew BMW Rules 2016 authorization for remaining 91 HCEs (notices served, monitoring by inspection) | Health Department + KSPCB | 31/12/2021",
+            "Mandate HCE MoUs with CBMWTF | Health Department + KSPCB | 31/12/2021",
+            "Extend bar-code implementation beyond some Government Hospitals; awareness/training on segregation and disposal | Health Department + KSPCB | not stated"
+          ],
+          "pages": [
+            67,
+            68,
+            69,
+            70,
+            71,
+            72
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "hazardous-waste",
+          "summary": "38 KSPCB-authorized industries generate 398.82 MT/annum of hazardous waste disposed through authorized TSDFs/recyclers outside the district (no TSDF, SLF or incinerator in-district), with the e-manifest system in force and no contaminated sites.",
+          "metrics": [
+            {
+              "label": "Industries generating hazardous waste",
+              "value": "38 (all authorized by KSPCB)"
+            },
+            {
+              "label": "Hazardous waste quantity",
+              "value": "398.82 MT/annum (incinerable 143.90; landfillable 194.29; recyclable/utilizable 60.63)"
+            },
+            {
+              "label": "TSDF / SLF / standalone incinerator in district",
+              "value": "Nil / Nil / Nil"
+            },
+            {
+              "label": "Contaminated sites",
+              "value": "Nil"
+            },
+            {
+              "label": "Used-oil recycling industry",
+              "value": "1 (M/s Lakshmi Refineries, Gowribidanur) with trained staff"
+            }
+          ],
+          "openActions": [
+            "Open separate domestic hazardous waste compartments at dry-waste collection centres | ULB's | 31/12/2021",
+            "6-monthly refresher training for recycling-industry staff | Oil recycling industry + KSPCB | 31/01/2022"
+          ],
+          "pages": [
+            73,
+            74,
+            75
+          ]
+        },
+        {
+          "theme": "waste-management",
+          "status": "covered",
+          "subtheme": "e-waste",
+          "summary": "The district reports a nil e-waste inventory and no ULB or producer collection centres, with one authorized recycler/dismantler (M/s Prakruthi Recycling, Gowribidanur) and household e-waste currently routed through dry-waste collection centres.",
+          "metrics": [
+            {
+              "label": "E-waste inventory",
+              "value": "Nil MT/year"
+            },
+            {
+              "label": "Collection centres (ULB / producer-PRO)",
+              "value": "Nil / Nil"
+            },
+            {
+              "label": "Authorized e-waste recycler/dismantler",
+              "value": "1 (M/s Prakruthi Recycling Pvt Ltd, Kudumalakunte, Gowribidanur taluk)"
+            },
+            {
+              "label": "Bulk e-waste generators identified",
+              "value": "None"
+            },
+            {
+              "label": "Illegal recycling/dismantling identified",
+              "value": "None"
+            }
+          ],
+          "openActions": [
+            "Complete e-waste and bulk-generator inventorisation | ULB's + KSPCB | 31/03/2022",
+            "Identify/register e-waste collection centres with producers/PROs/recyclers | ULB's | 31/01/2022",
+            "All ULBs to execute MoU with recycler/dismantler to channelize household e-waste | ULB's | 31/01/2022"
+          ],
+          "pages": [
+            76,
+            77,
+            78,
+            79,
+            80
+          ]
+        },
+        {
+          "theme": "water-quality",
+          "status": "covered",
+          "summary": "A district with no perennial rivers (North Pennar, South Pennar and Palar basins) relies on 201 tanks (including 32 HN Valley tanks receiving treated Bengaluru water) and heavily stressed groundwater - 45,116 borewells, fluoride contamination in Bagepalli/Gudibande/Chinthamani and nitrate/hardness in the rest - with 22 KSPCB-monitored lakes meeting only class D criteria and no environmental monitoring cell.",
+          "metrics": [
+            {
+              "label": "River basins",
+              "value": "North Pennar, South Pennar, Palar - none perennial"
+            },
+            {
+              "label": "Lakes/tanks",
+              "value": "201 tanks incl. 32 HN Valley project tanks; 27,106.42 ha; 169 tanks hold potable water"
+            },
+            {
+              "label": "ULB sewage",
+              "value": "13.1 MLD total"
+            },
+            {
+              "label": "Industrial wastewater",
+              "value": "1.61 MLD from 39 industries, treated and recycled/on-land disposed"
+            },
+            {
+              "label": "Borewells / groundwater extraction permissions",
+              "value": "45,116 borewells; 3,935 permissions"
+            },
+            {
+              "label": "Groundwater polluted areas",
+              "value": "Fluoride: Bagepalli, Gudibande, Chinthamani; Nitrate + hardness: Gowribidanur, Sidlaghatta, Chikkaballapura"
+            },
+            {
+              "label": "Lakes monitored by KSPCB",
+              "value": "22, meeting class D criteria"
+            },
+            {
+              "label": "Observation borewells (monthly levels)",
+              "value": "51 (baseline water quality data 2017-18 to 2020-21)"
+            },
+            {
+              "label": "Polluted river stretches / sewage joining water bodies",
+              "value": "Nil / none identified (as claimed by the plan)"
+            }
+          ],
+          "openActions": [
+            "Constitute environmental monitoring cell and inventorise all water bodies with quality data | Minor Irrigation + Groundwater authority + Zilla Panchayath + KSPCB + PRED | 31/12/2021",
+            "Increase number of lakes sampled by KSPCB | KSPCB | '31/11/2021' as printed (invalid date)",
+            "Tank rejuvenation estimates incl. Sidlaghatta 4 tanks (Rs 400 lakh) and Chinthamani 4 tanks | Minor Irrigation Department | not stated",
+            "Fix borewell monitoring frequency per CPCB guidelines (currently once in 2 years) and report to district administration | Groundwater authority | not stated",
+            "District-level water quality testing and dissemination; mobile-app complaint redressal | District administration + KSPCB | not stated"
+          ],
+          "pages": [
+            87,
+            88,
+            89,
+            90,
+            91,
+            92,
+            93,
+            94,
+            95,
+            96,
+            97
+          ],
+          "ocrUncertain": true
+        },
+        {
+          "theme": "domestic-sewage",
+          "status": "covered",
+          "summary": "Three of six ULBs have STPs (oxidation ponds totalling 15.1 MLD vs 13.01 MLD Class-II-town sewage) but over 80% of the district's estimated 36.15 MLD design sewage goes untreated, with SBR STP proposals for Chinthamani and Sidlaghatta awaiting government approval and Bagepalli under construction.",
+          "metrics": [
+            {
+              "label": "Class-II towns",
+              "value": "4 (Chikkaballapura, Chinthamani, Sidlaghatta, Gowribidanur); Class-I: 0"
+            },
+            {
+              "label": "STPs installed",
+              "value": "3 (Chikkaballapura 10 MLD, Chinthamani 2 MLD, Sidlaghatta 3.1 MLD - oxidation ponds needing technology upgrade)"
+            },
+            {
+              "label": "Towns needing STPs (incl. upgrades)",
+              "value": "6 of 6"
+            },
+            {
+              "label": "Sewage generated (Class II+)",
+              "value": "13.01 MLD; treatment capacity 15.10 MLD"
+            },
+            {
+              "label": "Untreated sewage (district-wide)",
+              "value": ">80% (8.9 MLD treated of estimated 36.15 MLD design generation)"
+            },
+            {
+              "label": "UGD coverage",
+              "value": "Chikkaballapura 91%, Chinthamani 98%, Sidlaghatta 70%; Gowribidanur, Bagepalli, Gudibande no sewerage network (ST&SP)"
+            },
+            {
+              "label": "Sewage flowing into rivers/lakes",
+              "value": "Nil (as claimed by the plan)"
+            }
+          ],
+          "openActions": [
+            "Chinthamani 6.40 MLD SBR STP + sewer lines - estimate submitted 28-12-2017, awaiting Government approval | ULB + KUWS&DB | NA",
+            "Sidlaghatta 6.60 MLD SBR STP (2nd stage UGD) - estimate submitted, awaiting approval | ULB + KUWS&DB | NA",
+            "Bagepalli 4.30 + 0.55 MLD STPs - work order issued 02/12/2020, completion by September 2022 | KUWS&DB + contractor | Sep-2022",
+            "Gowribidanur UGD via FSSM technology per G.O. dtd 03-12-2018 - work taken up by ULB | ULB + KUWS&DB | NA",
+            "Prepare DPR for UGD scheme for TP Gudibande | ULB + KUWS&DB | NA",
+            "Upgrade the three oxidation-pond STPs to new-technology STPs | ULB's + KUWS&DB + KUIDFC | NA"
+          ],
+          "pages": [
+            88,
+            98,
+            99,
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            106,
+            107
+          ]
+        },
+        {
+          "theme": "industrial-wastewater",
+          "status": "covered",
+          "summary": "Of 196 operating industries (16 red, 59 orange, 113 green, 8 white), 39 discharge 2.15 MLD of wastewater of which 1.61 MLD is treated and recycled or used on land, with all 39 meeting standards, none permitted to discharge to water bodies, and no CETP in the district.",
+          "metrics": [
+            {
+              "label": "Industries by category",
+              "value": "Red 16, Orange 59, Green 113, White 8 (total 196)"
+            },
+            {
+              "label": "Industries discharging wastewater",
+              "value": "39"
+            },
+            {
+              "label": "Industrial wastewater generated / treated",
+              "value": "2.15 MLD generated; 1.61 MLD treated (recycled or on-land disposal)"
+            },
+            {
+              "label": "Discharge to nalas/rivers",
+              "value": "None permitted"
+            },
+            {
+              "label": "CETP",
+              "value": "Nil"
+            },
+            {
+              "label": "Industries meeting / not meeting standards",
+              "value": "39 / Nil"
+            }
+          ],
+          "openActions": [
+            "Continuous CPCB-policy inspection, sampling and enforcement (show-cause, closure directions under Water/Air Acts) | KSPCB | continuous",
+            "Complaint redressal via KSPCB integrated command control centre (mobile app/online) and district phone-in programme | KSPCB + District Administration | existing/ongoing"
+          ],
+          "pages": [
+            108,
+            109,
+            110
+          ]
+        },
+        {
+          "theme": "air-quality",
+          "status": "covered",
+          "summary": "One KSPCB CAAQM station at Chikkaballapura and two private ACC Ltd stations at Gowribidanur report ambient air quality within satisfactory limits despite 161 air-polluting industries, with quarrying/blasting, stone crushers/m-sand clusters (Peresandra and Kanivenarayanapura) and unpaved roads the main sources.",
+          "metrics": [
+            {
+              "label": "CAAQM stations",
+              "value": "1 KSPCB (Junior College premises, Chikkaballapura) + 2 private (M/s ACC Ltd, Gowribidanur)"
+            },
+            {
+              "label": "Manual stations by KSPCB",
+              "value": "Nil"
+            },
+            {
+              "label": "Towns failing NAAQ standards",
+              "value": "Nil"
+            },
+            {
+              "label": "Air polluting industries",
+              "value": "161"
+            },
+            {
+              "label": "Prominent sources",
+              "value": "2 KIADB areas (Kudumalakunte-Gowribidanur, Chikkaballapura), stone crusher/m-sand clusters at Peresandra and Kanivenarayanapura, quarrying with blasting, unpaved roads"
+            },
+            {
+              "label": "Ambient air quality status",
+              "value": "Within satisfactory limits; data public on KSPCB website/CPCB server"
+            }
+          ],
+          "openActions": [
+            "Inventory of air pollution sources and hotspots; convert unpaved roads to paved | District Task Force + Mines & Geology + KSPCB + PWD | 31/03/2022",
+            "District-level air pollution action plan (public transport, green fuels, e-mobility, LPG, NCAP measures) | District administration + Urban Development + Forest + RTO + PWD | 31/03/2022"
+          ],
+          "pages": [
+            81,
+            82,
+            83,
+            84,
+            85,
+            86
+          ]
+        },
+        {
+          "theme": "mining",
+          "status": "covered",
+          "summary": "185 licensed quarry operations (111 building stone, 71 ornamental stone, plus clay/quartz/laterite) cover 0.0768% of the district (3.26 sq km) with no sand mining, and 152 FIRs/PCRs filed since 2013 against illegal activity under an active district task force with an NH-7 check post.",
+          "metrics": [
+            {
+              "label": "Licensed mining operations",
+              "value": "Building stone 111 (457.01 acres), Ornamental stone 71 (256.12 acres), China/Fire/Yellow clay-Red ochre 1, White quartz 1, Laterite 1 (91.30 acres)"
+            },
+            {
+              "label": "% district area under mining",
+              "value": "0.0768% (3.26 sq km)"
+            },
+            {
+              "label": "Sand mining",
+              "value": "NIL"
+            },
+            {
+              "label": "Illegal mining enforcement",
+              "value": "152 FIR/PCR filed 2013-to-date; regular patrolling; check post on NH-7"
+            },
+            {
+              "label": "District task force",
+              "value": "Constituted and in force"
+            }
+          ],
+          "openActions": [
+            "Continue task-force monitoring, patrolling and EC-compliance verification | Mines & Geology Department | Not applicable (already in force)"
+          ],
+          "pages": [
+            111,
+            112,
+            113
+          ]
+        },
+        {
+          "theme": "noise",
+          "status": "covered",
+          "summary": "The district has no fixed ambient noise monitoring stations (ULBs/KSPCB may co-install with the CAAQMS), while sign boards exist at listed sensitive points in Chikkaballapura town and complaints run through KSPCB channels, district phone-in and ERSS 112.",
+          "metrics": [
+            {
+              "label": "Fixed ambient noise monitoring stations",
+              "value": "0 (identified gap)"
+            },
+            {
+              "label": "Sign boards in noise zones",
+              "value": "Present at listed points in Chikkaballapura town limits (Honnenahalli Gate, Chadalapura Gate, Vapasandra Gate, Nimmakala Kunte, etc.)"
+            },
+            {
+              "label": "Complaint channels",
+              "value": "KSPCB mail/post/in-person, integrated command control centre (online/app), district phone-in, ERSS 112"
+            }
+          ],
+          "openActions": [
+            "Install fixed ambient noise monitoring stations alongside existing CAAQMS | ULB's + KSPCB | NA"
+          ],
+          "pages": [
+            114,
+            115
+          ]
+        }
+      ],
+      "ulbs": [],
+      "taluks": [
+        {
+          "key": "chikkaballapura",
+          "mapMatch": {
+            "family": "admin-taluk",
+            "prop": "name",
+            "values": [
+              "Chikkaballapura"
+            ]
+          },
+          "unit": {
+            "name": "Chikkaballapura (taluk)",
+            "level": "Taluk",
+            "coverage": "District Environmental Plan 2021/2022 (district-level snapshot)",
+            "headline": "Chikkaballapura town (Arkavathi headwaters near Nandi Hills) has a 10 MLD STP against ~3.5 MLD generated, but its underground sewerage network is only ~91% complete (9% gap) and ~40,000 tonnes of legacy waste sit at its dumpsite; the district has no CETP and most industrial effluent is handled by in-premises ETPs.",
+            "_provenance": {
+              "document_title": "DISTRICT ENVIRONMENT PLAN FOR CHIKKABALLAPURA DISTRICT, KARNATAKA STATE",
+              "source_page": "https://chikkaballapur.nic.in/en/about-district/district-environmental-plan/",
+              "document_url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf",
+              "data_as_on": "No explicit 'data as on' date is printed in the DEP. Dating evidence: PDF uploaded Nov 2021 (s3waas path /uploads/2021/11/); action-plan timelines are dated 30/11/2021, 31/12/2021 with completion targets to 2025; population is 2011 Census; HN Valley treated-water reuse cited 'from the year 2019-20'. Referenced throughout as 'DEP 2021'.",
+              "extraction_method": "PDF is image-only / scanned (116 pages; pdftotext -layout and pypdf both returned zero text on all pages). Extracted via pdftoppm at 200 dpi + tesseract 5.5.2 OCR. Figures below transcribed from OCR; minor OCR artefacts corrected against context but all numeric values reproduced verbatim from the OCR'd tables.",
+              "extraction_caveats": [
+                "The DEP reports almost everything at district level across its 6 ULBs (CMC Chikkaballapura, CMC Chinthamani, CMC Sidlaghatta, CMC Gowribidanur, TMC Bagepalli, TP Gudibande) and 157 gram panchayats. Town/taluk-specific rows for Chikkaballapura CMC are extracted where the DEP breaks them out; sewage-per-ULB and solid-waste-per-ULB tables do break out Chikkaballapura, but industrial effluent and CETP status are reported district-wide only (no taluk split).",
+                "The Domestic Sewage section is internally inconsistent on Chikkaballapura's generated volume: the per-ULB sewage-generated table lists 3.5 MLD, while the later waste-water/gap-analysis table lists 'The work has been taken up by KMRP and maintained by ULB' instead of a number for Chikkaballapura. The 3.5 MLD figure is the only printed numeric value and is used here.",
+                "Total district urban sewage generated is stated as 13.01 MLD; total available STP treatment capacity 15.10 MLD (CMC Chikkaballapura 10 + CMC Chinthamani 2 + CMC Sidlaghatta 3.1). 3 of 6 towns have STPs.",
+                "No explicit 'quantity processed' figure is printed for municipal solid waste; the DEP records 100% collection and that composting is practised in all ULBs, with legacy-waste tonnages given per ULB. Chikkaballapura CMC legacy waste = 40,000 tonnes; district total = 1,46,250 tonnes.",
+                "OCR rendered the C&D-waste district total as '72' which is inconsistent with the row sum (3+2+0.5+1+0.5+0.2 = 7.2 TPD); the intended total is 7.2 TPD. Not central to the three requested streams."
+              ]
+            },
+            "streams": [
+              {
+                "stream": "Sewage",
+                "summary": "Chikkaballapura CMC (31 wards) generates ~3.5 MLD of sewage and has a 10 MLD STP, so installed treatment capacity exceeds current generation. The binding gap is collection, not capacity: the underground sewerage network is ~91% complete with a 9% gap, and the DEP's own action plan notes the existing oxidation pond is inadequate and an upgraded STP plus completion of UGD missing links is required. The town sits in the Arkavathi headwaters zone near Nandi Hills.",
+                "metrics": [
+                  {
+                    "label": "Sewage generated, CMC Chikkaballapura",
+                    "value": "3.5 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Existing STP capacity, CMC Chikkaballapura",
+                    "value": "10 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Underground sewerage network coverage / gap, CMC Chikkaballapura",
+                    "value": "91% covered, 9% gap (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "District urban sewage generated (6 ULBs, Class-II towns and above)",
+                    "value": "13.01 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "District total available STP treatment capacity (3 of 6 towns have STPs)",
+                    "value": "15.10 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Treated/untreated sewage flowing to rivers or lakes (district)",
+                    "value": "Nil reported (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021, Domestic Sewage section",
+                    "says": "ULB's Existing STP Capacity (MLD) / Total Quantity of sewage generated in MLD: CMC. Chikkaballapura 10 / 3.5; CMC Chinthamani 2 / 3.4; CMC - Sidlaghatta 3.1 / 2.1; CMC - Gowribidanur Not existing / 2.2; TMC- Bagepalli 0 / 1; TP Gudibande 0 / 0.8. Total Quantity of Sewage generated in District From Class II cities and above [MLD]: 13.01 MLD.",
+                    "citation": "DEP 2021, Domestic Sewage, p.99 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Domestic Sewage section (UGD coverage table)",
+                    "says": "No of ULBs having partial underground Sewerage network [Nos]: 3 Nos. ULB's Existing STP Capacity / % area covered / Existing UGD Gap Analysis: CMC. Chikkaballapura 10 / 91% / 9%; CMC Chinthamani 2 / 98% / 2%; CMC - Sidlaghatta 3.1 / 70% / 30%.",
+                    "citation": "DEP 2021, Domestic Sewage, p.98 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Domestic Sewage treatment-capacity table",
+                    "says": "Total available Treatment Capacity [MLD]: 15.10 MLD. CMC. Chikkaballapura 10; CMC Chinthamani 2; CMC - Sidlaghatta 3.1; CMC - Gowribidanur No STP, discharged to ST & SP; TMC- Bagepalli No STP, discharged to ST & SP; TP - Gudibande No STP, discharged to ST & SP; Total 15.1.",
+                    "citation": "DEP 2021, Domestic Sewage, p.100 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Domestic Sewage action plan",
+                    "says": "Existing STP (oxidation pond) is inadequate to treat the sewage generated from the town. Due to incomplete UGD connection missing link exists, the completion of UGD work and connection shall be made. Note: The existing oxidation pond to be upgraded to STP of new technology in case of CMC - Chikkaballapura, Chinthamani & Shidlaghatta.",
+                    "citation": "DEP 2021, Domestic Sewage action plan, p.103 and p.97 (PDF labels)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 3.5,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Industrial effluent (CETP)",
+                "summary": "The DEP reports industrial effluent at district scale only (no separate Chikkaballapura-taluk figure). The district has 196 operating industries (16 Red, 59 Orange, 113 Green, 8 White); 39 discharge waste water, generating 2.15 MLD of which 1.61 MLD is treated. There is no CETP anywhere in Chikkaballapura district - effluent is handled by in-premises ETPs and no industry is permitted to discharge to nalas/rivers.",
+                "metrics": [
+                  {
+                    "label": "Operating industries in district (Red/Orange/Green/White)",
+                    "value": "196 total - 16 Red, 59 Orange, 113 Green, 8 White (DEP 2021)"
+                  },
+                  {
+                    "label": "Industries discharging waste water (district)",
+                    "value": "39 (DEP 2021)"
+                  },
+                  {
+                    "label": "Industrial trade effluent generated (district)",
+                    "value": "2.15 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "Industrial waste water treated (district)",
+                    "value": "1.61 MLD (DEP 2021)"
+                  },
+                  {
+                    "label": "CETP status (district)",
+                    "value": "No CETP established in Chikkaballapura district (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "ETP status (district)",
+                    "value": "Effluent treated in in-premises ETPs; 39 of 39 discharging industries meeting standards, 0 not meeting (DEP 2021)",
+                    "emphasis": "good"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021, Industrial Waste Water Management section",
+                    "says": "Total number of operating industries in the district is 196 ... [Nos. of Red industries]: 16; [Nos. of Orange industries]: 59; [Nos. of Green industries]: 113; [Nos. of White industries]: 8. No of Industries discharging waste water 39 Nos. Total Quantity of industrial waste water generated [MLD]: 2.15. Quantity of treated industrial waste water discharged in to Nalas/ Rivers [MLD]: 1.61. None of the industries are permitted to discharge either treated industrial wastewater into water bodies like Nalas /Rivers by KSPCB.",
+                    "citation": "DEP 2021, Industrial Waste Water Management, p.107 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Industrial Waste Water Management - CETP / standards",
+                    "says": "Common Effluent Treatment Facilities: There is no CETP's established in Chikkaballapura district. No of Industries meeting Standards Nos - 39. No of Industries not meeting discharge Standards Nil. As per the CPCB inspection policy the industries were inspected and sampling is carried out. If the samples are not confirming, the Show cause notice is served.",
+                    "citation": "DEP 2021, Industrial Waste Water Management, p.107 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ],
+                "medium": "liquid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 2.15,
+                  "unit": "MLD"
+                }
+              },
+              {
+                "stream": "Municipal solid waste",
+                "summary": "Chikkaballapura CMC (31 wards, ~63,652 population) generates 26 TPD of municipal solid waste with 100% door-to-door collection reported; composting is practised in all ULBs. The DEP prints no separate 'quantity processed' tonnage but records ~40,000 tonnes of legacy waste at the Chikkaballapura CMC dumpsite (district legacy total 1,46,250 tonnes), with remediation via screening machines targeted by 31/12/2025. There is no C&D recycling facility in the district.",
+                "metrics": [
+                  {
+                    "label": "MSW generated, CMC Chikkaballapura",
+                    "value": "26 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Door-to-door collection, CMC Chikkaballapura",
+                    "value": "100% of 31 wards (DEP 2021)",
+                    "emphasis": "good"
+                  },
+                  {
+                    "label": "Legacy / historic dumpsite waste, CMC Chikkaballapura",
+                    "value": "40,000 tonnes (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "District legacy waste total (6 ULBs)",
+                    "value": "1,46,250 tonnes (DEP 2021)",
+                    "emphasis": "bad"
+                  },
+                  {
+                    "label": "District urban MSW generated (6 ULBs)",
+                    "value": "112.5 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Processing / disposal status (district)",
+                    "value": "100% collection; composting in all ULBs; no separate processed-tonnage printed; legacy remediation by screening machine targeted 31/12/2025 (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021, Solid Waste Management current status",
+                    "says": "Urban Local bodies / No. of Wards / No. of House holds / Population / Solid Waste Generated per day (TPD): CMC. Chikkaballapura 31 / 14806 / 63652 / 26; CMC Chinthamani 31 / 17841 / 76068 / 28; CMC - Sidlaghatta 31 / 10169 / 51159 / 23; CMC - Gowribidanur 31 / 10256 / 53290 / 23; TMC- Bagepalli 23 / 4263 / 27011 / 10; TP Gudibande 11 / 2250 / 9441 / 2.5. Total 280621 population / 112.5 TPD.",
+                    "citation": "DEP 2021, Solid Waste Management current status, p.9 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Solid Waste Management - 100% collection table",
+                    "says": "Whether 100% collection achieved? CMC. Chikkaballapura 31 wards / 100% collection of solid waste; ... Total 158 wards / 100%. Door to door collection: CMC. Chikkaballapura 31 wards / 31 having arrangement / 100% achieved / Nil gap.",
+                    "citation": "DEP 2021, Solid Waste Management, p.24-25 (PDF labels)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, Remediation of historic/legacy dumpsite",
+                    "says": "Whether existing old dumpsite if any required remediation as per rules? No. of existing old dump site / Total Quantity of legacy waste dumped at dump site in Tonnes: CMC. Chikkaballapura 1 / 40000; CMC Chinthamani 1 / 43000; CMC - Sidlaghatta 1 / 31000; CMC - Gowribidanur 20500; TMC- Bagepalli 10200; TP Gudibande 1550; Total 146250. Screening machines have been purchased and installed in 5 ULB's and tendered in CMC-Gowribidanur. Legacy waste will be disposed using screening machine. Timeline 31/12/2025.",
+                    "citation": "DEP 2021, Solid Waste Management gap analysis (v), p.37-38 (PDF labels)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  },
+                  {
+                    "source": "Chikkaballapura DEP 2021, C&D Waste section",
+                    "says": "Quantity of C&D waste generated in TPD: CMC. Chikkaballapura 3; CMC Chinthamani 2; CMC - Sidlaghatta 0.5; CMC - Gowribidanur 1; TMC- Bagepalli 0.5; TP Gudibande 0.2. Does the District has access to C&D waste recycling facility? No facility exist to process C & D waste in the district.",
+                    "citation": "DEP 2021, C&D Waste section, p.62 (PDF label)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ],
+                "medium": "solid",
+                "sector": "public",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 26.0,
+                  "unit": "TPD"
+                }
+              },
+              {
+                "stream": "Industrial hazardous waste",
+                "medium": "solid",
+                "sector": "industry",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 1.1,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Industrial hazardous waste, reported district-wide (covers all taluks in the district); generation is recorded but no taluk-level treatment is.",
+                "metrics": [
+                  {
+                    "label": "Hazardous waste generated (district)",
+                    "value": "398.82 MT/yr ≈ 1.1 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Incinerable / land-fillable / recyclable",
+                    "value": "143.90 / 194.290 / 60.63 MT/yr (DEP 2021)"
+                  },
+                  {
+                    "label": "HW-generating industries (district)",
+                    "value": "38 (DEP 2021)"
+                  },
+                  {
+                    "label": "Disposal facilities",
+                    "value": "No TSDF, no SLF, no standalone incinerator in the district; HW sent off-district under MoU. One in-district used-oil recycler (Gowribidanur). (DEP 2021)",
+                    "emphasis": "bad"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021",
+                    "says": "No of Industries generating HW: 38. Quantity of HW: 398.82 MT/Annum; Incinerable 143.90; land-fillable 194.29; recyclable/utilizable 60.63 (sub-totals sum exactly). TSDF/SLF/standalone incinerator: Nil.",
+                    "citation": "V. Hazardous Waste Management, p.72 (printed)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Biomedical (healthcare) waste",
+                "medium": "solid",
+                "sector": "institutional",
+                "granularity": "district",
+                "magnitude": {
+                  "perDay": 0.38,
+                  "unit": "TPD",
+                  "estimated": true
+                },
+                "summary": "Institutional (healthcare) biomedical waste, reported district-wide; the DEP records it as fully treated via common facilities.",
+                "metrics": [
+                  {
+                    "label": "Biomedical waste generated (district)",
+                    "value": "378.221 kg/day ≈ 0.38 t/day (DEP 2021)"
+                  },
+                  {
+                    "label": "Treatment facilities (CBMWTF)",
+                    "value": "2 (DEP 2021)"
+                  },
+                  {
+                    "label": "Notes",
+                    "value": "2 CBWTFs (one in-district at Gowribidanur, one at Kolar within 75 km); 100% treated. The DEP's own gaps table elsewhere prints 378.58 kg/day. (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021",
+                    "says": "Inventory of BMW: 225 bedded + 353 non-bedded HCF; 378.221 kg/day generated and treated; 2 CBWTFs (Prajwal, Gowribidanur in-district; Meera Envirotech, Kolar). Gaps table (p.68) prints 378.58 kg/day.",
+                    "citation": "(iv) Bio-Medical Waste Management, p.66 (printed)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ]
+              },
+              {
+                "stream": "Construction & demolition waste",
+                "medium": "solid",
+                "sector": "construction",
+                "granularity": "taluk",
+                "magnitude": {
+                  "perDay": 3.0,
+                  "unit": "TPD"
+                },
+                "summary": "Construction & demolition waste.",
+                "metrics": [
+                  {
+                    "label": "C&D waste generated",
+                    "value": "3.0 TPD (DEP 2021)"
+                  },
+                  {
+                    "label": "Recycling facility",
+                    "value": "None in the district (DEP 2021)"
+                  }
+                ],
+                "sources": [
+                  {
+                    "source": "Chikkaballapura DEP 2021",
+                    "says": "C&D waste generation (per ULB), Chikkaballapura: 3.0 MT/day. No C&D recycling facility in the district.",
+                    "citation": "(iii) C&D Waste, p.62 (printed)",
+                    "url": "https://cdn.s3waas.gov.in/s35751ec3e9a4feab575962e78e006250d/uploads/2021/11/2021112595.pdf"
+                  }
+                ]
+              }
+            ],
+            "conflicts": [
+              "The DEP's sewage-generation figure for Chikkaballapura is inconsistent - one table gives 3.5 MLD while another replaces the number with 'work taken up by KMRP'."
+            ]
+          }
         }
       ]
     }
-  },
-  "note": "District Environment Plans (2022) are prepared at the district level and are not river basin-specific. As a result, the information shown may include areas outside the Arkavathi Basin."
+  ]
 }

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { MapContainer, TileLayer, GeoJSON, CircleMarker, Circle, Tooltip, ZoomControl, Pane, useMap } from "react-leaflet";
 import L from "leaflet";
 import type { Feature, FeatureCollection } from "geojson";
@@ -102,6 +102,54 @@ function polygonOuterRings(geom: Feature["geometry"] | null | undefined): [numbe
 // the ~0.36 km² Harohalli/Kaggalahalli exclave, excludes hair-thin slivers.
 const GAP_BADGE_MIN_AREA = 1.2e-5;
 interface GapUnit { name: string; level?: string; coverage?: string; conflicts?: string[]; caveats?: string[]; headline: string; streams: GapStream[] }
+
+// ── DEP Snapshot v2 (gaps.json `version: 2`; district-first) ─────────────────
+// One tab per district whose DEP covers part of the basin (Paani review,
+// 28 Jul 2026): DEPs are district documents, so the panel now leads with the
+// district, taluks nest below it, ULBs below that, and the content is re-cut
+// to the 7 NGT thematic areas (OA 360/2018). v1 basins (plain `units`) keep
+// the old single-unit GapPanel untouched.
+/** How to find a region on the map (shared by accountability + DEP panels). */
+type MapMatch = { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
+type DepThemeStatus = "covered" | "district-level" | "not-covered";
+interface DepTheme {
+  theme: string;
+  subtheme?: string;
+  /** covered = unit-specific data; district-level = reported district-wide
+   *  only; not-covered = the plan is silent for this unit. */
+  status: DepThemeStatus;
+  summary?: string;
+  metrics?: { label: string; value: string; emphasis?: boolean | "good" | "bad" }[];
+  /** Action items the plan itself lists for this theme - the accountability
+   *  payload (action point / timeline / responsible agency). */
+  openActions?: string[];
+  /** Source page numbers in the DEP document. */
+  pages?: number[];
+  /** Value read via OCR from a scanned plan; treat as approximate. */
+  ocrUncertain?: boolean;
+}
+interface DepUlb { key: string; name: string; type: string; note?: string; mapMatch?: MapMatch; themes: DepTheme[] }
+interface DepTaluk { key: string; label?: string; mapMatch?: MapMatch; unit: GapUnit }
+interface DepDistrict {
+  key: string;
+  name: string;
+  dep: { label: string; url: string; note?: string };
+  /** Share of the district's area inside the basin (computed from the
+   *  admin-district and boundary layers). */
+  pctInBasin: number;
+  counts?: { label: string; value: string }[];
+  countsNote?: string;
+  mapMatch?: MapMatch;
+  districtThemes: DepTheme[];
+  ulbs: DepUlb[];
+  taluks: DepTaluk[];
+  industrialAreas?: { name: string; mapMatch?: MapMatch }[];
+}
+interface DepGovernance {
+  items: { heading: string; body: string; source?: GapSource }[];
+  gaps: string[];
+}
+interface DepData { version: 2; title?: string; note?: string; governance?: DepGovernance; districts: DepDistrict[] }
 
 // ── PRS (Polluted River Stretch) entry-point panel (prs.json) ────────────────
 // Tabbed surface: each tab is a stressor theme; the subtab axis differs per
@@ -263,7 +311,7 @@ export interface AccRegion {
   /** How to find this region on the map: the layer family plus a property
    *  match (exact values or substring contains). When the family is split into
    *  kind-filtered layer entries, `kinds` names which entries to switch on. */
-  mapMatch?: { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
+  mapMatch?: MapMatch;
   categories: AccCategory[];
 }
 export interface AccountabilityData {
@@ -423,6 +471,8 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
   const [selectedGapUnit, setSelectedGapUnit] = useState<string | null>(null);
   const [gapData, setGapData] = useState<Record<string, GapUnit>>({});
   const [gapNote, setGapNote] = useState<string | null>(null);
+  // District-first DEP snapshot (gaps.json version 2); null for v1 basins.
+  const [depData, setDepData] = useState<DepData | null>(null);
   // PRS entry-point panel: open when the polluted-stretch line is clicked.
   const [selectedPrs, setSelectedPrs] = useState(false);
   const [prsData, setPrsData] = useState<PrsData | null>(null);
@@ -456,6 +506,25 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     () => Object.fromEntries(manifest.layers.map((l) => [l.family, l])),
     [manifest.layers],
   );
+  // "Show X on the map": switch on the matched family's layers and highlight
+  // the region. Shared by the accountability matrix and the DEP panel. Toggle
+  // keys are layerKey(l) (family:kindFilter for split families), so enabling
+  // the bare family name would miss kind-filtered entries (e.g.
+  // pressures-industrial). Which kinds to switch on: mapMatch.kinds, else a
+  // kind-valued property match, else every entry of the family.
+  const showOnMap = useCallback((m: MapMatch) => {
+    const kinds = m.kinds ?? (m.prop === "kind" ? m.values : undefined);
+    setEnabled((s) => {
+      const next = { ...s };
+      for (const l of manifest.layers) {
+        if (l.family !== m.family) continue;
+        if (l.kindFilter && kinds && !kinds.includes(l.kindFilter)) continue;
+        next[layerKey(l)] = true;
+      }
+      return next;
+    });
+    setMapHighlight(m);
+  }, [manifest.layers]);
   const shedToRiver = useMemo(() => {
     const m = new Map<string, string>();
     for (const r of manifest.rivers) for (const s of r.subHydroshedIds) m.set(s, r.riverId);
@@ -534,6 +603,15 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
   useEffect(() => {
     fetchJson(`/data/basins/${manifest.basinId}/gaps.json`)
       .then((d) => {
+        const v2 = d as unknown as DepData;
+        if (v2?.version === 2 && Array.isArray(v2.districts)) {
+          setDepData(v2);
+          // The map machinery (badges, dimming, defaultGapUnit) keys on flat
+          // unit ids, which in v2 are the taluks nested under districts.
+          setGapData(Object.fromEntries(v2.districts.flatMap((dist) => dist.taluks.map((t) => [t.key, t.unit]))));
+          setGapNote(v2.note ?? null);
+          return;
+        }
         const parsed = d as unknown as { units?: Record<string, GapUnit>; note?: string };
         setGapData(parsed?.units ?? {});
         setGapNote(parsed?.note ?? null);
@@ -1349,23 +1427,7 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                 depUnit={manifest.defaultGapUnit}
                 onShowRegion={(r) => {
                   if (!r.mapMatch) return;
-                  const m = r.mapMatch;
-                  // Toggle keys are layerKey(l) (family:kindFilter for split
-                  // families), so enabling the bare family name would miss the
-                  // kind-filtered entries (e.g. pressures-industrial). Which
-                  // kinds to switch on: mapMatch.kinds, else a kind-valued
-                  // property match, else every entry of the family.
-                  const kinds = m.kinds ?? (m.prop === "kind" ? m.values : undefined);
-                  setEnabled((s) => {
-                    const next = { ...s };
-                    for (const l of manifest.layers) {
-                      if (l.family !== m.family) continue;
-                      if (l.kindFilter && kinds && !kinds.includes(l.kindFilter)) continue;
-                      next[layerKey(l)] = true;
-                    }
-                    return next;
-                  });
-                  setMapHighlight(m);
+                  showOnMap(r.mapMatch);
                   // On phones this sheet covers the map - close it so the
                   // highlighted region is actually visible.
                   if (typeof window !== "undefined" && window.innerWidth < 768) setSelectedPrs(false);
@@ -1386,6 +1448,20 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
                   }
                 }}
                 onClose={() => setSelectedPrs(false)}
+              />
+            ) : selectedGapUnit && depData ? (
+              <DepPanel
+                data={depData}
+                focusTaluk={selectedGapUnit}
+                onSelectTaluk={setSelectedGapUnit}
+                onShowMatch={(m) => {
+                  showOnMap(m);
+                  // On phones this sheet covers the map - close it so the
+                  // highlighted region is actually visible.
+                  if (typeof window !== "undefined" && window.innerWidth < 768) { setSelectedGapUnit(null); setGapFromPrs(false); }
+                }}
+                onClose={() => { setSelectedGapUnit(null); setGapFromPrs(false); }}
+                onBack={gapFromPrs ? () => { setSelectedGapUnit(null); setGapFromPrs(false); setSelectedPrs(true); } : undefined}
               />
             ) : selectedGapUnit && gapData[selectedGapUnit] ? (
               <GapPanel
@@ -1626,7 +1702,7 @@ const ADMIN_DASH: Record<string, string | undefined> = {
   "admin-gp": "1 4",
 };
 
-type MapHighlight = { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
+type MapHighlight = MapMatch;
 
 function matchesHighlight(hl: MapHighlight | null | undefined, l: BasinLayer, feat: Feature | undefined): boolean {
   if (!hl || hl.family !== l.family) return false;
@@ -2598,68 +2674,383 @@ function GapPanel({ unit, note, onClose, onBack }: { unit: GapUnit; note?: strin
       {unit.coverage && (
         <p className="text-[11px] text-slate-400">Data coverage: {unit.coverage}</p>
       )}
-      {unit.conflicts && unit.conflicts.length > 0 && (
-        <div className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-2.5">
-          <div className="text-[11px] uppercase tracking-wider text-amber-700 dark:text-amber-400 font-semibold mb-1">Points to reconcile across sources</div>
-          <ul className="space-y-1 list-disc pl-4">
-            {unit.conflicts.map((c, i) => (
-              <li key={i} className="text-[12px] text-amber-800 dark:text-amber-200 leading-snug">{c}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-      {unit.caveats && unit.caveats.length > 0 && (
-        <div className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 p-2.5">
-          <div className="text-[11px] uppercase tracking-wider text-slate-500 dark:text-slate-400 font-semibold mb-1">Notes &amp; caveats</div>
-          <ul className="space-y-1 list-disc pl-4">
-            {unit.caveats.map((c, i) => (
-              <li key={i} className="text-[12px] text-slate-600 dark:text-slate-300 leading-snug">{c}</li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <GapConflicts conflicts={unit.conflicts} />
+      <GapCaveats caveats={unit.caveats} />
 
-      {(() => {
-        const media: GapMedium[] = ["liquid", "solid"];
-        const orphans = unit.streams.filter((s) => !s.medium);
-        const presentSectors = SECTOR_ORDER.filter((sec) => unit.streams.some((s) => s.sector === sec));
-        return (
-          <div className="space-y-4">
-            {presentSectors.length > 0 && (
-              <div className="pt-1">
-                <div className="text-[10px] uppercase tracking-wider text-slate-400 mb-1">Colour = who generates it</div>
-                <div className="flex flex-wrap gap-x-3 gap-y-1">
-                  {presentSectors.map((sec) => (
-                    <span key={sec} className="flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400">
-                      <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: SECTOR_META[sec].color }} />
-                      {SECTOR_META[sec].label}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-            {media.map((med) => {
-              const ms = unit.streams.filter((s) => s.medium === med);
-              if (!ms.length) return null;
-              return (
-                <section key={med} className="border-t border-slate-200 dark:border-slate-700 pt-3 space-y-3">
-                  <h3 className="text-[13px] font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">{MEDIUM_LABEL[med]}</h3>
-                  <CompositionBar streams={ms} />
-                  <div className="space-y-3.5">
-                    {ms.map((s, i) => <StreamCard key={i} s={s} />)}
-                  </div>
-                </section>
-              );
-            })}
-            {orphans.map((s, i) => (
-              <section key={`x${i}`} className="border-t border-slate-200 dark:border-slate-700 pt-3"><StreamCard s={s} /></section>
-            ))}
-          </div>
-        );
-      })()}
+      <GapStreamsBody unit={unit} />
       <p className="text-[11px] text-slate-400 pt-2 border-t border-slate-200 dark:border-slate-700 leading-relaxed">
         Figures extracted from public documents; each line links to its source. Composition bars show generation by sector; hazardous &amp; biomedical are reported district-wide.
       </p>
+    </div>
+  );
+}
+
+function GapConflicts({ conflicts }: { conflicts?: string[] }) {
+  if (!conflicts?.length) return null;
+  return (
+    <div className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-2.5">
+      <div className="text-[11px] uppercase tracking-wider text-amber-700 dark:text-amber-400 font-semibold mb-1">Points to reconcile across sources</div>
+      <ul className="space-y-1 list-disc pl-4">
+        {conflicts.map((c, i) => (
+          <li key={i} className="text-[12px] text-amber-800 dark:text-amber-200 leading-snug">{c}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function GapCaveats({ caveats }: { caveats?: string[] }) {
+  if (!caveats?.length) return null;
+  return (
+    <div className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 p-2.5">
+      <div className="text-[11px] uppercase tracking-wider text-slate-500 dark:text-slate-400 font-semibold mb-1">Notes &amp; caveats</div>
+      <ul className="space-y-1 list-disc pl-4">
+        {caveats.map((c, i) => (
+          <li key={i} className="text-[12px] text-slate-600 dark:text-slate-300 leading-snug">{c}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** The waste-stream cards for one admin unit, grouped by medium with the
+ *  sector legend and composition bars. Shared by the v1 GapPanel and the
+ *  taluk tier of the v2 DepPanel. */
+function GapStreamsBody({ unit }: { unit: GapUnit }) {
+  const media: GapMedium[] = ["liquid", "solid"];
+  const orphans = unit.streams.filter((s) => !s.medium);
+  const presentSectors = SECTOR_ORDER.filter((sec) => unit.streams.some((s) => s.sector === sec));
+  return (
+    <div className="space-y-4">
+      {presentSectors.length > 0 && (
+        <div className="pt-1">
+          <div className="text-[10px] uppercase tracking-wider text-slate-400 mb-1">Colour = who generates it</div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {presentSectors.map((sec) => (
+              <span key={sec} className="flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: SECTOR_META[sec].color }} />
+                {SECTOR_META[sec].label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {media.map((med) => {
+        const ms = unit.streams.filter((s) => s.medium === med);
+        if (!ms.length) return null;
+        return (
+          <section key={med} className="border-t border-slate-200 dark:border-slate-700 pt-3 space-y-3">
+            <h3 className="text-[13px] font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">{MEDIUM_LABEL[med]}</h3>
+            <CompositionBar streams={ms} />
+            <div className="space-y-3.5">
+              {ms.map((s, i) => <StreamCard key={i} s={s} />)}
+            </div>
+          </section>
+        );
+      })}
+      {orphans.map((s, i) => (
+        <section key={`x${i}`} className="border-t border-slate-200 dark:border-slate-700 pt-3"><StreamCard s={s} /></section>
+      ))}
+    </div>
+  );
+}
+
+// ── DEP Snapshot v2 panel (district-first) ───────────────────────────────────
+// Display order and labels of the 7 NGT thematic areas (OA 360/2018).
+const DEP_THEME_LABEL: Record<string, string> = {
+  "waste-management": "Waste Management",
+  "water-quality": "Water Quality",
+  "domestic-sewage": "Domestic Sewage",
+  "industrial-wastewater": "Industrial Wastewater",
+  "air-quality": "Air Quality",
+  mining: "Mining Activity",
+  noise: "Noise Pollution",
+};
+const DEP_THEME_ORDER = Object.keys(DEP_THEME_LABEL);
+const DEP_SUBTHEME_LABEL: Record<string, string> = {
+  "solid-waste": "Solid Waste",
+  "plastic-waste": "Plastic Waste",
+  "cd-waste": "C&D Waste",
+  "biomedical-waste": "Biomedical Waste",
+  "hazardous-waste": "Hazardous Waste",
+  "e-waste": "E-Waste",
+};
+const DEP_STATUS: Record<DepThemeStatus, { label: string; cls: string }> = {
+  covered: { label: "In the plan", cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300" },
+  "district-level": { label: "District-level only", cls: "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300" },
+  "not-covered": { label: "Not covered", cls: "bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300" },
+};
+
+function depThemeTitle(t: DepTheme): string {
+  const base = DEP_THEME_LABEL[t.theme] ?? t.theme;
+  return t.subtheme ? `${base}: ${DEP_SUBTHEME_LABEL[t.subtheme] ?? t.subtheme}` : base;
+}
+
+/** One thematic-area entry: status chip, summary, metrics, and the plan's own
+ *  action items (the accountability payload). Collapsible - a unit has up to
+ *  12 entries (7 themes, waste split into 6 sub-plans). */
+function DepThemeCard({ t, defaultOpen = false }: { t: DepTheme; defaultOpen?: boolean }) {
+  const hasBody = Boolean(t.summary || t.metrics?.length || t.openActions?.length);
+  return (
+    <details className="group py-1.5" open={defaultOpen && hasBody}>
+      <summary className={`list-none flex items-center gap-2 ${hasBody ? "cursor-pointer" : "cursor-default"}`}>
+        {hasBody && <span aria-hidden className="text-slate-400 text-[10px] transition-transform group-open:rotate-90">▶</span>}
+        <span className="text-[13px] font-semibold text-slate-800 dark:text-slate-200 flex-1">{depThemeTitle(t)}</span>
+        <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${DEP_STATUS[t.status].cls}`}>{DEP_STATUS[t.status].label}</span>
+      </summary>
+      {hasBody && (
+        <div className="pl-4 pt-1.5 space-y-2">
+          {t.summary && <p className="text-[13px] text-slate-600 dark:text-slate-400 leading-relaxed">{t.summary}</p>}
+          {t.metrics && t.metrics.length > 0 && (
+            <dl className="space-y-1.5">
+              {t.metrics.map((m, j) => (
+                <div key={j} className="flex items-baseline justify-between gap-3">
+                  <dt className="text-[13px] text-slate-500 dark:text-slate-400">{m.label}</dt>
+                  <dd className={`text-[13px] tabular-nums text-right ${m.emphasis === "good" ? "font-bold text-emerald-600 dark:text-emerald-400" : m.emphasis ? "font-bold text-rose-600 dark:text-rose-400" : "text-slate-700 dark:text-slate-300"}`}>{m.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          {t.openActions && t.openActions.length > 0 && (
+            <div className="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-2">
+              <div className="text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400 font-semibold mb-1">Action items in the plan</div>
+              <ul className="space-y-1 list-disc pl-4">
+                {t.openActions.map((a, i) => (
+                  <li key={i} className="text-[12px] text-amber-800 dark:text-amber-200 leading-snug">{a}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {(t.pages?.length || t.ocrUncertain) && (
+            <p className="text-[10px] text-slate-400">
+              {t.pages?.length ? `DEP p. ${t.pages.join(", ")}` : null}
+              {t.ocrUncertain ? `${t.pages?.length ? " - " : ""}read via OCR from a scanned plan; values approximate` : null}
+            </p>
+          )}
+        </div>
+      )}
+    </details>
+  );
+}
+
+/** A unit's thematic areas in canonical NGT order (waste sub-plans inline). */
+function DepThemeList({ themes }: { themes: DepTheme[] }) {
+  const ordered = [...themes].sort((a, b) => DEP_THEME_ORDER.indexOf(a.theme) - DEP_THEME_ORDER.indexOf(b.theme));
+  if (!ordered.length) return null;
+  return <div className="divide-y divide-slate-100 dark:divide-slate-800">{ordered.map((t, i) => <DepThemeCard key={i} t={t} />)}</div>;
+}
+
+function DepShowOnMap({ name, match, onShowMatch }: { name: string; match?: MapMatch; onShowMatch?: (m: MapMatch) => void }) {
+  if (!match || !onShowMatch) return null;
+  return (
+    <button onClick={() => onShowMatch(match)} className="inline-flex items-center gap-1 text-[12px] font-medium text-blue-600 dark:text-blue-400 hover:underline">
+      Show {name} on the map →
+    </button>
+  );
+}
+
+function DepPanel({ data, focusTaluk, onSelectTaluk, onShowMatch, onClose, onBack }: {
+  data: DepData;
+  focusTaluk: string | null;
+  onSelectTaluk: (key: string) => void;
+  onShowMatch: (m: MapMatch) => void;
+  onClose: () => void;
+  onBack?: () => void;
+}) {
+  // The map badge that opened the panel is a taluk key: land on its district
+  // with that taluk's card open. GOV_TAB is the extra governance tab.
+  const GOV_TAB = "__governance";
+  const homeDistrict = useMemo(
+    () => data.districts.find((d) => d.taluks.some((t) => t.key === focusTaluk)) ?? data.districts[0],
+    [data.districts, focusTaluk],
+  );
+  const [tab, setTab] = useState<string>(homeDistrict?.key ?? GOV_TAB);
+  const [view, setView] = useState<{ kind: "district" } | { kind: "ulb"; key: string } | { kind: "taluk"; key: string }>(
+    focusTaluk && homeDistrict?.taluks.some((t) => t.key === focusTaluk) ? { kind: "taluk", key: focusTaluk } : { kind: "district" },
+  );
+  const district = data.districts.find((d) => d.key === tab) ?? null;
+  const selUlb = district && view.kind === "ulb" ? district.ulbs.find((u) => u.key === view.key) ?? null : null;
+  const selTaluk = district && view.kind === "taluk" ? district.taluks.find((t) => t.key === view.key) ?? null : null;
+
+  const chip = (active: boolean) =>
+    `text-[11px] px-2 py-0.5 rounded border transition-colors ${active
+      ? "bg-rose-600 text-white border-rose-600"
+      : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700"}`;
+
+  return (
+    <div className="space-y-4">
+      {onBack && (
+        <button onClick={onBack} className="inline-flex items-center gap-1 text-[12px] font-medium text-blue-600 dark:text-blue-400 hover:underline">
+          ← Back to polluted stretch
+        </button>
+      )}
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[11px] uppercase tracking-wider text-rose-500">{data.title ?? "District Environment Plan (DEP) 2022 Snapshot"}</div>
+          {data.note && <p className="mt-1 text-[11px] text-slate-500 dark:text-slate-400 leading-snug">{data.note}</p>}
+        </div>
+        <button onClick={onClose} aria-label="Close" className="p-1 hover:bg-slate-100 dark:hover:bg-slate-800 rounded">
+          <svg className="w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+
+      {/* District tabs + governance. DEPs are district documents, so the
+          district - not the taluk - is the entry axis (Paani review). */}
+      <div className="flex flex-wrap gap-1.5">
+        {data.districts.map((d) => (
+          <button key={d.key} onClick={() => { setTab(d.key); setView({ kind: "district" }); }} className={chip(tab === d.key)}>
+            {d.name}
+          </button>
+        ))}
+        {data.governance && (
+          <button onClick={() => { setTab(GOV_TAB); setView({ kind: "district" }); }} className={chip(tab === GOV_TAB)}>
+            Governance &amp; compliance
+          </button>
+        )}
+      </div>
+
+      {tab === GOV_TAB && data.governance ? (
+        <DepGovernanceView gov={data.governance} />
+      ) : district ? (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 leading-snug">{district.name}</h2>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">
+              <a href={district.dep.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">{district.dep.label} ↗</a>
+              {district.dep.note ? ` - ${district.dep.note}` : ""}
+            </p>
+            <DepShowOnMap name={district.name} match={district.mapMatch} onShowMatch={onShowMatch} />
+          </div>
+
+          {/* Basin-share stat + admin composition of the district. */}
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5 space-y-1.5">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="text-[13px] text-slate-500 dark:text-slate-400">Share of the district inside the Arkavathi basin</span>
+              <span className="text-[15px] font-bold tabular-nums text-slate-900 dark:text-slate-100">{district.pctInBasin}%</span>
+            </div>
+            <div className="h-1.5 rounded bg-slate-100 dark:bg-slate-800 overflow-hidden">
+              <div className="h-full bg-rose-500/80" style={{ width: `${Math.min(district.pctInBasin, 100)}%` }} />
+            </div>
+            {district.counts && district.counts.length > 0 && (
+              <dl className="pt-1 space-y-1">
+                {district.counts.map((c, i) => (
+                  <div key={i} className="flex items-baseline justify-between gap-3">
+                    <dt className="text-[12px] text-slate-500 dark:text-slate-400">{c.label}</dt>
+                    <dd className="text-[12px] tabular-nums font-semibold text-slate-700 dark:text-slate-300">{c.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+            {district.countsNote && <p className="text-[10px] text-slate-400 leading-snug">{district.countsNote}</p>}
+          </div>
+
+          {/* Sub-navigation: district-wide themes / ULBs / taluks. */}
+          <div className="flex flex-wrap gap-1.5 items-center">
+            <button onClick={() => setView({ kind: "district" })} className={chip(view.kind === "district")}>District-wide</button>
+            {district.ulbs.map((u) => (
+              <button key={u.key} onClick={() => setView({ kind: "ulb", key: u.key })} className={chip(view.kind === "ulb" && view.key === u.key)}>
+                {u.name} ({u.type})
+              </button>
+            ))}
+          </div>
+          {district.taluks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 items-center">
+              <span className="text-[10px] uppercase tracking-wider text-slate-400">Taluks</span>
+              {district.taluks.map((t) => (
+                <button
+                  key={t.key}
+                  onClick={() => { setView({ kind: "taluk", key: t.key }); onSelectTaluk(t.key); }}
+                  className={chip(view.kind === "taluk" && view.key === t.key)}
+                >
+                  {t.label ?? t.unit.name.replace(/ \(taluk.*\)$/i, "")}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {view.kind === "district" && (
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5">
+              <div className="text-[11px] uppercase tracking-wider text-slate-400 mb-1">The 7 NGT thematic areas - district-wide</div>
+              <DepThemeList themes={district.districtThemes} />
+            </div>
+          )}
+          {selUlb && (
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5 space-y-2">
+              <div>
+                <div className="text-[13px] font-bold text-slate-900 dark:text-slate-100">{selUlb.name} ({selUlb.type})</div>
+                {selUlb.note && <p className="text-[11px] text-slate-500 dark:text-slate-400 leading-snug">{selUlb.note}</p>}
+                <DepShowOnMap name={`${selUlb.name} (${selUlb.type})`} match={selUlb.mapMatch} onShowMatch={onShowMatch} />
+              </div>
+              <DepThemeList themes={selUlb.themes} />
+            </div>
+          )}
+          {selTaluk && (
+            <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5 space-y-3">
+              <div>
+                <div className="text-[13px] font-bold text-slate-900 dark:text-slate-100">{selTaluk.unit.name}</div>
+                {selTaluk.unit.headline && <p className="text-[12px] font-semibold text-rose-900 dark:text-rose-100 leading-snug mt-0.5">{selTaluk.unit.headline}</p>}
+                <DepShowOnMap name={selTaluk.unit.name.replace(/ \(taluk.*\)$/i, "")} match={selTaluk.mapMatch} onShowMatch={onShowMatch} />
+              </div>
+              <GapConflicts conflicts={selTaluk.unit.conflicts} />
+              <GapCaveats caveats={selTaluk.unit.caveats} />
+              <GapStreamsBody unit={selTaluk.unit} />
+            </div>
+          )}
+
+          {district.industrialAreas && district.industrialAreas.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 items-center">
+              <span className="text-[10px] uppercase tracking-wider text-slate-400">Industrial areas (in-basin)</span>
+              {district.industrialAreas.map((ia, i) =>
+                ia.mapMatch ? (
+                  <button key={i} onClick={() => onShowMatch(ia.mapMatch!)} className={chip(false)}>{ia.name} ↗</button>
+                ) : (
+                  <span key={i} className="text-[11px] px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700 text-slate-500">{ia.name}</span>
+                ),
+              )}
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <p className="text-[11px] text-slate-400 pt-2 border-t border-slate-200 dark:border-slate-700 leading-relaxed">
+        Figures extracted from the District Environment Plans; each entry cites its page in the source document. Themes follow the NGT&apos;s 7 thematic areas (OA 360/2018).
+      </p>
+    </div>
+  );
+}
+
+function DepGovernanceView({ gov }: { gov: DepGovernance }) {
+  return (
+    <div className="space-y-3">
+      {gov.items.map((it, i) => (
+        <div key={i} className="rounded-lg border border-slate-200 dark:border-slate-700 p-2.5">
+          <div className="text-[13px] font-bold text-slate-900 dark:text-slate-100 mb-1">{it.heading}</div>
+          <p className="text-[13px] text-slate-600 dark:text-slate-400 leading-relaxed">{it.body}</p>
+          {it.source && (
+            <div className="mt-1.5 text-[13px] leading-relaxed">
+              <span className="font-semibold text-slate-700 dark:text-slate-300">{it.source.source}:</span>{" "}
+              <span className="text-slate-600 dark:text-slate-400">{it.source.says}</span>
+              {it.source.url ? (
+                <a href={it.source.url} target="_blank" rel="noopener noreferrer" className="block text-[11px] text-blue-600 dark:text-blue-400 hover:underline mt-0.5">
+                  {it.source.citation} ↗
+                </a>
+              ) : (
+                <span className="block text-[11px] text-slate-400 italic mt-0.5">{it.source.citation}</span>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+      {gov.gaps.length > 0 && (
+        <div className="rounded-md border border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 p-2.5">
+          <div className="text-[11px] uppercase tracking-wider text-rose-700 dark:text-rose-400 font-semibold mb-1">The compliance gap</div>
+          <ul className="space-y-1 list-disc pl-4">
+            {gov.gaps.map((g, i) => (
+              <li key={i} className="text-[12px] text-rose-800 dark:text-rose-200 leading-snug">{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Round-3 Paani Earth feedback (Madhuri's review PDF, 28 Jul 2026) on the Arkavathi DEP 2022 Snapshot, all seven items:

- **District-first restructure** (`gaps.json` v2): one tab per district - Bengaluru South (Earlier Ramanagara), Bengaluru Urban, Bengaluru Rural, Chikkaballapura - with the previous taluk cards nested below their district and ULB cards below that. v1 basins (chennai-rivers, cauvery-ka) keep the old `GapPanel` path untouched.
- **Per-district stats**: share of the district inside the basin computed from the shipped shapefiles (59.9 / 45.9 / 39.7 / 0.2 %), CMC/TMC/TP/GP counts as each DEP reports them.
- **"Show on the map"** links for districts, every ULB, and in-basin KIADB industrial areas (reuses the accountability-matrix highlight mechanism).
- **7 NGT thematic areas** (OA 360/2018; waste management carries its 6 sub-plans) per ULB - 189 theme entries, each with the plan's own action items and an honest status: in the plan / district-level only / not covered. ULBs verified absent from their plan (Madanayakanahalli CMC, Chikkabanavara TMC post-date the 2022 plan; Bashettihalli TP is missing from the Bengaluru Rural roster) say so explicitly.
- **Governance & compliance tab**: NGT order 05.07.2021 directions (d)/(e) - DM monthly reviews, state-plan publication duty - cited to the CPCB status report (p.5), plus the public-domain gap callouts.
- **MPR data stripped from DEP cards**: the Ramanagara sewage card now carries the DEP's own 10.12 vs 7.5 MLD = 2.62 MLD gap instead of the PRS MPRs' 4.0 MLD tracking.
- **Copy fixes**: F-register counts reattributed to the KSPCB Ramanagara Regional Office (jurisdiction does not follow the taluk boundary); reconcile box reframed on KIADB/CETP - 6 in-basin KIADB areas, DEP p.76 "There are no CETPs in the Ramanagara District", CAG No. 8/2017 p.28 CETP/CSTP expectation (all verified against source PDFs).

Extraction: Bengaluru South + Urban DEPs are text PDFs, read directly with page cites; Bengaluru Rural + Chikkaballapura are scanned and were OCR'd (tesseract; BR pages 8-62 were scanned upside down and re-OCR'd after rotation; approximate values carry `ocrUncertain` and render an "approximate" note). The plans' internal inconsistencies (e.g. four conflicting Bengaluru South sewage totals: 18.87/27.4/23.32/28.81 MLD) are recorded, not resolved.

## Test plan

- [x] `npm run lint`, `npm run data:check`, `npm run build`, `npm run test` (68/68)
- [x] API job: `ruff check`, `ruff format --check`, `pytest` (138/138)
- [x] Driven in the dev app (headless Chrome/CDP): district tabs, ULB theme cards, taluk tier, governance tab, Bengaluru Rural OCR tab, map-link highlighting - screenshot-verified
- [x] mapMatch audit: every district/ULB/taluk/industrial-area link resolves against the shipped geojson layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)