### PR TITLE
Protect public data pipelines from silent corruption

### DIFF
--- a/neer-vazhvu-api/app/cascade/publish.py
+++ b/neer-vazhvu-api/app/cascade/publish.py
@@ -120,7 +120,18 @@ def write_geojson(
     river_outlets is a list of LineString features from a tank centroid
     to its nearest in-flow-direction river point; tanks that drain into
     a river instead of into another tank.
+
+    Refuses empty input: writing zero nodes AND zero edges would replace
+    shipped artifacts with empty FeatureCollections, which is only ever a
+    caller bug (a real district always has nodes).
     """
+    if not nodes and not edges:
+        raise ValueError(
+            f"Refusing to write empty cascade GeoJSON for "
+            f"{district.district_id}: nodes and edges are both empty — this "
+            f"would overwrite shipped artifacts. Run build-topology to "
+            f"produce real inputs."
+        )
     _ensure_dirs()
     river_outlets = river_outlets or []
 

--- a/neer-vazhvu-api/app/etl/constants.py
+++ b/neer-vazhvu-api/app/etl/constants.py
@@ -22,7 +22,11 @@ DAY_ZERO_DATE = "2019-06-19"
 DAY_ZERO_STORAGE_MCFT = 19.0
 
 # --- Reservoir capacities ---
-TOTAL_RESERVOIR_CAPACITY_MCFT = 14_096.0  # All 6 reservoirs
+# Must match src/lib/utils/constants.ts RESERVOIR_METADATA (per CMWSSB lake
+# level page). Cholavaram 881→1081 and Kannankottai 1574→500 corrected
+# 2026-08-03 after the values drifted from the TS side (Apr 2026 correction
+# landed only there); 13,222 is CMWSSB's published 6-reservoir total.
+TOTAL_RESERVOIR_CAPACITY_MCFT = 13_222.0  # All 6 reservoirs
 
 
 class ReservoirName(StrEnum):
@@ -36,11 +40,11 @@ class ReservoirName(StrEnum):
 
 RESERVOIR_CAPACITY: dict[str, float] = {
     "poondi": 3231.0,
-    "cholavaram": 881.0,
+    "cholavaram": 1081.0,
     "redhills": 3300.0,
     "chembarambakkam": 3645.0,
     "veeranam": 1465.0,
-    "kannankottai": 1574.0,
+    "kannankottai": 500.0,
 }
 
 EXPECTED_RESERVOIR_COUNT = len(RESERVOIR_CAPACITY)

--- a/neer-vazhvu-api/app/scrapers/cmwssb.py
+++ b/neer-vazhvu-api/app/scrapers/cmwssb.py
@@ -5,13 +5,16 @@ Ported from src/lib/scrapers/cmwssb.ts.
 Scrapes https://cmwssb.tn.gov.in/lake-level for daily reservoir data.
 """
 
+import logging
 import re
 
 import httpx
 from bs4 import BeautifulSoup
 
-from app.etl.constants import RESERVOIR_NAME_MAP
+from app.etl.constants import RESERVOIR_CAPACITY, RESERVOIR_NAME_MAP
 from app.models.reservoir import ScrapedReservoir, ScrapeResult
+
+logger = logging.getLogger(__name__)
 
 CMWSSB_URL = "https://cmwssb.tn.gov.in/lake-level"
 # The CMWSSB site (Drupal) drops connections from non-browser user agents.
@@ -77,12 +80,39 @@ def _parse_cmwssb_html(html: str) -> ScrapeResult:
         if reservoir_key is None:
             continue
 
+        # An unparseable storage cell ("-", "NIL", blank) means UNREPORTED,
+        # not empty: skip the reservoir so the day reads as partial (the
+        # pipeline's completeness guard then refuses it) instead of storing
+        # a confident 0 that renders as an empty reservoir.
+        storage = _parse_num(cells[4])
+        if storage is None:
+            logger.warning(
+                "CMWSSB: %s storage cell unparseable (%r) — skipping row",
+                reservoir_key,
+                cells[4],
+            )
+            continue
+
+        # Positional-shift guard: columns are identified by position only, so
+        # an inserted/reordered column upstream silently swaps fields. Storage
+        # above known capacity is the cheapest tell.
+        known_capacity = RESERVOIR_CAPACITY.get(reservoir_key)
+        if known_capacity is not None and storage > known_capacity * 1.1:
+            logger.warning(
+                "CMWSSB: %s storage %.1f exceeds capacity %.1f — column shift "
+                "or unit change upstream? Skipping row",
+                reservoir_key,
+                storage,
+                known_capacity,
+            )
+            continue
+
         readings.append(
             ScrapedReservoir(
                 reservoir=reservoir_key,
                 date=date_str,
                 current_level_ft=_parse_num(cells[3]),
-                current_storage_mcft=_parse_num(cells[4]) or 0,
+                current_storage_mcft=storage,
                 capacity_mcft=_parse_num(cells[2]) or 0,
                 storage_pct=_parse_num(cells[5]) or 0,
                 inflow_cusecs=_parse_num(cells[6]) or 0,

--- a/neer-vazhvu-api/scripts/run_cascade.py
+++ b/neer-vazhvu-api/scripts/run_cascade.py
@@ -142,15 +142,18 @@ def cmd_curate(district_id: str) -> int:
 
 
 def cmd_publish(district_id: str) -> int:
-    from app.cascade import publish
-    from app.cascade.districts import get_district_cascade_config
-
-    district = get_district_cascade_config(district_id)
-    geo = publish.write_geojson(district, nodes=[], edges=[], river_outlets=[])
-    manifest = publish.write_systems_manifest(district, systems={})
-    stats = publish.write_stats_manifest(district)
-    print(json.dumps({**geo, **manifest, **stats}, indent=2))
-    return 0
+    """Refuse: standalone `publish` had no real inputs and overwrote shipped
+    GeoJSONs with empty FeatureCollections (2026-08 baseline P0.3). The real
+    publish happens inside build-topology; `stats` refreshes manifests from
+    the existing GeoJSONs."""
+    print(
+        f"'publish' is disabled: it would overwrite {district_id}'s shipped "
+        f"cascade artifacts with empty data. Use 'build-topology' to build "
+        f"and publish, or 'stats' to refresh manifests from existing "
+        f"GeoJSONs.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_stats(district_id: str) -> int:
@@ -239,7 +242,8 @@ def cmd_run_all(district_id: str) -> int:
     cmd_detect_encroachment(district_id)
     cmd_score(district_id)
     cmd_curate(district_id)
-    cmd_publish(district_id)
+    # publish intentionally absent: build-topology already wrote the
+    # GeoJSONs; the old standalone publish step re-wrote them empty.
     cmd_tile(district_id)
     return 0
 

--- a/neer-vazhvu-api/tests/test_cascade_districts.py
+++ b/neer-vazhvu-api/tests/test_cascade_districts.py
@@ -178,7 +178,17 @@ def test_publish_write_geojson_embeds_meta_in_each_collection(tmp_path, monkeypa
         lambda self: outlets_path,
     )
 
-    publish.write_geojson(test_district, [], [], [])
+    # write_geojson refuses fully-empty input (it would overwrite shipped
+    # artifacts), so give it one minimal node.
+    minimal_node = {
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [78.1, 9.9]},
+        "properties": {"id": "tank-1"},
+    }
+    with pytest.raises(ValueError, match="Refusing to write empty"):
+        publish.write_geojson(test_district, [], [], [])
+
+    publish.write_geojson(test_district, [minimal_node], [], [])
 
     expected_meta_keys = {
         "district_id",

--- a/neer-vazhvu-api/tests/test_cmwssb_scraper.py
+++ b/neer-vazhvu-api/tests/test_cmwssb_scraper.py
@@ -1,0 +1,55 @@
+"""CMWSSB HTML parser: unreported and implausible values must never become 0.
+
+A "-" or blank storage cell means the reservoir is UNREPORTED that day; the
+parser skips the row so the pipeline's completeness guard refuses the partial
+day, instead of storing a confident 0 that renders as an empty reservoir
+(2026-08 baseline P0.1b).
+"""
+
+from app.scrapers.cmwssb import _parse_cmwssb_html
+
+
+def _page(rows: str) -> str:
+    return f"""
+    <html><body>
+    <p>Lake level as on 01/08/2026</p>
+    <table>{rows}</table>
+    </body></html>
+    """
+
+
+def _row(name: str, capacity: str, level: str, storage: str, pct: str) -> str:
+    # Parser layout: cells[0]=name, [2]=capacity, [3]=level, [4]=storage,
+    # [5]=pct, [6]=inflow, [7]=outflow, [8]=rainfall.
+    cells = [name, "x", capacity, level, storage, pct, "10", "5", "0"]
+    return "<tr>" + "".join(f"<td>{c}</td>" for c in cells) + "</tr>"
+
+
+def test_normal_row_parses():
+    result = _parse_cmwssb_html(_page(_row("Poondi", "3231", "30.1", "1500.5", "46.4")))
+    assert len(result.readings) == 1
+    r = result.readings[0]
+    assert r.reservoir == "poondi"
+    assert r.current_storage_mcft == 1500.5
+    assert r.date == "2026-08-01"
+
+
+def test_unparseable_storage_skips_row_not_zero():
+    html = _page(
+        _row("Poondi", "3231", "30.1", "1500.5", "46.4")
+        + _row("Cholavaram", "1081", "-", "-", "-")
+    )
+    result = _parse_cmwssb_html(html)
+    names = [r.reservoir for r in result.readings]
+    assert names == ["poondi"], "unreported reservoir must be skipped, not stored as 0"
+
+
+def test_storage_above_capacity_skips_row():
+    # Column-shift guard: storage far above known capacity means the table
+    # layout changed upstream; better no row than a wrong row.
+    html = _page(
+        _row("Poondi", "3231", "30.1", "1500.5", "46.4")
+        + _row("Cholavaram", "1081", "22.0", "3300", "100")
+    )
+    result = _parse_cmwssb_html(html)
+    assert [r.reservoir for r in result.readings] == ["poondi"]

--- a/scripts/compute-restoration-priority.ts
+++ b/scripts/compute-restoration-priority.ts
@@ -283,8 +283,14 @@ async function fetchCensusData(): Promise<CensusRow[]> {
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !key) {
-    console.warn("  Supabase credentials not found, skipping census data");
-    return [];
+    // Shipping without census data silently drops ~305 census-only bodies
+    // and neutralizes condition scoring for the rest — a degraded artifact
+    // that would overwrite the good committed one (baseline P0.3).
+    throw new Error(
+      "Supabase credentials not set (NEXT_PUBLIC_SUPABASE_URL / " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY) — refusing to build a degraded " +
+        "restoration-priority artifact without census data",
+    );
   }
 
   const { createClient } = await import("@supabase/supabase-js");

--- a/src/app/api/groundwater/history/route.ts
+++ b/src/app/api/groundwater/history/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { internalServerError, logRouteError } from "@/lib/api-error";
+import { dataServiceUnavailable, internalServerError, isExplicitDemoMode, logRouteError } from "@/lib/api-error";
 import { generateMockWardHistory } from "@/lib/mock-data";
 
 const wardNamesPath = resolve(process.cwd(), "public/data/ward-names.json");
@@ -29,6 +29,7 @@ export async function GET(request: NextRequest) {
   }
 
   if (!isSupabaseConfigured()) {
+    if (!isExplicitDemoMode()) return dataServiceUnavailable();
     return NextResponse.json(generateMockWardHistory(wardNumber));
   }
 

--- a/src/app/api/groundwater/risk/route.ts
+++ b/src/app/api/groundwater/risk/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { internalServerError, logRouteError } from '@/lib/api-error';
+import { dataServiceUnavailable, internalServerError, isExplicitDemoMode, logRouteError } from '@/lib/api-error';
 import { generateMockRiskScores } from '@/lib/mock-data';
 import type { RiskLevel } from '@/types/groundwater';
 
@@ -8,8 +8,10 @@ function isSupabaseConfigured(): boolean {
 }
 
 export async function GET() {
-  // Demo mode: Supabase not configured  -  use mock data so the full UI is exercisable
+  // Mock data only behind explicit demo mode (NEER_VAZHVU_DEMO_MODE=true);
+  // a bare missing config is an error, not a fallback (baseline P0.4).
   if (!isSupabaseConfigured()) {
+    if (!isExplicitDemoMode()) return dataServiceUnavailable();
     return NextResponse.json(generateMockRiskScores());
   }
 

--- a/src/app/api/groundwater/route.ts
+++ b/src/app/api/groundwater/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { internalServerError, logRouteError } from '@/lib/api-error';
+import { dataServiceUnavailable, internalServerError, isExplicitDemoMode, logRouteError } from '@/lib/api-error';
 import { getGroundwaterStatus } from '@/types/groundwater';
 import { generateMockGroundwater } from '@/lib/mock-data';
 
@@ -22,8 +22,10 @@ function isSupabaseConfigured(): boolean {
 }
 
 export async function GET(request: NextRequest) {
-  // If Supabase is not configured, return mock data
+  // Mock data only behind explicit demo mode; a bare missing config is an
+  // error, not a fallback (baseline P0.4).
   if (!isSupabaseConfigured()) {
+    if (!isExplicitDemoMode()) return dataServiceUnavailable();
     const { searchParams } = new URL(request.url);
     const VALID_STYLES = ['healthy', 'declining', 'crisis', 'recovering'] as const;
     const rawStyle = searchParams.get('style');

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -16,3 +16,20 @@ export function sanitizeErrorMessage(error: unknown): string {
 export function internalServerError() {
   return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
 }
+
+/**
+ * Mock data may only be served when demo mode is explicitly requested via
+ * env. A missing Supabase config alone must never silently serve fabricated
+ * numbers with a 200 (2026-08 baseline P0.4) — routes return this 503
+ * instead.
+ */
+export function isExplicitDemoMode(): boolean {
+  return process.env.NEER_VAZHVU_DEMO_MODE === 'true';
+}
+
+export function dataServiceUnavailable() {
+  return NextResponse.json(
+    { error: 'Data service not configured' },
+    { status: 503 },
+  );
+}

--- a/supabase/migrations/036_fix_reservoir_capacities.sql
+++ b/supabase/migrations/036_fix_reservoir_capacities.sql
@@ -1,0 +1,12 @@
+-- 036: Correct drifted reservoir capacities in the 001 seed.
+--
+-- Migration 001 seeded reservoir_meta with Cholavaram 881 and Kannankottai
+-- 1574 mcft; migration 017's water_sources seed and the frontend carry the
+-- correct CMWSSB figures (Cholavaram 1081, Kannankottai 500 — verified
+-- against CMWSSB lake level page and press reports; 6-reservoir total
+-- 13,222 mcft). Nothing currently reads reservoir_meta, but a stale seed is
+-- a drift trap for the next consumer.
+-- See docs/engineering/reviews/2026-08-baseline.md P0.1.
+
+UPDATE reservoir_meta SET full_capacity_mcft = 1081.0 WHERE reservoir = 'cholavaram';
+UPDATE reservoir_meta SET full_capacity_mcft = 500.0  WHERE reservoir = 'kannankottai';


### PR DESCRIPTION
## Summary

- refuses empty cascade publication and removes the destructive empty publish step from `run-all`
- treats unreported or physically implausible CMWSSB storage values as incomplete input rather than fabricated zeroes
- aligns Python reservoir capacities with the published six-reservoir total and repairs the stale database seed
- fails closed when restoration-priority census inputs or production groundwater configuration are missing

## Repository boundary

These public dashboard, API, scraper, and schema corrections were separated from platform PR #10 so the public repository remains authoritative. The repaired platform PR will mirror this accepted public change alongside its private engineering-governance documents.

## Verification

- 26 focused Python tests pass
- 73 TypeScript tests pass
- targeted ESLint passes
- data, freshness, upstream-edition, and mirrored-document checks pass
- full Next.js production build passes

## Failure behavior

The affected pipelines now stop with an explicit error instead of overwriting good artifacts, publishing partial reservoir readings, or serving mock groundwater data without an explicit demo-mode flag.
