### PR TITLE
Add candidate NVDM semantic core contract

### DIFF
--- a/.github/workflows/nvdm-conformance.yml
+++ b/.github/workflows/nvdm-conformance.yml
@@ -3,8 +3,8 @@ name: NVDM conformance
 # Guards the machine-readable arm of the NVDM data-model standard
 # (schemas/nvdm/ + the dataset catalogue). Three checks:
 #   1. Validator selftest - the schemas and rules keep rejecting what they
-#      must reject (29 checks incl. adversarial probes from four review
-#      rounds and the L2 gate selector regressions).
+#      must reject (including adversarial probes and L2 gate selector
+#      regressions).
 #   2. Catalogue + conformance-report freshness - the committed outputs match
 #      the tree (same pattern as the ward-profiles.json CI gate). Regenerate
 #      with: python3 scripts/build_dataset_catalogue.py && python3 scripts/validate_nvdm.py

--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -8330,7 +8330,7 @@
    "family": "data-root",
    "scope": "mumbai",
    "dataset": "mmr-dam-storage",
-   "bytes": 4562,
+   "bytes": 4566,
    "schema": {
     "kind": "object",
     "keys": [
@@ -20625,7 +20625,7 @@
    "scopes": [
     "mumbai"
    ],
-   "bytes": 4562,
+   "bytes": 4566,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true

--- a/docs/architecture/nvdm-semantic-core.md
+++ b/docs/architecture/nvdm-semantic-core.md
@@ -1,0 +1,159 @@
+# NVDM semantic core candidate
+
+**Status:** candidate 0.1 for review. It is not an accepted NVDM v1 contract,
+is not registered in `scripts/validate_nvdm.py`, and is not used by a
+production artifact.
+
+## Decision
+
+NVDM remains one data model. Source families such as monthly progress reports
+(MPRs), STP inspections, groundwater reports and river-pollution datasets do
+not get independent canonical models. They may have different private intake
+contracts, but reviewed outputs converge on one small semantic graph:
+
+```mermaid
+flowchart LR
+    A["Source document or dataset"] --> B["Private extraction contract"]
+    B --> C["Private mapping and entity review"]
+    C --> D["NVDM semantic release bundle"]
+    D --> E["Version diff and governed release"]
+    E --> F["Public or private product view"]
+```
+
+The release bundle is an interoperability and validation unit. It is not a
+database schema. The platform may persist these records in normalized tables,
+subject to workspace RLS, while public releases can remain self-contained JSON.
+
+## The graph
+
+```mermaid
+flowchart LR
+    S["Subject"] --> C["Typed claim"]
+    SS["Explicit subject set"] --> C
+    C --> E["Immutable evidence"]
+    C --> L["Supersedes / contradicts / derived from"]
+    C --> T["Time interval"]
+    C --> V["Tagged value"]
+```
+
+A subject is a stable real-world thing: a treatment facility, monitoring point,
+local government, river reach or aquifer. A subject set represents an explicit
+reported aggregation or analytical cohort. It prevents labels such as “two
+municipalities combined” from being fabricated into canonical real-world
+entities.
+
+The candidate has four claim families:
+
+| Family | Meaning | Example |
+|---|---|---|
+| Relationship | A typed connection between two subjects | outlet is part of an STP |
+| Standing fact | A value intended to hold over a stated interval | design capacity or applicable standard |
+| Observation | A measured, reported or estimated value at a time | outlet BOD result |
+| Assessed gap | A reported or derived shortfall | treatment-capacity gap |
+
+Monitoring locations are subjects, not strings embedded in readings. A
+regulatory threshold is a standing-fact claim; an observation may point to the
+threshold through `comparison_claim_ids`. The raw result and the rule used to
+interpret it therefore remain independently reviewable.
+
+## Public and private ownership
+
+The public NVDM contract owns the minimum structure needed for durable
+interoperability:
+
+- stable subjects and explicit subject sets;
+- evidence custody and locators;
+- relationships, standing facts, observations and assessed gaps;
+- tagged values, time intervals and lifecycle edges;
+- executable validation of referential and custody invariants.
+
+The private platform owns client- and method-specific operational knowledge:
+
+- source-document extraction contracts and prompts;
+- source fields mapped to NVDM concepts;
+- entity-resolution candidates, aliases under review and reviewer decisions;
+- customer records, storage paths, access policy and workflow state;
+- unpublished crosswalks and higher-order ontology logic.
+
+The structural schema accepting a namespaced `concept` does not publish or
+accept a Neer Vazhvu concept vocabulary. Which concept definitions and
+crosswalks become public remains an explicit product and IP decision.
+
+## Value, time and absence
+
+Values use a closed tagged union: quantity, range, text, terms, date or boolean.
+A quantity always names its unit and qualifier. A range always names its unit.
+Dates are real ISO years, year-months or dates. Time intervals use one precision
+at both ends and cannot run backwards.
+
+`null` is never shorthand for missing, unreported or not applicable. If a
+source does not report a field, the private review workflow records that
+coverage state; it does not manufacture a canonical claim. This keeps absence
+semantics out of downstream analytics unless they have been deliberately
+modelled.
+
+## Evidence and custody
+
+Each evidence record names an envelope source, a source version, the SHA-256 of
+the immutable source artifact and a typed locator. A document fragment requires
+a positive page number. Dataset, API and field records use record/field/fragment
+locators as appropriate. Storage bucket keys and signed URLs are intentionally
+absent: custody remains stable when delivery infrastructure changes.
+
+Normalized page-text hashes, provider-result checksums and processor editions
+remain in the platform's private document-observation receipt. Duplicating
+those fields in the public graph would create a second canonicalization regime;
+the governed projector instead binds its release to the reviewed private
+receipt while publishing the source artifact and locator needed to verify the
+claim.
+
+Within a bundle, one `(source_id, source_version_id)` pair must resolve to one
+artifact hash. Evidence and all claims share a global identifier namespace, so
+an identifier cannot silently change type. Exact external identities cannot be
+bound to two canonical subjects.
+
+## History and derivation
+
+Claims are append-only. A correction creates a new claim and points to the old
+claim with `supersedes_claim_ids`; the old record remains addressable. A
+superseding claim must keep the same subject and concept. Contradictions remain
+visible through `contradicts_claim_ids`. A claim with `basis: derived` must name
+its input claims through `derived_from_claim_ids`.
+
+Model execution receipts are not yet an evidence kind. The current NVDM
+envelope defines `provenance.sources` as external upstreams, so treating an
+internal model run as an external source would corrupt lineage. Headwaters or a
+future model-run contract should first define model, version, parameters,
+inputs, environment and output custody; semantic claims can then link to that
+receipt without changing their subject/claim shape.
+
+## Pressure tests
+
+| Pressure | Candidate response | Deliberate non-goal |
+|---|---|---|
+| One MPR reports a total for several municipalities | Explicit reported subject set | Inventing a combined municipality subject |
+| One document contains several STPs | One canonical facility subject per resolved facility | One-candidate-per-document assumption |
+| STP reading belongs to an inlet or outlet | Monitoring point subject plus `part-of` relationship | Free-text location on the observation |
+| Result must be compared with a standard | Observation references a standing-fact claim | Baking pass/fail into the raw value |
+| Two reports disagree | Both claims retained and linked as contradictions | Last-write-wins replacement |
+| A later report corrects an earlier value | New claim supersedes the old claim | Mutating historical evidence |
+| A source field is absent | No canonical claim is emitted | Null-as-unreported convention |
+| A derived gap is published | Claim names evidence and input claims | Untraceable computed number |
+
+## Acceptance path
+
+The candidate can become a registered contract only after all of these gates:
+
+1. Review confirms the public/private ontology and IP boundary.
+2. STP and MPR private mappings both project into the candidate without
+   source-family fields leaking into the core.
+3. The concept vocabulary publication strategy is decided explicitly.
+4. A projector round-trip proves stable IDs, evidence custody and repeatable
+   output.
+5. Platform persistence, workspace authorization and RLS are designed against
+   the same graph without weakening tenant isolation.
+6. A migration and rollback note identifies every consumer before any
+   production artifact or `CONTRACTS` registration is added.
+
+Until then, this PR reserves and tests the shape only. Removing it changes no
+public data, runtime route or accepted conformance level.

--- a/docs/architecture/nvdm-semantic-core.md
+++ b/docs/architecture/nvdm-semantic-core.md
@@ -38,9 +38,10 @@ flowchart LR
 
 A subject is a stable real-world thing: a treatment facility, monitoring point,
 local government, river reach or aquifer. A subject set represents an explicit
-reported aggregation or analytical cohort. It prevents labels such as “two
-municipalities combined” from being fabricated into canonical real-world
-entities.
+publisher-reported aggregation over two or more subjects. It prevents labels
+such as “two municipalities combined” from being fabricated into canonical
+real-world entities. Analytical cohorts are deferred until a governed cohort-
+definition contract exists.
 
 The candidate has four claim families:
 
@@ -83,8 +84,15 @@ crosswalks become public remains an explicit product and IP decision.
 
 Values use a closed tagged union: quantity, range, text, terms, date or boolean.
 A quantity always names its unit and qualifier. A range always names its unit.
-Dates are real ISO years, year-months or dates. Time intervals use one precision
-at both ends and cannot run backwards.
+Terms are namespaced controlled codes; free source wording uses text. Dates are
+real ISO years, year-months or dates. Every claim is time-bound; time
+intervals use one precision at both ends and cannot run backwards. Assessed
+gaps may be quantitative or qualitative because source reports contain both
+numeric shortfalls and typed operational/compliance deficiencies.
+
+An assessed gap is a water-domain claim supported by evidence. An extraction
+warning, ambiguous mapping or missing reviewer decision remains private review
+workflow state and never becomes a canonical gap by convenience.
 
 `null` is never shorthand for missing, unreported or not applicable. If a
 source does not report a field, the private review workflow records that
@@ -135,6 +143,7 @@ receipt without changing their subject/claim shape.
 | One document contains several STPs | One canonical facility subject per resolved facility | One-candidate-per-document assumption |
 | STP reading belongs to an inlet or outlet | Monitoring point subject plus `part-of` relationship | Free-text location on the observation |
 | Result must be compared with a standard | Observation references a standing-fact claim | Baking pass/fail into the raw value |
+| A report states an operational deficiency | Qualitative assessed-gap claim with controlled terms | Confusing a domain gap with an extraction-review finding |
 | Two reports disagree | Both claims retained and linked as contradictions | Last-write-wins replacement |
 | A later report corrects an earlier value | New claim supersedes the old claim | Mutating historical evidence |
 | A source field is absent | No canonical claim is emitted | Null-as-unreported convention |

--- a/schemas/nvdm/README.md
+++ b/schemas/nvdm/README.md
@@ -49,3 +49,19 @@ CI (`.github/workflows/nvdm-conformance.yml`) runs the selftest, the freshness
 checks, and the L2 gate on newly added data artifacts - all **blocking**
 (v1 accepted 2026-07-30). New artifacts carry the envelope from their first
 commit; legacy files remain report-only until their city migrates.
+
+## Semantic core candidate
+
+`semantic-core.schema.json` and `semantic-records.schema.json` are a
+**0.1 candidate**, pressure-tested with the synthetic
+`examples/example-semantic-records.json` bundle. They define the interoperable
+shape for canonical subjects, explicit subject sets, immutable evidence and
+typed claims. The validator selftest exercises both schema conformance and
+cross-record graph integrity.
+
+This candidate does **not** change accepted NVDM v1. `semantic-core/records` is
+intentionally absent from `CONTRACTS`, no production artifact uses it, and no
+concept vocabulary has been accepted by implication. Registration is a later
+decision after the public/private ontology boundary, projector compatibility
+and persistence implications have been reviewed. See
+`docs/architecture/nvdm-semantic-core.md`.

--- a/schemas/nvdm/examples/example-semantic-records.json
+++ b/schemas/nvdm/examples/example-semantic-records.json
@@ -98,6 +98,20 @@
         "column_label": "Result",
         "field_key": "laboratory.outlet.bod"
       }
+    },
+    {
+      "id": "nv-example:evidence:mpr-operational-gap-cell",
+      "kind": "document-fragment",
+      "source_id": "nvdm-semantic-example",
+      "source_version_id": "example-mpr-2025-08",
+      "artifact_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "locator": {
+        "page_number": 5,
+        "table_label": "Example STP status table",
+        "row_label": "Example Ramanagara facility",
+        "column_label": "Reported operational gap",
+        "field_key": "stp.facility.example.operational-gap"
+      }
     }
   ],
   "relationships": [
@@ -116,6 +130,7 @@
       "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp-outlet" },
       "object": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp" },
       "basis": "reported",
