### PR TITLE
Consume the corpus at a locked data revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
 # Serving-hardening D4 split (review addendum 2026-07-30): the FULL-corpus
-# jobs validate against the complete corpus (today: from the checkout; after
-# the P2 cutover: fetched via scripts/fetch-corpus.sh, which requires the
-# CORPUS_REPO_TOKEN secret and therefore cannot run on fork PRs). The
+# jobs validate against the complete corpus fetched at the immutable
+# corpus.lock commit. This requires the CORPUS_REPO_TOKEN secret and therefore
+# runs only on main pushes and same-repository PRs. The
 # sample-corpus job needs no secrets and runs everywhere: it prunes the
 # corpus to the clean reference set plus documented fixtures
 # (scripts/sample-corpus.json) and proves build + tests pass against it.
@@ -18,8 +18,11 @@ on:
 
 jobs:
   frontend:
-    name: Frontend - full corpus from checkout (lint + build + tests + data checks)
+    name: Frontend - locked full corpus (lint + build + tests + data checks)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    env:
+      CORPUS_SOURCE: remote
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +37,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Fetch exact corpus.lock edition
+        run: bash scripts/fetch-corpus.sh
+        env:
+          CORPUS_REPO_TOKEN: ${{ secrets.CORPUS_REPO_TOKEN }}
 
       - run: npm ci
       - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -379,6 +379,18 @@ Areas where help is needed:
 
 Please open an issue first to discuss significant changes.
 
+## Corpus build source
+
+Local development uses the corpus committed under `public/data/` and
+`public/geojson/` by default. Full-corpus CI and hosted deployments can instead
+set `CORPUS_SOURCE=remote` and provide a `CORPUS_REPO_TOKEN` with read-only
+Contents access to `neer-vazhvu-data`. The build then fetches the exact commit
+and file counts recorded in [`corpus.lock`](corpus.lock), and fails rather than
+falling back to partial data. Preview and Production variables are configured
+separately; promote the remote mode to Production only after its Preview build
+and rollback checks pass. The token is removed from the environment before the
+Next.js compiler runs.
+
 ## License
 
 [MIT](LICENSE) - for the **code**.

