### PR TITLE
NVDM governance round 3: graph-wide taint + mixed lineage + candidate cleanup

### DIFF
--- a/.github/workflows/overture-buildings-refresh.yml
+++ b/.github/workflows/overture-buildings-refresh.yml
@@ -5,7 +5,7 @@ name: Overture buildings refresh
 # within ~30 days of publication (Overture releases ~every 3 months).
 #
 # Anomaly detection in the script: if any zone's count changes by >20%
-# from the previous JSON, the script writes a *.candidate.json instead
+# from the previous JSON, the script writes a *.candidate file instead
 # of overwriting the canonical file and exits non-zero. The workflow
 # then opens a PR with the candidate for human review. Within-threshold
 # changes are committed directly to the working branch.
@@ -111,7 +111,7 @@ jobs:
           body: |
             One or more rich-body building counts changed by more than the
             anomaly threshold vs the previous Overture release. The job has
-            written `*-overture-buildings.candidate.json` files alongside the
+            written `*-overture-buildings.candidate` files alongside the
             existing canonical JSONs - the canonicals were not overwritten.
 
             Please review the deltas (compare canonical vs candidate JSON)

--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -7014,7 +7014,7 @@
    "family": "data-root",
    "scope": "madurai",
    "dataset": "facts",
-   "bytes": 23606,
+   "bytes": 23881,
    "schema": {
     "kind": "object",
     "keys": [
@@ -7327,7 +7327,8 @@
    "consumers": [],
    "producer_refs": [
     "scripts/compute-madurai-derived-facts.ts",
-    "scripts/fetch-wris-groundwater-madurai.ts"
+    "scripts/fetch-wris-groundwater-madurai.ts",
+    "scripts/nvdm_envelope_madurai.py"
    ],
    "headwaters_sources": [
     "ingres-gw-assessment-madurai"
@@ -14353,6 +14354,7 @@
     "scripts/compute-madurai-derived-facts.ts",
     "scripts/compute-madurai-ward-profiles.ts",
     "scripts/fetch-rivers-osm-madurai.ts",
+    "scripts/nvdm_envelope_madurai.py",
     "scripts/snap-river-stations.py"
    ],
    "headwaters_sources": [
@@ -14658,7 +14660,8 @@
     "scripts/compute-delhi-ward-risk.py",
     "scripts/compute-madurai-derived-facts.ts",
     "scripts/compute-madurai-ward-risk.ts",
-    "scripts/compute-mumbai-ward-risk.py"
+    "scripts/compute-mumbai-ward-risk.py",
+    "scripts/nvdm_envelope_madurai.py"
    ],
    "headwaters_sources": [
     "osm-overpass"
@@ -19598,7 +19601,7 @@
     "madurai",
     "mumbai"
    ],
-   "bytes": 126086,
+   "bytes": 126361,
    "schema_variants": 2,
    "registered": true,
    "has_consumer": true

--- a/docs/architecture/nvdm-conformance.md
+++ b/docs/architecture/nvdm-conformance.md
@@ -114,7 +114,7 @@ Levels per `docs/specs/nvdm-v1.md` Part 10: L0 catalogued, L1 registered, L2 env
 - L2 `public/data/river-events-madurai.json` - no contract published for this dataset (L3 not applicable yet)
 - L2 `public/data/river-quality-madurai.json` - no contract published for this dataset (L3 not applicable yet)
 - L2 `public/data/river-quality.json` - no contract published for this dataset (L3 not applicable yet)
-- L2 `public/data/ward-profiles.json` - capped at L2: internal input(s) ungoverned or floor-capped - public/geojson/chennai-wards-2022.geojson
+- L2 `public/data/ward-profiles.json` - capped at L2: lineage rests (transitively) on ungoverned inputs - public/geojson/chennai-wards-2022.geojson
 - L2 `public/data/ward-representatives.json` - no contract published for this dataset (L3 not applicable yet)
 - L2 `public/data/ward-risk-madurai.json` - no contract published for this dataset (L3 not applicable yet)
 - L2 `public/data/water-bodies-flagship-madurai.json` - no contract published for this dataset (L3 not applicable yet)

--- a/public/data/facts-madurai.json
+++ b/public/data/facts-madurai.json
@@ -34,6 +34,13 @@
     ],
     "method": "mixed",
     "produced_at": "2026-06-18",
+    "internal_inputs": [
+      "public/data/gwr-blocks-madurai.json",
+      "public/data/restoration-priority-madurai.json",
+      "public/data/river-quality-madurai.json",
+      "public/data/ward-risk-madurai.json",
+      "public/data/water-bodies-lost-madurai.json"
+    ],
     "produced_by": "scripts/compute-madurai-derived-facts.ts (derived facts) + manual curation",
     "note": "Envelope lists the registered upstreams; every fact carries its own citation (source_label/source_url/data_date, migrated to per-record sources), including one-off documents (1886 lease indenture, court reports) not registrable as living sources."
   },