+      "valid_time": { "start": "2025-08-15", "end": "2025-08-15" },
       "evidence_ids": ["nv-example:evidence:stp-bod-cell"]
     }
   ],
@@ -194,6 +209,18 @@
       },
       "assessed_time": { "start": "2025-08-31", "end": "2025-08-31" },
       "evidence_ids": ["nv-example:evidence:mpr-total-cell"]
+    },
+    {
+      "id": "nv-example:claim:stp-operational-gap",
+      "concept": "nv:facility-operational-gap",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp" },
+      "basis": "reported-assessment",
+      "value": {
+        "kind": "terms",
+        "values": ["nv:primary-clarifier-partly-operational"]
+      },
+      "assessed_time": { "start": "2025-08-31", "end": "2025-08-31" },
+      "evidence_ids": ["nv-example:evidence:mpr-operational-gap-cell"]
     }
   ]
 }

--- a/schemas/nvdm/examples/example-semantic-records.json
+++ b/schemas/nvdm/examples/example-semantic-records.json
@@ -1,0 +1,199 @@
+{
+  "nvdm": "1.0",
+  "dataset": "semantic-core/records",
+  "scope": { "kind": "basin", "id": "arkavathi" },
+  "provenance": {
+    "sources": [
+      {
+        "id": "nvdm-semantic-example",
+        "title": "Illustrative treatment-report fixture",
+        "publisher": "Neer Vazhvu",
+        "url": "https://neervazhvu.org/",
+        "license": "CC0-1.0",
+        "as_of": "2025-08-31",
+        "retrieved": "2026-08-04"
+      }
+    ],
+    "method": "pdf-extract",
+    "produced_at": "2026-08-04",
+    "produced_by": "schemas/nvdm/examples/example-semantic-records.json",
+    "note": "Schema pressure-test only. Every label and value is synthetic; this artifact does not claim that a publisher reported these records."
+  },
+  "semantic_schema": "0.1-candidate",
+  "subjects": [
+    {
+      "id": "nv-example:subject:ramanagara-cmc",
+      "kind": "nv:local-government",
+      "preferred_label": "Example Ramanagara municipal body",
+      "aliases": ["Example CMC Ramanagara"]
+    },
+    {
+      "id": "nv-example:subject:kanakapura-cmc",
+      "kind": "nv:local-government",
+      "preferred_label": "Example Kanakapura municipal body"
+    },
+    {
+      "id": "nv-example:subject:ramanagara-stp",
+      "kind": "nv:treatment-facility",
+      "preferred_label": "Example Ramanagara STP"
+    },
+    {
+      "id": "nv-example:subject:ramanagara-stp-outlet",
+      "kind": "nv:monitoring-point",
+      "preferred_label": "Example Ramanagara STP outlet"
+    }
+  ],
+  "subject_sets": [
+    {
+      "id": "nv-example:set:two-municipality-total",
+      "set_kind": "reported-aggregation",
+      "label": "Example publisher-reported total for two municipalities",
+      "member_subject_ids": [
+        "nv-example:subject:ramanagara-cmc",
+        "nv-example:subject:kanakapura-cmc"
+      ],
+      "basis": "reported",
+      "evidence_ids": ["nv-example:evidence:mpr-total-cell"]
+    }
+  ],
+  "evidence": [
+    {
+      "id": "nv-example:evidence:mpr-capacity-cell",
+      "kind": "document-fragment",
+      "source_id": "nvdm-semantic-example",
+      "source_version_id": "example-mpr-2025-08",
+      "artifact_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "locator": {
+        "page_number": 5,
+        "table_label": "Example STP table",
+        "row_label": "Example Ramanagara facility",
+        "column_label": "Capacity",
+        "field_key": "stp.facility.example.capacity"
+      }
+    },
+    {
+      "id": "nv-example:evidence:mpr-total-cell",
+      "kind": "document-fragment",
+      "source_id": "nvdm-semantic-example",
+      "source_version_id": "example-mpr-2025-08",
+      "artifact_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "locator": {
+        "page_number": 1,
+        "table_label": "Example municipal summary",
+        "row_label": "Treatment capacity total",
+        "column_label": "Total",
+        "field_key": "stp.summary.example.treatment-capacity.total"
+      }
+    },
+    {
+      "id": "nv-example:evidence:stp-bod-cell",
+      "kind": "document-fragment",
+      "source_id": "nvdm-semantic-example",
+      "source_version_id": "example-inspection-2025-08",
+      "artifact_sha256": "4111111111111111111111111111111111111111111111111111111111111111",
+      "locator": {
+        "page_number": 13,
+        "table_label": "Example outlet analysis",
+        "row_label": "BOD",
+        "column_label": "Result",
+        "field_key": "laboratory.outlet.bod"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "id": "nv-example:claim:stp-local-body-context",
+      "concept": "nv:reported-local-body-context",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp" },
+      "object": { "kind": "subject", "id": "nv-example:subject:ramanagara-cmc" },
+      "basis": "reported",
+      "valid_time": { "start": "2025-08-31", "end": "2025-08-31" },
+      "evidence_ids": ["nv-example:evidence:mpr-capacity-cell"]
+    },
+    {
+      "id": "nv-example:claim:outlet-part-of-stp",
+      "concept": "nv:part-of",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp-outlet" },
+      "object": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp" },
+      "basis": "reported",
+      "evidence_ids": ["nv-example:evidence:stp-bod-cell"]
+    }
+  ],
+  "standing_facts": [
+    {
+      "id": "nv-example:claim:stp-design-capacity",
+      "concept": "nv:facility-design-capacity",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp" },
+      "basis": "reported",
+      "value": {
+        "kind": "quantity",
+        "value": 7.5,
+        "unit": "MLD",
+        "qualifier": "exact"
+      },
+      "valid_time": { "start": "2025-08-31", "end": "2025-08-31" },
+      "evidence_ids": ["nv-example:evidence:mpr-capacity-cell"]
+    },
+    {
+      "id": "nv-example:claim:bod-regulatory-maximum",
+      "concept": "nv:bod-regulatory-maximum",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp-outlet" },
+      "basis": "reported",
+      "value": {
+        "kind": "quantity",
+        "value": 20,
+        "unit": "mg/L",
+        "qualifier": "exact"
+      },
+      "valid_time": { "start": "2025-08-15", "end": "2025-08-15" },
+      "evidence_ids": ["nv-example:evidence:stp-bod-cell"]
+    }
+  ],
+  "observations": [
+    {
+      "id": "nv-example:claim:reported-treatment-capacity-total",
+      "concept": "nv:treatment-capacity",
+      "subject": { "kind": "subject-set", "id": "nv-example:set:two-municipality-total" },
+      "basis": "reported",
+      "value": {
+        "kind": "quantity",
+        "value": 12.5,
+        "unit": "MLD",
+        "qualifier": "exact"
+      },
+      "observed_time": { "start": "2025-08-31", "end": "2025-08-31" },
+      "evidence_ids": ["nv-example:evidence:mpr-total-cell"]
+    },
+    {
+      "id": "nv-example:claim:outlet-bod",
+      "concept": "nv:bod",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-stp-outlet" },
+      "basis": "laboratory-measured",
+      "value": {
+        "kind": "quantity",
+        "value": 18,
+        "unit": "mg/L",
+        "qualifier": "exact"
+      },
+      "observed_time": { "start": "2025-08-15", "end": "2025-08-15" },
+      "comparison_claim_ids": ["nv-example:claim:bod-regulatory-maximum"],
+      "evidence_ids": ["nv-example:evidence:stp-bod-cell"]
+    }
+  ],
+  "assessed_gaps": [
+    {
+      "id": "nv-example:claim:sewage-treatment-gap",
+      "concept": "nv:sewage-treatment-capacity-gap",
+      "subject": { "kind": "subject", "id": "nv-example:subject:ramanagara-cmc" },
+      "basis": "reported-assessment",
+      "value": {
+        "kind": "quantity",
+        "value": 4,
+        "unit": "MLD",
+        "qualifier": "approximate"
+      },
+      "assessed_time": { "start": "2025-08-31", "end": "2025-08-31" },
+      "evidence_ids": ["nv-example:evidence:mpr-total-cell"]
+    }
+  ]
+}