--- a/corpus.lock
+++ b/corpus.lock
@@ -1,9 +1,9 @@
 {
   "_doc": [
     "Pins the private data repo commit that scripts/fetch-corpus.sh syncs into",
-    "public/data + public/geojson when CORPUS_SOURCE=remote (serving-hardening",
-    "P1). With CORPUS_SOURCE unset or 'repo' this file is inert and the corpus",
-    "comes from the git checkout. The data repo's toolchain.lock is the",
+    "public/data + public/geojson when CORPUS_SOURCE=remote. With",
+    "CORPUS_SOURCE unset or 'repo' this file is inert and the corpus comes",
+    "from the git checkout. The data repo's toolchain.lock is the",
     "mirror-image pin in the other direction. Bump deliberately: deploys stay",
     "reproducible and rolling back the site rolls back the data.",
     "expected_files pins the per-root file counts at the locked commit - the",
@@ -12,9 +12,9 @@
     "success."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "30adf016537a9980b7efa1d7b63f6d59379a8497",
+  "sha": "9ac54136e16046dbda6d2f00e5fd3271e4744856",
   "expected_files": {
-    "data": 380,
+    "data": 382,
     "geojson": 92
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "bash scripts/fetch-corpus.sh && next build",
+    "build": "bash scripts/fetch-corpus.sh && unset CORPUS_REPO_TOKEN && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "find src -name '*.test.ts' | xargs tsx --test",

--- a/scripts/fetch-corpus.sh
+++ b/scripts/fetch-corpus.sh
@@ -41,19 +41,17 @@ esac
 
 REPO="$(python3 -c "import json; print(json.load(open('$LOCK'))['repo'])")"
 SHA="$(python3 -c "import json; print(json.load(open('$LOCK'))['sha'])")"
+EXPECTED_REPO="github.com/SundareshPrasanna/neer-vazhvu-data"
 
-if [[ -n "${CORPUS_REPO_TOKEN:-}" ]]; then
-  URL="https://x-access-token:${CORPUS_REPO_TOKEN}@${REPO}.git"
-elif [[ "${CORPUS_USE_GIT_AUTH:-0}" == "1" ]]; then
-  URL="https://${REPO}.git"
-else
-  cat >&2 <<'EOF'
-fetch-corpus: CORPUS_SOURCE=remote but no credential is configured.
-Set CORPUS_REPO_TOKEN (fine-grained PAT with Contents: Read on the data
-repo) or, on a developer machine with git auth, CORPUS_USE_GIT_AUTH=1.
-Refusing to fall back silently (D4): a build without the real corpus must
-fail, not go green against partial data.
-EOF
+# The read credential must never be sent to a repository selected by a changed
+# lock file. P2 full-corpus CI runs only for branches in this repository, but
+# this allowlist remains the credential's final fail-closed boundary.
+if [[ "$REPO" != "$EXPECTED_REPO" ]]; then
+  echo "fetch-corpus: corpus.lock names unsupported repo '$REPO'" >&2
+  exit 1
+fi
+if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "fetch-corpus: corpus.lock sha must be a full lowercase Git SHA" >&2
   exit 1
 fi
 
@@ -62,6 +60,20 @@ mkdir -p "$CACHE"
 git -C "$CACHE" init -q 2>/dev/null || true
 
 if ! git -C "$CACHE" cat-file -e "$SHA^{commit}" 2>/dev/null; then
+  if [[ -n "${CORPUS_REPO_TOKEN:-}" ]]; then
+    URL="https://x-access-token:${CORPUS_REPO_TOKEN}@${REPO}.git"
+  elif [[ "${CORPUS_USE_GIT_AUTH:-0}" == "1" ]]; then
+    URL="https://${REPO}.git"
+  else
+    cat >&2 <<'EOF'
+fetch-corpus: CORPUS_SOURCE=remote but the locked commit is not cached and no
+credential is configured. Set CORPUS_REPO_TOKEN (fine-grained PAT with
+Contents: Read on the data repo) or, on a developer machine with git auth,
+CORPUS_USE_GIT_AUTH=1. Refusing to fall back silently: a build without the
+real corpus must fail, not go green against partial data.
+EOF
+    exit 1
+  fi
   echo "fetch-corpus: shallow-fetching $REPO @ ${SHA:0:12}"
   git -C "$CACHE" fetch -q --depth 1 "$URL" "$SHA"
 fi


### PR DESCRIPTION
## Outcome

The public application can build from the private data repository at one immutable `corpus.lock` revision. A deployment rollback therefore restores its corresponding code and data revision, while a missing or invalid corpus fails the build instead of falling back to partial checkout data.

## Changes

- Pin the authority-ready data commit and its exact `data/` and `geojson/` file counts.
- Restrict authenticated fetches to the intended private repository and a full lowercase commit SHA.
- Reuse a previously verified local cache so later build steps do not need the credential.
- Fetch the locked corpus in same-repository full-corpus CI while retaining secret-free sample-corpus CI for forks.
- Remove `CORPUS_REPO_TOKEN` from the environment before Next.js compilation.

## Validation

- Remote fetch: 382 data files and 92 GeoJSON files at `9ac54136e16046dbda6d2f00e5fd3271e4744856`.
- Credential-free repeat fetch from the verified cache.
- Zero diff between the fetched private corpus and the current public corpus.
- ESLint: 0 errors (32 pre-existing warnings).
- Data checks: passed.
- Tests: 73 passed, 0 failed.
- Production build: passed against the locked remote corpus.
- Generator-drift check: passed.
- Commit-level rollback rehearsal: changing only the lock to compatible data commit `119f0e1286632285cb3629b9872f12248aa2ee10` also produced a successful full build, after which the reviewed lock was restored cleanly.

## Promotion gates

- `neer-vazhvu-data` PR #1 is merged at `e95c693c`; this lock pins its reviewed data parent `9ac54136`.
- The least-privilege GitHub Actions `CORPUS_REPO_TOKEN` is configured. GitHub has not created this PR workflow run during the active Actions outage; the full-corpus check remains required before merge.
- Vercel Preview still needs `CORPUS_SOURCE=remote` and the same read-only `CORPUS_REPO_TOKEN` before staging reflection can be accepted. Production remains unchanged.
- The stale pre-cutover lock is not a valid recovery target. A changed-data rollback will be rehearsed with the first post-cutover corpus edition.
- This PR does not deploy production or make the private repository authoritative by itself.