--- a/scripts/nvdm_envelope_madurai.py
+++ b/scripts/nvdm_envelope_madurai.py
@@ -195,6 +195,13 @@ PROVENANCE: dict[str, dict] = {
     "data-root/facts": {
         "method": "mixed",
         "produced_by": "scripts/compute-madurai-derived-facts.ts (derived facts) + manual curation",
+        "internal_inputs": [
+            "public/data/gwr-blocks-madurai.json",
+            "public/data/restoration-priority-madurai.json",
+            "public/data/river-quality-madurai.json",
+            "public/data/ward-risk-madurai.json",
+            "public/data/water-bodies-lost-madurai.json",
+        ],
         "sources": [
             reg("cgwb-yearbook-tn"),
             reg("ingres-gw-assessment-madurai"),

--- a/scripts/validate_nvdm.py
+++ b/scripts/validate_nvdm.py
@@ -330,31 +330,38 @@ def apply_internal_input_floor(results: list[dict]) -> None:
     input is below L2 - an input missing from the catalogue counts as L0.
     Runs to a FIXPOINT so demotions propagate through chains (round-2 review:
     A(L3)->B(L3)->C(L0) must cap A too, not just B)."""
+    # Round-3 review: taint is a property of LINEAGE, computed for every
+    # declaring node regardless of its own level - an L2 intermediary (no
+    # contract published) over an L0 input must still pass taint upward, or
+    # A(L3)->B(L2)->C(L0) leaves A laundered at L3. Fixpoint over the graph
+    # first; only then cap tainted L3 nodes.
     by_path = {r["path"]: r for r in results}
+    taint: dict[str, bool] = {}
     changed = True
     while changed:
         changed = False
         for r in results:
-            if r["level"] < 3 or "internal_inputs" not in r:
+            if "internal_inputs" not in r or taint.get(r["path"]):
                 continue
-            # An input is weak if below L2 OR itself floor-capped: a cap marks
-            # the whole chain as resting on ungoverned ground, and L2-by-
-            # demotion must not launder into L3-eligibility one hop up.
             weak = [
                 p for p in r["internal_inputs"]
                 if by_path.get(p) is None
                 or by_path[p]["level"] < 2
-                or by_path[p].get("_floor_capped")
+                or taint.get(p, False)
             ]
             if weak:
-                r["level"] = 2
-                r["_floor_capped"] = True
-                r["notes"].append(
-                    f"capped at L2: internal input(s) ungoverned or floor-capped - {', '.join(weak[:3])}"
-                )
+                taint[r["path"]] = True
+                r["_weak"] = weak
                 changed = True
     for r in results:
-        r.pop("_floor_capped", None)
+        if taint.get(r["path"]) and r["level"] >= 3:
+            r["level"] = 2
+            r["notes"].append(
+                "capped at L2: lineage rests (transitively) on ungoverned inputs - "
+                + ", ".join(r.get("_weak", [])[:3])
+            )
+    for r in results:
+        r.pop("_weak", None)
 
 
 # Claim datasets (spec 5.1): every record makes an independently quotable claim
@@ -452,13 +459,14 @@ def assess(rec: dict, schemas: dict[str, dict], scopes: dict[str, str], reg_ids:
             c_errs += claim_provenance_errors(doc, f"{rec['family']}/{rec['dataset']}")
             c_errs += unknown_key_errors(doc, schemas[contract])
             c_errs += license_errors(doc)
-            # Fail-closed internal lineage (round-2 review: omission kept L3):
-            # derived/gee artifacts must DECLARE internal_inputs - explicitly
-            # empty [] when they truly consume no repo artifacts.
-            if doc.get("provenance", {}).get("method") in ("derived", "gee") and \
+            # Fail-closed internal lineage (rounds 2-3: omission kept L3, and
+            # `mixed` was exempt while its producer read five repo artifacts):
+            # derived/gee/mixed artifacts must DECLARE internal_inputs -
+            # explicitly [] when they truly consume no repo artifacts.
+            if doc.get("provenance", {}).get("method") in ("derived", "gee", "mixed") and \
                     "internal_inputs" not in doc.get("provenance", {}):
                 c_errs.append(
-                    "derived artifact seeking L3 must declare provenance.internal_inputs "
+                    "derived/mixed artifact seeking L3 must declare provenance.internal_inputs "
                     "(explicitly [] if none) - the dependency floor is fail-closed"
                 )
             if c_errs:
@@ -637,6 +645,25 @@ def selftest(schemas: dict[str, dict]) -> int:
     apply_internal_input_floor(chain)
     check("dependency floor propagates transitively (A over B over L0-C)",
           chain[0]["level"] == 2 and chain[1]["level"] == 2)
+
+    # Round-3 regression: an L2 INTERMEDIARY (no contract, legitimately L2)
+    # must still pass taint upward - A(L3)->B(L2, declares C)->C(L0) caps A.
+    chain2 = [
+        {"path": "A.json", "level": 3, "notes": [], "internal_inputs": ["B.json"]},
+        {"path": "B.json", "level": 2, "notes": [], "internal_inputs": ["C.json"]},
+        {"path": "C.json", "level": 0, "notes": []},
+    ]
+    apply_internal_input_floor(chain2)
+    check("L2 intermediary does not launder weak lineage (round 3)",
+          chain2[0]["level"] == 2 and any("capped" in n for n in chain2[0]["notes"]))
+    # And a governed L2 intermediary does NOT taint its dependent.
+    chain3 = [
+        {"path": "A.json", "level": 3, "notes": [], "internal_inputs": ["B.json"]},
+        {"path": "B.json", "level": 2, "notes": [], "internal_inputs": ["D.json"]},
+        {"path": "D.json", "level": 2, "notes": []},
+    ]
+    apply_internal_input_floor(chain3)
+    check("governed L2 intermediary leaves L3 dependent standing", chain3[0]["level"] == 3)
 
     # Refresh gate (round-2 review: report mode cannot fail, so workflows now
     # call scripts/nvdm-refresh-gate.sh): a file enveloped at HEAD is enforced;

--- a/scripts/verify_rich_body_overture_buildings.py
+++ b/scripts/verify_rich_body_overture_buildings.py
@@ -12,7 +12,7 @@ Anomaly detection: when re-running this script (e.g. on a quarterly
 cron after a new Overture release), the new count is delta-checked
 against the previous JSON. If any zone's building count changes by
 more than ANOMALY_DELTA_PCT, the script exits non-zero AND writes
-the new JSON to a *.candidate.json file instead of overwriting the
+the new payload to a *.candidate file instead of overwriting the
 canonical path - so a CI workflow can fail loudly and require human
 review before publication.
 
@@ -212,7 +212,11 @@ def main():
     }
 
     out_path = ROOT / "public/data/rich-bodies" / f"{body_id}-overture-buildings.json"
-    candidate_path = out_path.with_suffix(".candidate.json")
+    # .candidate (not .json): review candidates stay OUTSIDE the catalogue
+    # walk and the L2 gate pathspecs (round-3 review: a .candidate.json was
+    # catalogued with a mismatched identity, guaranteeing red PRs).
+    # Acceptance = rename over the canonical .json (envelope already inherited).
+    candidate_path = out_path.with_suffix(".candidate")
 
     # Anomaly detection: compare against the previously published JSON
     anomalies = _detect_anomalies(out_path, payload, args.anomaly_pct)


### PR DESCRIPTION
Closes the round-3 findings: lineage taint computed graph-wide before capping (L2 intermediaries no longer launder weak lineage; both chain regressions in selftest); fail-closed internal_inputs extends to mixed (facts-madurai declares its five inputs); review candidates move to a .candidate extension outside the governed surface. Selftest 36; ladder stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)