--- a/schemas/nvdm/semantic-core.schema.json
+++ b/schemas/nvdm/semantic-core.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "semantic-core.schema.json",
+  "title": "NVDM semantic core candidate definitions",
+  "description": "Reusable candidate definitions for canonical subjects, explicit subject sets, evidence and typed water claims. This is an interchange contract, not a persistence schema or source-document model.",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9.-]*:[A-Za-z0-9][A-Za-z0-9._:-]*$",
+      "description": "Stable namespaced identifier. Labels, source row keys and document-local candidate keys are not canonical identifiers."
+    },
+    "concept": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9.-]*:[a-z][a-z0-9-]*$",
+      "description": "Namespaced semantic concept. The structural contract is public; mapping and crosswalk policy remain outside this schema."
+    },
+    "subject_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": { "enum": ["subject", "subject-set"] },
+        "id": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "time_interval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "$ref": "envelope.schema.json#/$defs/date" },
+        "end": { "$ref": "envelope.schema.json#/$defs/date" }
+      },
+      "description": "Closed interval. An instant uses the same ISO date for start and end."
+    },
+    "semantic_value": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["quantity", "range", "text", "terms", "date", "boolean"] },
+        "value": { "type": ["number", "string", "boolean"] },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "minimum": { "type": "number" },
+        "maximum": { "type": "number" },
+        "unit": { "type": "string", "minLength": 1 },
+        "qualifier": { "enum": ["exact", "approximate", "less-than", "greater-than"] }
+      },
+      "description": "Tagged value. Graph validation enforces the exact fields allowed for each kind; null never means absent or unreported."
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "preferred_label"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "kind": { "$ref": "#/$defs/concept" },
+        "preferred_label": { "type": "string", "minLength": 1 },
+        "aliases": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "external_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["scheme", "value"],
+            "properties": {
+              "scheme": { "type": "string", "minLength": 1 },
+              "value": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "subject_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "set_kind", "label", "member_subject_ids", "basis", "evidence_ids"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "set_kind": { "enum": ["reported-aggregation", "analytical-cohort"] },
+        "label": { "type": "string", "minLength": 1 },
+        "member_subject_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "basis": { "enum": ["reported", "derived"] },
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        }
+      },
+      "description": "An explicit set or reported aggregate, never a fabricated canonical subject."
+    },
+    "evidence_locator": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "page_number": { "type": "integer" },
+        "table_label": { "type": "string", "minLength": 1 },
+        "row_label": { "type": "string", "minLength": 1 },
+        "column_label": { "type": "string", "minLength": 1 },
+        "record_key": { "type": "string", "minLength": 1 },
+        "field_key": { "type": "string", "minLength": 1 },
+        "uri_fragment": { "type": "string", "minLength": 1 }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "source_id", "source_version_id", "artifact_sha256", "locator"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "kind": {
+          "enum": ["document-fragment", "dataset-record", "api-record", "field-record"]
+        },
+        "source_id": { "type": "string", "minLength": 1 },
+        "source_version_id": { "type": "string", "minLength": 1 },
+        "artifact_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "locator": { "$ref": "#/$defs/evidence_locator" }
+      }
+    },
+    "claim_common": {
+      "type": "object",
+      "required": ["id", "concept", "subject", "basis", "evidence_ids"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "concept": { "$ref": "#/$defs/concept" },
+        "subject": { "$ref": "#/$defs/subject_reference" },
+        "basis": {
+          "enum": ["reported", "observed", "instrument-reported", "laboratory-measured", "estimated", "derived", "reported-assessment"]
+        },
+        "evidence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "supersedes_claim_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "contradicts_claim_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "derived_from_claim_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        }
+      }
+    },
+    "relationship": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        { "$ref": "#/$defs/claim_common" },
+        {
+          "type": "object",
+          "required": ["object"],
+          "properties": {
+            "object": { "$ref": "#/$defs/subject_reference" },
+            "valid_time": { "$ref": "#/$defs/time_interval" }
+          }
+        }
+      ]
+    },
+    "standing_fact": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        { "$ref": "#/$defs/claim_common" },
+        {
+          "type": "object",
+          "required": ["value"],
+          "properties": {
+            "value": { "$ref": "#/$defs/semantic_value" },
+            "valid_time": { "$ref": "#/$defs/time_interval" }
+          }
+        }
+      ]
+    },
+    "observation": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        { "$ref": "#/$defs/claim_common" },
+        {
+          "type": "object",
+          "required": ["value", "observed_time"],
+          "properties": {
+            "value": { "$ref": "#/$defs/semantic_value" },
+            "observed_time": { "$ref": "#/$defs/time_interval" },
+            "comparison_claim_ids": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/identifier" },
+              "description": "Standing-fact claims such as an applicable regulatory maximum or range."
+            }
+          }
+        }
+      ]
+    },
+    "assessed_gap": {
+      "unevaluatedProperties": false,
+      "allOf": [
+        { "$ref": "#/$defs/claim_common" },
+        {
+          "type": "object",
+          "required": ["value", "assessed_time"],
+          "properties": {
+            "value": { "$ref": "#/$defs/semantic_value" },
+            "assessed_time": { "$ref": "#/$defs/time_interval" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/nvdm/semantic-core.schema.json
+++ b/schemas/nvdm/semantic-core.schema.json
@@ -44,7 +44,7 @@
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "type": "string", "minLength": 1 }
+          "items": { "$ref": "#/$defs/concept" }
         },
         "minimum": { "type": "number" },
         "maximum": { "type": "number" },
@@ -87,15 +87,15 @@
       "required": ["id", "set_kind", "label", "member_subject_ids", "basis", "evidence_ids"],
       "properties": {
         "id": { "$ref": "#/$defs/identifier" },
-        "set_kind": { "enum": ["reported-aggregation", "analytical-cohort"] },
+        "set_kind": { "enum": ["reported-aggregation"] },
         "label": { "type": "string", "minLength": 1 },
         "member_subject_ids": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 2,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/identifier" }
         },
-        "basis": { "enum": ["reported", "derived"] },
+        "basis": { "enum": ["reported"] },
         "evidence_ids": {
           "type": "array",
           "minItems": 1,
@@ -103,7 +103,7 @@
           "items": { "$ref": "#/$defs/identifier" }
         }
       },
-      "description": "An explicit set or reported aggregate, never a fabricated canonical subject."
+      "description": "An explicit publisher-reported aggregate over two or more subjects, never a fabricated canonical subject. Analytical cohorts require a future governed definition contract."
     },
     "evidence_locator": {
       "type": "object",
@@ -172,7 +172,7 @@
         { "$ref": "#/$defs/claim_common" },
         {
           "type": "object",
-          "required": ["object"],
+          "required": ["object", "valid_time"],
           "properties": {
             "object": { "$ref": "#/$defs/subject_reference" },
             "valid_time": { "$ref": "#/$defs/time_interval" }
@@ -186,7 +186,7 @@
         { "$ref": "#/$defs/claim_common" },
         {
           "type": "object",
-          "required": ["value"],
+          "required": ["value", "valid_time"],
           "properties": {
             "value": { "$ref": "#/$defs/semantic_value" },
             "valid_time": { "$ref": "#/$defs/time_interval" }

--- a/schemas/nvdm/semantic-records.schema.json
+++ b/schemas/nvdm/semantic-records.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "semantic-records.schema.json",
+  "title": "semantic-core/records candidate contract",
+  "description": "Self-contained NVDM semantic release bundle. Typed collections share one subject/evidence graph; this bundle is an interchange and validation unit, not a database layout.",
+  "allOf": [{ "$ref": "envelope.schema.json#/$defs/envelope" }],
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": ["semantic_schema", "subjects", "subject_sets", "evidence", "relationships", "standing_facts", "observations", "assessed_gaps"],
+  "properties": {
+    "semantic_schema": { "enum": ["0.1-candidate"] },
+    "subjects": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/subject" }
+    },
+    "subject_sets": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/subject_set" }
+    },
+    "evidence": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/evidence" }
+    },
+    "relationships": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/relationship" }
+    },
+    "standing_facts": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/standing_fact" }
+    },
+    "observations": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/observation" }
+    },
+    "assessed_gaps": {
+      "type": "array",
+      "items": { "$ref": "semantic-core.schema.json#/$defs/assessed_gap" }
+    }
+  }
+}

