### PR TITLE
NVDM v1 ratification: L2 gate advisory -> enforcing

### DIFF
--- a/.github/workflows/nvdm-conformance.yml
+++ b/.github/workflows/nvdm-conformance.yml
@@ -7,9 +7,9 @@ name: NVDM conformance
 #   2. Catalogue + conformance-report freshness - the committed outputs match
 #      the tree (same pattern as the ward-profiles.json CI gate). Regenerate
 #      with: python3 scripts/build_dataset_catalogue.py && python3 scripts/validate_nvdm.py
-#   3. L2 envelope gate on NEWLY ADDED data artifacts - ADVISORY (warns, does
-#      not block) until NVDM v1 is accepted; flips to enforcing then.
-#      See schemas/nvdm/README.md.
+#   3. L2 envelope gate on NEWLY ADDED data artifacts - ENFORCING since NVDM
+#      v1 acceptance (2026-07-30): a new artifact below L2 fails the PR.
+#      Legacy files stay report-only. See schemas/nvdm/README.md.
 
 on:
   pull_request:
@@ -53,9 +53,8 @@ jobs:
           python3 scripts/validate_nvdm.py
           git diff --exit-code docs/architecture/nvdm-conformance.md
 
-      - name: L2 gate on newly added data artifacts (advisory until NVDM v1 acceptance)
+      - name: L2 gate on newly added data artifacts (ENFORCING - NVDM v1 accepted 2026-07-30)
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           NEW=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- \
@@ -67,6 +66,6 @@ jobs:
           echo "New data artifacts:"; echo "$NEW"
           # shellcheck disable=SC2086
           if ! python3 scripts/validate_nvdm.py --check $NEW; then
-            echo "::warning title=NVDM L2::New data artifacts are below NVDM L2 (no envelope). Advisory until NVDM v1 is accepted - envelope them now to avoid migration debt. See schemas/nvdm/README.md."
+            echo "::error title=NVDM L2::New data artifacts must carry a valid NVDM envelope (L2). NVDM v1 is accepted and this gate is enforcing. See schemas/nvdm/README.md."
             exit 1
           fi

--- a/docs/architecture/nvdm-conformance.md
+++ b/docs/architecture/nvdm-conformance.md
@@ -63,6 +63,6 @@ Levels per `docs/specs/nvdm-v1.md` Part 10: L0 catalogued, L1 registered, L2 env
   UNWATCHED reason; 118 artifacts remain unaccounted (largest block: basins packs).
 - L2/L3 progress is the migration meter: the Madurai pilot moved first; each city's
   migration lifts its artifacts (spec Part 9 order).
-- CI (`.github/workflows/nvdm-conformance.yml`): selftest + catalogue/report freshness
-  are blocking; the `--check` L2 gate on newly added data artifacts is ADVISORY until
-  NVDM v1 is accepted, then flips to enforcing. Legacy files stay report-only (spec 9.4).
+- CI (`.github/workflows/nvdm-conformance.yml`): selftest, catalogue/report freshness,
+  and the `--check` L2 gate on newly added data artifacts are all BLOCKING (NVDM v1
+  accepted 2026-07-30). Legacy files stay report-only until migrated (spec 9.4).

--- a/schemas/nvdm/README.md
+++ b/schemas/nvdm/README.md
@@ -5,6 +5,9 @@ standard: the envelope every data artifact carries (identity + scope +
 provenance + conventions), per-dataset payload contracts, the scope registry,
 and worked examples.
 
+**Status: NVDM v1 ACCEPTED 2026-07-30** after four adversarial review rounds.
+The L2 gate on newly added data artifacts is ENFORCING.
+
 The full normative prose specification is maintained privately while its
 publication is decided; for validation purposes **these schemas and the
 validator are authoritative**. Spec section references in schema descriptions
@@ -42,8 +45,7 @@ python3 scripts/validate_nvdm.py                # regenerate the conformance rep
 python3 scripts/validate_nvdm.py --check FILE…  # gate: exit 1 unless FILE reaches L2
 ```
 
-CI (`.github/workflows/nvdm-conformance.yml`) runs the selftest and freshness
-checks as blocking, and the L2 gate on newly added data artifacts as
-**advisory** until NVDM v1 is accepted, after which it becomes enforcing.
-New artifacts should carry the envelope from their first commit regardless -
-retrofit is migration debt.
+CI (`.github/workflows/nvdm-conformance.yml`) runs the selftest, the freshness
+checks, and the L2 gate on newly added data artifacts - all **blocking**
+(v1 accepted 2026-07-30). New artifacts carry the envelope from their first
+commit; legacy files remain report-only until their city migrates.

--- a/scripts/validate_nvdm.py
+++ b/scripts/validate_nvdm.py
@@ -595,9 +595,9 @@ def main(argv: list[str]) -> int:
         f"  UNWATCHED reason; {sum(1 for r in results if r['level'] < 1)} artifacts remain unaccounted (largest block: basins packs).",
         f"- L2/L3 progress is the migration meter: the Madurai pilot moved first; each city's",
         f"  migration lifts its artifacts (spec Part 9 order).",
-        "- CI (`.github/workflows/nvdm-conformance.yml`): selftest + catalogue/report freshness",
-        "  are blocking; the `--check` L2 gate on newly added data artifacts is ADVISORY until",
-        "  NVDM v1 is accepted, then flips to enforcing. Legacy files stay report-only (spec 9.4).",
+        "- CI (`.github/workflows/nvdm-conformance.yml`): selftest, catalogue/report freshness,",
+        "  and the `--check` L2 gate on newly added data artifacts are all BLOCKING (NVDM v1",
+        "  accepted 2026-07-30). Legacy files stay report-only until migrated (spec 9.4).",
         "",
     ]
     OUT_MD.write_text("\n".join(lines))


### PR DESCRIPTION
The atomic acceptance merge per the conditional-acceptance ruling: NVDM v1 is formally accepted (2026-07-30, four adversarial review rounds on #204) and the CI L2 envelope gate on newly added data artifacts flips from advisory to enforcing in the same change. Legacy files remain report-only behind the shrinking migration baseline. Workflow + README + conformance-report wording aligned; no data or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)