### PR TITLE
fix(embed): move Arkavathi embed access to Paani Earth's new host

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,10 +29,12 @@ const securityHeaders = [
 // /embed/* is the ONLY framable namespace: chrome-less atlas pages built for
 // partner sites (Paani Earth's Arkavathi deep dive). Everything else keeps
 // frame-ancestors 'none'. localhost is allowed in dev so embeds are testable.
+// Paani Earth lost edit access to paani.earth; the deep dive now lives on
+// their Hostinger staging origin until forrivers.life goes live (swap it in
+// here when it does). CSP host-sources take no trailing slash or path.
 const EMBED_FRAME_ANCESTORS = [
   "'self'",
-  "https://paani.earth",
-  "https://www.paani.earth",
+  "https://orchid-wildcat-815854.hostingersite.com",
   ...(process.env.NODE_ENV === "development" ? ["http://localhost:*"] : []),
 ].join(" ");
 const embedHeaders = securityHeaders.map((h) => {

--- a/src/app/embed/basins/[basinId]/page.tsx
+++ b/src/app/embed/basins/[basinId]/page.tsx
@@ -6,8 +6,8 @@ import { tryGetBasinManifest, type BasinFloor, type BasinInventory } from "@/lib
 import { tryGetPlaceConfig } from "@/lib/cities";
 import { BasinAtlasClient } from "@/components/basin/basin-atlas-client";
 
-// Chrome-less basin atlas for third-party embedding (e.g. the Arkavathi deep
-// dive on paani.earth). The site Header/Footer suppress themselves on /embed,
+// Chrome-less basin atlas for third-party embedding (e.g. Paani Earth's
+// Arkavathi deep dive). The site Header/Footer suppress themselves on /embed,
 // and next.config.ts relaxes frame-ancestors for this namespace ONLY - the
 // rest of the site stays unframeable. Generic over the basin registry: a new
 // basin is embeddable the moment its manifest + data exist (data-only add).


### PR DESCRIPTION
Paani Earth can no longer edit paani.earth, so the Arkavathi deep dive embed is moving to their new site. This swaps the `/embed/*` `frame-ancestors` allowlist from `paani.earth` + `www.paani.earth` to their Hostinger staging origin, `https://orchid-wildcat-815854.hostingersite.com`. When forrivers.life goes live it gets swapped in here (noted in the config comment). The rest of the site stays unframeable, and the Paani Earth attribution on the rivers page is untouched.

**Testing**
- Both CI jobs green locally: frontend (lint, ward-profiles check, data:check, build, 73 node tests) and API (ruff check + format, 142 pytest).
- Prod-mode header check: `/embed/basins/arkavathi` now serves `frame-ancestors 'self' https://orchid-wildcat-815854.hostingersite.com` with `X-Frame-Options: SAMEORIGIN`; `/` unchanged at `frame-ancestors 'none'` / `X-Frame-Options: DENY`.