--- a/scripts/validate_nvdm.py
+++ b/scripts/validate_nvdm.py
@@ -675,8 +675,6 @@ def semantic_graph_errors(doc: dict) -> list[str]:
             interval(row.get("assessed_time"), f"{path}.assessed_time")
             if row.get("basis") not in ("reported-assessment", "derived"):
                 errs.append(f"{path}.basis: assessed gaps must be reported-assessment or derived")
-            if isinstance(row.get("value"), dict) and row["value"].get("kind") not in ("quantity", "range"):
-                errs.append(f"{path}.value: assessed gaps must be quantities or ranges")
         evidence_refs(row, path)
         own_id = row.get("id")
         if row.get("basis") == "derived" and not row.get("derived_from_claim_ids"):
@@ -1081,6 +1079,18 @@ def selftest(schemas: dict[str, dict]) -> int:
     check("semantic global duplicate id rejected", bool(semantic_graph_errors(d)))
     d = dup(semantic); d["standing_facts"][0]["value"]["unused"] = "hidden"
     check("semantic tagged-value placeholder rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0].pop("valid_time")
+    check(
+        "semantic standing facts require time",
+        bool(validate(d, schemas["semantic-records.schema.json"], schemas, "semantic-records.schema.json")),
+    )
+    d = dup(semantic); d["subject_sets"][0]["member_subject_ids"] = [
+        d["subject_sets"][0]["member_subject_ids"][0]
+    ]
+    check(
+        "semantic reported aggregates require multiple subjects",
+        bool(validate(d, schemas["semantic-records.schema.json"], schemas, "semantic-records.schema.json")),
+    )
     d = dup(semantic); d["observations"][0]["observed_time"] = {
         "start": "2025-09-01", "end": "2025-08-31"
     }

--- a/scripts/validate_nvdm.py
+++ b/scripts/validate_nvdm.py
@@ -15,16 +15,19 @@ Usage:
 
 Stdlib only. Implements the subset of JSON Schema the NVDM schemas restrict
 themselves to: type (incl. unions), properties, required, items, enum, pattern,
-minItems, allOf, and $ref within schemas/nvdm/ files. Run the catalogue builder
-first; this tool deliberately reuses its output instead of re-walking the tree.
+minItems, minLength, uniqueItems, additionalProperties:false, allOf, and $ref
+within schemas/nvdm/ files. Run the catalogue builder first; this tool
+deliberately reuses its output instead of re-walking the tree.
 """
 
 from __future__ import annotations
 
 import json
+import math
 import re
 import sys
 from collections import defaultdict
+from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -288,8 +291,6 @@ def source_accountability_errors(
 def calendar_date_errors(doc: dict) -> list[str]:
     """Bounded patterns admit 2026-02-30; real calendars do not. Checks every
     envelope date and claim-record data_date/as_of."""
-    from datetime import date
-
     def bad(v) -> bool:
         if not isinstance(v, str) or len(v) != 10:
             return False  # year / year-month forms carry no day to mis-state
@@ -314,6 +315,417 @@ def calendar_date_errors(doc: dict) -> list[str]:
                 for k in ("as_of", "data_date"):
                     if bad(r.get(k)):
                         errs.append(f"$.{coll}[{i}].{k} '{r.get(k)}' is not a real calendar date")
+    return errs
+
+
+SEMANTIC_CLAIM_COLLECTIONS = (
+    "relationships",
+    "standing_facts",
+    "observations",
+    "assessed_gaps",
+)
+
+
+def semantic_value_errors(value, path: str) -> list[str]:
+    """Candidate semantic-core value rules JSON Schema cannot express cleanly.
+
+    The tagged union is deliberately closed: no unused placeholder fields, no
+    null-as-absence and no quantity without an explicit unit/qualifier.
+    """
+    if not isinstance(value, dict):
+        return [f"{path}: semantic value must be an object"]
+    kind = value.get("kind")
+    expected = {
+        "quantity": {"kind", "value", "unit", "qualifier"},
+        "range": {"kind", "minimum", "maximum", "unit"},
+        "text": {"kind", "value"},
+        "terms": {"kind", "values"},
+        "date": {"kind", "value"},
+        "boolean": {"kind", "value"},
+    }.get(kind)
+    if expected is None:
+        return [f"{path}: unsupported semantic value kind {kind!r}"]
+    actual = set(value)
+    if actual != expected:
+        return [
+            f"{path}: {kind} value keys differ "
+            f"(missing={sorted(expected - actual)}, extra={sorted(actual - expected)})"
+        ]
+    raw = value.get("value")
+    if kind == "quantity" and (
+        not isinstance(raw, (int, float))
+        or isinstance(raw, bool)
+        or not math.isfinite(raw)
+    ):
+        return [f"{path}.value: quantity must be numeric"]
+    if kind == "quantity" and (
+        not isinstance(value.get("unit"), str) or not value["unit"].strip()
+    ):
+        return [f"{path}.unit: quantity unit must be a non-empty string"]
+    if kind == "range":
+        low, high = value.get("minimum"), value.get("maximum")
+        if not all(
+            isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(v)
+            for v in (low, high)
+        ):
+            return [f"{path}: range bounds must be numeric"]
+        if low > high:
+            return [f"{path}: range minimum exceeds maximum"]
+        if not isinstance(value.get("unit"), str) or not value["unit"].strip():
+            return [f"{path}.unit: range unit must be a non-empty string"]
+    if kind in ("text", "date") and (not isinstance(raw, str) or not raw.strip()):
+        return [f"{path}.value: {kind} value must be a non-empty string"]
+    if kind == "date" and isinstance(raw, str):
+        try:
+            valid = (
+                (len(raw) == 4 and 1 <= int(raw) <= 9999)
+                or (
+                    len(raw) == 7
+                    and 1 <= int(raw[:4]) <= 9999
+                    and raw[4] == "-"
+                    and 1 <= int(raw[5:]) <= 12
+                )
+                or (len(raw) == 10 and date.fromisoformat(raw).isoformat() == raw)
+            )
+        except (TypeError, ValueError):
+            valid = False
+        if not valid:
+            return [f"{path}.value: date must be an ISO year, year-month or date"]
+    if kind == "terms":
+        terms = value.get("values")
+        if (
+            not isinstance(terms, list)
+            or not terms
+            or not all(isinstance(term, str) and term.strip() for term in terms)
+            or len(terms) != len(set(terms))
+        ):
+            return [f"{path}.values: terms must be a non-empty unique list"]
+    if kind == "boolean" and not isinstance(raw, bool):
+        return [f"{path}.value: boolean value must be true or false"]
+    return []
+
+
+def semantic_graph_errors(doc: dict) -> list[str]:
+    """Cross-record integrity for the candidate semantic release bundle.
+
+    This is intentionally separate from source adapters and concept mapping.
+    It validates the graph the public contract owns: globally unique IDs,
+    resolvable subjects/evidence/lifecycle edges, time/value discipline and
+    source-version custody.
+    """
+    if not isinstance(doc, dict):
+        return ["semantic artifact must be an object"]
+    errs: list[str] = []
+
+    def closed_keys(value, allowed: set[str], path: str) -> None:
+        if not isinstance(value, dict):
+            return
+        extra = set(value) - allowed
+        if extra:
+            errs.append(f"{path}: unsupported keys {sorted(extra)}")
+
+    def records(key: str) -> list:
+        value = doc.get(key)
+        return value if isinstance(value, list) else []
+
+    subjects = records("subjects")
+    subject_sets = records("subject_sets")
+    evidence = records("evidence")
+    claim_groups = {key: records(key) for key in SEMANTIC_CLAIM_COLLECTIONS}
+
+    subject_keys = {"id", "kind", "preferred_label", "aliases", "external_ids"}
+    external_id_keys = {"scheme", "value"}
+    subject_set_keys = {
+        "id", "set_kind", "label", "member_subject_ids", "basis", "evidence_ids",
+    }
+    evidence_keys = {
+        "id", "kind", "source_id", "source_version_id", "artifact_sha256",
+        "locator",
+    }
+    subject_ref_keys = {"kind", "id"}
+    interval_keys = {"start", "end"}
+    claim_common_keys = {
+        "id", "concept", "subject", "basis", "evidence_ids",
+        "supersedes_claim_ids", "contradicts_claim_ids", "derived_from_claim_ids",
+    }
+    claim_keys = {
+        "relationships": claim_common_keys | {"object", "valid_time"},
+        "standing_facts": claim_common_keys | {"value", "valid_time"},
+        "observations": claim_common_keys | {
+            "value", "observed_time", "comparison_claim_ids",
+        },
+        "assessed_gaps": claim_common_keys | {"value", "assessed_time"},
+    }
+
+    for index, row in enumerate(subjects):
+        closed_keys(row, subject_keys, f"$.subjects[{index}]")
+        if isinstance(row, dict):
+            for external_index, external_id in enumerate(row.get("external_ids", [])):
+                closed_keys(
+                    external_id,
+                    external_id_keys,
+                    f"$.subjects[{index}].external_ids[{external_index}]",
+                )
+    for index, row in enumerate(subject_sets):
+        closed_keys(row, subject_set_keys, f"$.subject_sets[{index}]")
+    for index, row in enumerate(evidence):
+        closed_keys(row, evidence_keys, f"$.evidence[{index}]")
+    for collection, rows in claim_groups.items():
+        for index, row in enumerate(rows):
+            closed_keys(row, claim_keys[collection], f"$.{collection}[{index}]")
+
+    external_identity_owner: dict[tuple[str, str], str] = {}
+    for index, row in enumerate(subjects):
+        if not isinstance(row, dict):
+            continue
+        for external_index, external_id in enumerate(row.get("external_ids", [])):
+            if not isinstance(external_id, dict):
+                continue
+            key = (external_id.get("scheme"), external_id.get("value"))
+            if not all(isinstance(part, str) for part in key):
+                continue
+            path = f"$.subjects[{index}].external_ids[{external_index}]"
+            if key in external_identity_owner:
+                errs.append(
+                    f"{path}: external identity {key!r} is already bound to "
+                    f"{external_identity_owner[key]}"
+                )
+            else:
+                external_identity_owner[key] = (
+                    row["id"] if isinstance(row.get("id"), str) else path
+                )
+
+    all_ids: dict[str, str] = {}
+    for collection, rows in (
+        ("subjects", subjects),
+        ("subject_sets", subject_sets),
+        ("evidence", evidence),
+        *((key, rows) for key, rows in claim_groups.items()),
+    ):
+        for index, row in enumerate(rows):
+            if not isinstance(row, dict) or not isinstance(row.get("id"), str):
+                continue
+            rid = row["id"]
+            if rid in all_ids:
+                errs.append(
+                    f"$.{collection}[{index}].id: {rid!r} duplicates {all_ids[rid]}"
+                )
+            else:
+                all_ids[rid] = f"$.{collection}[{index}]"
+
+    subject_ids = {
+        r["id"] for r in subjects
+        if isinstance(r, dict) and isinstance(r.get("id"), str)
+    }
+    set_ids = {
+        r["id"] for r in subject_sets
+        if isinstance(r, dict) and isinstance(r.get("id"), str)
+    }
+    evidence_ids = {
+        r["id"] for r in evidence
+        if isinstance(r, dict) and isinstance(r.get("id"), str)
+    }
+    claims = [
+        (collection, index, row)
+        for collection, rows in claim_groups.items()
+        for index, row in enumerate(rows)
+        if isinstance(row, dict)
+    ]
+    claim_ids = {
+        row["id"] for _, _, row in claims if isinstance(row.get("id"), str)
+    }
+    if not claims:
+        errs.append("semantic artifact must contain at least one typed claim")
+
+    source_ids = {
+        source.get("id")
+        for source in doc.get("provenance", {}).get("sources", [])
+        if isinstance(source, dict) and source.get("id")
+    }
+    locator_keys = {
+        "page_number", "table_label", "row_label", "column_label",
+        "record_key", "field_key", "uri_fragment",
+    }
+    source_version_artifacts: dict[tuple[str, str], str] = {}
+    for index, row in enumerate(evidence):
+        if not isinstance(row, dict):
+            continue
+        if row.get("source_id") not in source_ids:
+            errs.append(
+                f"$.evidence[{index}].source_id: {row.get('source_id')!r} "
+                "does not resolve to provenance.sources"
+            )
+        version_key = (row.get("source_id"), row.get("source_version_id"))
+        artifact_hash = row.get("artifact_sha256")
+        if all(isinstance(part, str) for part in version_key) and isinstance(artifact_hash, str):
+            previous = source_version_artifacts.get(version_key)
+            if previous is not None and previous != artifact_hash:
+                errs.append(
+                    f"$.evidence[{index}].artifact_sha256: source version "
+                    f"{version_key!r} has conflicting artifact hashes"
+                )
+            else:
+                source_version_artifacts[version_key] = artifact_hash
+        locator = row.get("locator")
+        if not isinstance(locator, dict) or not locator:
+            errs.append(f"$.evidence[{index}].locator: at least one locator is required")
+        else:
+            closed_keys(locator, locator_keys, f"$.evidence[{index}].locator")
+            if row.get("kind") == "document-fragment" and (
+                not isinstance(locator.get("page_number"), int)
+                or isinstance(locator.get("page_number"), bool)
+                or locator["page_number"] < 1
+            ):
+                errs.append(
+                    f"$.evidence[{index}].locator.page_number: document fragments require a positive page"
+                )
+
+    def evidence_refs(row: dict, path: str) -> None:
+        for evidence_id in row.get("evidence_ids", []):
+            if evidence_id not in evidence_ids:
+                errs.append(f"{path}.evidence_ids: unknown evidence {evidence_id!r}")
+
+    for index, row in enumerate(subject_sets):
+        if not isinstance(row, dict):
+            continue
+        path = f"$.subject_sets[{index}]"
+        for subject_id in row.get("member_subject_ids", []):
+            if subject_id not in subject_ids:
+                errs.append(f"{path}.member_subject_ids: unknown subject {subject_id!r}")
+        evidence_refs(row, path)
+
+    def subject_ref(ref, path: str) -> None:
+        if not isinstance(ref, dict):
+            return
+        closed_keys(ref, subject_ref_keys, path)
+        rid = ref.get("id")
+        if ref.get("kind") == "subject" and rid not in subject_ids:
+            errs.append(f"{path}: unknown subject {rid!r}")
+        elif ref.get("kind") == "subject-set" and rid not in set_ids:
+            errs.append(f"{path}: unknown subject set {rid!r}")
+
+    def interval(value, path: str) -> None:
+        def valid(part) -> bool:
+            if not isinstance(part, str):
+                return False
+            try:
+                if len(part) == 4:
+                    return 1 <= int(part) <= 9999
+                if len(part) == 7:
+                    year, month = map(int, part.split("-"))
+                    return 1 <= year <= 9999 and 1 <= month <= 12
+                return len(part) == 10 and date.fromisoformat(part).isoformat() == part
+            except (TypeError, ValueError):
+                return False
+
+        if not isinstance(value, dict):
+            return
+        closed_keys(value, interval_keys, path)
+        start, end = value.get("start"), value.get("end")
+        if isinstance(start, str) and isinstance(end, str):
+            if not valid(start) or not valid(end):
+                errs.append(f"{path}: interval contains an invalid calendar date")
+            elif len(start) != len(end):
+                errs.append(f"{path}: interval endpoints must use the same precision")
+            elif end < start:
+                errs.append(f"{path}: interval end precedes start")
+
+    lifecycle = ("supersedes_claim_ids", "contradicts_claim_ids", "derived_from_claim_ids")
+    claim_collections_by_id = {
+        row["id"]: collection
+        for collection, _, row in claims
+        if isinstance(row.get("id"), str)
+    }
+    claims_by_id = {
+        row["id"]: row
+        for _, _, row in claims
+        if isinstance(row.get("id"), str)
+    }
+    supersedes: dict[str, list[str]] = {}
+    derivations: dict[str, list[str]] = {}
+    for collection, index, row in claims:
+        path = f"$.{collection}[{index}]"
+        subject_ref(row.get("subject"), f"{path}.subject")
+        if collection == "relationships":
+            subject_ref(row.get("object"), f"{path}.object")
+            interval(row.get("valid_time"), f"{path}.valid_time")
+            if row.get("basis") not in ("reported", "derived"):
+                errs.append(f"{path}.basis: relationships must be reported or derived")
+        elif collection == "standing_facts":
+            errs += semantic_value_errors(row.get("value"), f"{path}.value")
+            interval(row.get("valid_time"), f"{path}.valid_time")
+            if row.get("basis") not in ("reported", "derived"):
+                errs.append(f"{path}.basis: standing facts must be reported or derived")
+        elif collection == "observations":
+            errs += semantic_value_errors(row.get("value"), f"{path}.value")
+            interval(row.get("observed_time"), f"{path}.observed_time")
+            if row.get("basis") == "reported-assessment":
+                errs.append(f"{path}.basis: reported-assessment belongs in assessed_gaps")
+            for target in row.get("comparison_claim_ids", []):
+                if target not in claim_ids:
+                    errs.append(f"{path}.comparison_claim_ids: unknown claim {target!r}")
+                elif claim_collections_by_id.get(target) != "standing_facts":
+                    errs.append(
+                        f"{path}.comparison_claim_ids: {target!r} is not a standing fact"
+                    )
+        elif collection == "assessed_gaps":
+            errs += semantic_value_errors(row.get("value"), f"{path}.value")
+            interval(row.get("assessed_time"), f"{path}.assessed_time")
+            if row.get("basis") not in ("reported-assessment", "derived"):
+                errs.append(f"{path}.basis: assessed gaps must be reported-assessment or derived")
+            if isinstance(row.get("value"), dict) and row["value"].get("kind") not in ("quantity", "range"):
+                errs.append(f"{path}.value: assessed gaps must be quantities or ranges")
+        evidence_refs(row, path)
+        own_id = row.get("id")
+        if row.get("basis") == "derived" and not row.get("derived_from_claim_ids"):
+            errs.append(
+                f"{path}.derived_from_claim_ids: derived claims must name their inputs"
+            )
+        for key in lifecycle:
+            for target in row.get(key, []):
+                if target == own_id:
+                    errs.append(f"{path}.{key}: a claim cannot reference itself")
+                elif target not in claim_ids:
+                    errs.append(f"{path}.{key}: unknown claim {target!r}")
+                elif key == "supersedes_claim_ids":
+                    older = claims_by_id[target]
+                    if (
+                        claim_collections_by_id[target] != collection
+                        or older.get("concept") != row.get("concept")
+                        or older.get("subject") != row.get("subject")
+                    ):
+                        errs.append(
+                            f"{path}.{key}: superseded claim {target!r} must have "
+                            "the same family, concept and subject"
+                        )
+        if isinstance(own_id, str):
+            supersedes[own_id] = row.get("supersedes_claim_ids", [])
+            derivations[own_id] = row.get("derived_from_claim_ids", [])
+
+    def reject_cycles(edge_name: str, graph: dict[str, list[str]]) -> None:
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit(claim_id: str) -> None:
+            if claim_id in visiting:
+                errs.append(f"{edge_name} contains a cycle at {claim_id!r}")
+                return
+            if claim_id in visited:
+                return
+            visiting.add(claim_id)
+            for target in graph.get(claim_id, []):
+                if target in graph:
+                    visit(target)
+            visiting.remove(claim_id)
+            visited.add(claim_id)
+
+        for claim_id in graph:
+            visit(claim_id)
+
+    reject_cycles("supersedes_claim_ids", supersedes)
+    reject_cycles("derived_from_claim_ids", derivations)
     return errs
 
 
@@ -555,6 +967,7 @@ def selftest(schemas: dict[str, dict]) -> int:
 
     facts = json.loads((SCHEMA_DIR / "examples/example-facts.json").read_text())
     wb = json.loads((SCHEMA_DIR / "examples/example-water-bodies-current.geojson").read_text())
+    semantic = json.loads((SCHEMA_DIR / "examples/example-semantic-records.json").read_text())
 
     # Positives: examples must pass the FULL L3 path (envelope + registry
     # agreement + accountability + contract + claim + unknown-key), with the
@@ -571,6 +984,32 @@ def selftest(schemas: dict[str, dict]) -> int:
         check(f"{name} passes full L3 path", not errs)
         for e in errs[:6]:
             print(f"  {e}")
+
+    semantic_ids = {
+        source["id"]
+        for source in semantic["provenance"]["sources"]
+        if source.get("id")
+    }
+    semantic_errs = env(semantic)
+    semantic_errs += validate(
+        semantic,
+        schemas["semantic-records.schema.json"],
+        schemas,
+        "semantic-records.schema.json",
+    )
+    semantic_errs += scope_registry_errors(semantic, scopes)
+    semantic_errs += source_accountability_errors(
+        semantic, semantic_ids, semantic_ids, "semantic-core/records"
+    )
+    semantic_errs += provenance_rule_errors(semantic)
+    semantic_errs += semantic_graph_errors(semantic)
+    semantic_errs += unknown_key_errors(
+        semantic, schemas["semantic-records.schema.json"]
+    )
+    semantic_errs += license_errors(semantic)
+    check("example-semantic-records passes candidate full-graph path", not semantic_errs)
+    for error in semantic_errs[:10]:
+        print(f"  {error}")
 
     # Negatives: each acceptance gap found in review must stay closed.
     bad = {"nvdm": "1.0", "dataset": "data-root/facts", "scope": {"kind": "city"}}
@@ -633,6 +1072,69 @@ def selftest(schemas: dict[str, dict]) -> int:
     d["features"].append({"type": "Feature", "geometry": None, "properties": {}})
     errs = validate(d, schemas["water-bodies-current.schema.json"], schemas, "water-bodies-current.schema.json")
     check("invalid record beyond position 500 caught", any("[501]" in e for e in errs))
+
+    d = dup(semantic); d["observations"][0]["subject"]["id"] = "nv-example:subject:missing"
+    check("semantic dangling subject rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["evidence_ids"] = ["nv-example:evidence:missing"]
+    check("semantic dangling evidence rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["evidence"][0]["id"] = d["subjects"][0]["id"]
+    check("semantic global duplicate id rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["value"]["unused"] = "hidden"
+    check("semantic tagged-value placeholder rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["observations"][0]["observed_time"] = {
+        "start": "2025-09-01", "end": "2025-08-31"
+    }
+    check("semantic reverse interval rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["supersedes_claim_ids"] = [
+        d["standing_facts"][0]["id"]
+    ]
+    check("semantic self-supersession rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["observations"][0]["supersedes_claim_ids"] = [
+        d["standing_facts"][0]["id"]
+    ]
+    check(
+        "semantic supersession stays within claim identity",
+        any("same family, concept and subject" in error for error in semantic_graph_errors(d)),
+    )
+    d = dup(semantic)
+    first, second = d["standing_facts"]
+    first["basis"] = second["basis"] = "derived"
+    first["derived_from_claim_ids"] = [second["id"]]
+    second["derived_from_claim_ids"] = [first["id"]]
+    check(
+        "semantic derivation cycles rejected",
+        any("derived_from_claim_ids contains a cycle" in error for error in semantic_graph_errors(d)),
+    )
+    d = dup(semantic); d["evidence"][0]["source_id"] = "missing-source"
+    check("semantic evidence source custody rejected", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["undocumented_shortcut"] = True
+    check("semantic nested claim keys are closed", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["observations"][0]["comparison_claim_ids"] = [
+        d["observations"][1]["id"]
+    ]
+    check("semantic comparison target must be a standing fact", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["basis"] = "derived"
+    check("semantic derived claim requires inputs", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["evidence"][1]["source_version_id"] = d["evidence"][0]["source_version_id"]
+    d["evidence"][1]["artifact_sha256"] = "f" * 64
+    check("semantic source version has one artifact hash", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["subjects"][0]["external_ids"] = [
+        {"scheme": "example-register", "value": "STP-1"}
+    ]
+    d["subjects"][1]["external_ids"] = [
+        {"scheme": "example-register", "value": "STP-1"}
+    ]
+    check("semantic external identity has one subject", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["observations"][0]["observed_time"]["timezone"] = "UTC"
+    check("semantic interval keys are closed", bool(semantic_graph_errors(d)))
+    d = dup(semantic); d["standing_facts"][0]["value"] = {
+        "kind": "date", "value": "2026-02-30"
+    }
+    check("semantic date value must be a real date", bool(semantic_graph_errors(d)))
+    d = dup(semantic)
+    for collection in SEMANTIC_CLAIM_COLLECTIONS:
+        d[collection] = []
+    check("semantic empty claim bundle rejected", bool(semantic_graph_errors(d)))
 
     # ---- L2 gate selector regression (2026-07-30 review: --diff-filter=A
     # missed renames into serving; unprefixed pathspecs missed path shapes).


### PR DESCRIPTION
## Outcome

Defines a review-only NVDM semantic-core candidate so different private intake contracts can converge on one interoperable data model.

The candidate introduces:

- canonical subjects and explicit publisher-reported subject sets;
- immutable source-artifact evidence with precise locators;
- time-bound relationships, standing facts, observations, and assessed gaps;
- quantitative and qualitative gaps without conflating domain gaps with review findings;
- tagged values, controlled categorical terms, comparison links, and append-only lifecycle edges;
- executable graph invariants for identity, custody, references, derivation, and supersession;
- a synthetic STP/MPR pressure-test bundle and an architecture decision record.

## Boundary

This does not register a production contract, change accepted NVDM v1, add a public dataset, or accept a concept vocabulary. Source extraction contracts, mappings, entity resolution, review decisions, and customer records remain private operational concerns.

Analytical cohorts and model-run evidence are deliberately deferred until their own governed definition and execution-provenance contracts exist.

## Validation

- `python3 scripts/validate_nvdm.py --selftest`
- catalogue and conformance-report freshness generation
- NVDM L2 gate against `origin/main`
- Python bytecode compilation
- JSON parsing for all candidate artifacts
- Ajv 2020-12 positive example and closed-shape negative probe
- `git diff --check`

All passed locally.

## Base freshness repair

The branch also updates two generated byte-count fields for `mmr-dam-storage.json`. The scheduled Pravah refresh changed the artifact from 4,562 to 4,566 bytes without refreshing the catalogue; the schema-path CI job regenerates the catalogue and would otherwise fail on the unchanged base.

## Acceptance gates

The contract remains a candidate until the public/private ontology boundary, concept publication strategy, STP and MPR projector compatibility, stable-ID round trip, and platform persistence/RLS implications are reviewed.