### PR TITLE
Show governed Arkavathi MPR releases

### DIFF
--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -16,6 +16,13 @@ import type {
   BasinManifest,
 } from "@/lib/basins";
 import { tryGetBasinManifest } from "@/lib/basins";
+import {
+  parseReviewedMprSeries,
+  reviewedMprConceptLabel,
+  reviewedMprValueLabel,
+  type ReviewedMprRecord,
+  type ReviewedMprSeries,
+} from "@/lib/basins/reviewed-mpr";
 import "leaflet/dist/leaflet.css";
 
 interface Props {
@@ -496,6 +503,7 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
   const [selectedPrs, setSelectedPrs] = useState(false);
   const [prsData, setPrsData] = useState<PrsData | null>(null);
   const [accData, setAccData] = useState<AccountabilityData | null>(null);
+  const [reviewedMpr, setReviewedMpr] = useState<ReviewedMprSeries | null>(null);
   // True when a gap unit was opened FROM the PRS panel, so the gap panel can
   // offer a "back to PRS" affordance.
   const [gapFromPrs, setGapFromPrs] = useState(false);
@@ -649,6 +657,9 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     fetchJson(`/data/basins/${manifest.basinId}/accountability.json`)
       .then((d) => setAccData((d as unknown as AccountabilityData) ?? null))
       .catch(() => setAccData(null));
+    fetchJson(`/data/basins/${manifest.basinId}/mpr-reviewed.json`)
+      .then((d) => setReviewedMpr(parseReviewedMprSeries(d)))
+      .catch(() => setReviewedMpr(null));
   }, [manifest.basinId, manifest.layers]);
 
   // On phones the layers panel is an off-canvas drawer; start it closed so the
@@ -1462,6 +1473,7 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
               <PRSPanel
                 prs={prsData}
                 accountability={accData}
+                reviewedMpr={reviewedMpr}
                 layerByFamily={layerByFamily}
                 onOpenUnit={(u) => { setSelectedPrs(false); setSelectedFeature(null); setSelectedGapUnit(u); setGapFromPrs(true); }}
                 depUnit={manifest.defaultGapUnit}
@@ -1982,6 +1994,7 @@ function priorityClass(p: string): string {
 function PRSPanel({
   prs,
   accountability,
+  reviewedMpr,
   layerByFamily,
   onOpenUnit,
   onShowLayer,
@@ -1991,6 +2004,7 @@ function PRSPanel({
 }: {
   prs: PrsData;
   accountability?: AccountabilityData | null;
+  reviewedMpr?: ReviewedMprSeries | null;
   layerByFamily: Record<string, BasinLayer>;
   onOpenUnit: (unit: string) => void;
   onShowLayer: (family: string) => void;
@@ -2242,6 +2256,8 @@ function PRSPanel({
         )}
       </section>
 
+      {reviewedMpr && <ReviewedMprSection series={reviewedMpr} />}
+
       {/* Governance & compliance: who is accountable, and what they must report */}
       {prs.governance && (
         <section>
@@ -2388,6 +2404,94 @@ function PRSPanel({
       )}
       {prs.grievance?.urlNote && <p className="text-[10px] text-slate-400 italic">{prs.grievance.urlNote}</p>}
     </div>
+  );
+}
+
+function ReviewedMprSection({ series }: { series: ReviewedMprSeries }) {
+  const latest = series.editions.at(-1);
+  const [editionId, setEditionId] = useState(latest?.editionId ?? "");
+  const edition = series.editions.find((item) => item.editionId === editionId) ?? latest;
+  const groups = useMemo(() => {
+    const grouped = new Map<string, ReviewedMprRecord[]>();
+    for (const record of edition?.records ?? []) {
+      const current = grouped.get(record.subjectLabel) ?? [];
+      current.push(record);
+      grouped.set(record.subjectLabel, current);
+    }
+    return [...grouped.entries()];
+  }, [edition]);
+  if (!edition) return null;
+
+  const month = (date: string) => new Intl.DateTimeFormat("en-IN", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
+
+  return (
+    <section className="rounded-lg border border-blue-200 dark:border-blue-900/70 bg-blue-50/60 dark:bg-blue-950/20 p-3 space-y-2.5">
+      <div>
+        <div className="text-[11px] uppercase tracking-wider text-blue-700 dark:text-blue-300 font-semibold">Reviewed monthly progress</div>
+        <p className="text-[12px] text-slate-600 dark:text-slate-300 leading-snug">
+          {series.summary.editionCount} report editions · {series.summary.recordCount} source-linked values
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-1" aria-label="Monthly progress report editions">
+        {series.editions.map((item) => (
+          <button
+            key={item.editionId}
+            onClick={() => setEditionId(item.editionId)}
+            className={`text-[11px] px-2 py-1 rounded border font-semibold transition-colors ${
+              item.editionId === edition.editionId
+                ? "bg-blue-700 text-white border-blue-700"
+                : "bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700 hover:bg-blue-50 dark:hover:bg-slate-800"
+            }`}
+          >
+            {month(item.period.end)}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[13px] font-semibold text-slate-900 dark:text-slate-100">{month(edition.period.end)}</div>
+          <p className="text-[11px] text-slate-500 dark:text-slate-400 leading-snug">{edition.source.title}</p>
+        </div>
+        <a
+          href={edition.source.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-[11px] font-medium text-blue-700 dark:text-blue-300 hover:underline"
+        >
+          Source PDF ↗
+        </a>
+      </div>
+
+      <div key={edition.editionId} className="rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 divide-y divide-slate-100 dark:divide-slate-800">
+        {groups.map(([subject, records]) => (
+          <details key={subject} open={edition.records.length <= 15} className="group px-2.5 py-2">
+            <summary className="cursor-pointer list-none flex items-center gap-2">
+              <span aria-hidden className="text-[10px] text-slate-400 group-open:rotate-90 transition-transform">▸</span>
+              <span className="flex-1 text-[12px] font-semibold text-slate-800 dark:text-slate-100 leading-snug">{subject}</span>
+              <span className="text-[10px] text-slate-400">{records.length}</span>
+            </summary>
+            <dl className="mt-2 ml-4 space-y-1.5">
+              {records.map((record) => (
+                <div key={record.claimId} className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5">
+                  <dt className="text-[11px] text-slate-500 dark:text-slate-400">{reviewedMprConceptLabel(record.concept)}</dt>
+                  <dd className="text-[11px] font-semibold text-slate-800 dark:text-slate-100 text-right">{reviewedMprValueLabel(record.value)}</dd>
+                  <dd className="col-span-2 text-[10px] text-slate-400">Evidence: page {record.pageNumber}</dd>
+                </div>
+              ))}
+            </dl>
+          </details>
+        ))}
+      </div>
+      <p className="text-[10px] text-slate-400 leading-snug">
+        Values are published only after platform review. Page numbers point back to the named report above.
+      </p>
+    </section>
   );
 }
 

--- a/src/lib/basins/reviewed-mpr.test.ts
+++ b/src/lib/basins/reviewed-mpr.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseReviewedMprSeries,
+  reviewedMprConceptLabel,
+  reviewedMprValueLabel,
+} from "./reviewed-mpr";
+
+function fixture() {
+  return {
+    schema: "neer-vazhvu.public-mpr-series",
+    schemaVersion: "1",
+    surfaceId: "arkavathi-progress",
+    scope: { kind: "basin", id: "arkavathi" },
+    editions: [{
+      editionId: "nmcg-ngt-mpr-listing:2026-03-31",
+      period: { start: "2026-03-31", end: "2026-03-31" },
+      source: {
+        title: "Arkavathi River Monthly Progress Report, March 2026",
+        publisher: "NMCG",
+        url: "https://example.test/march.pdf",
+        asOf: "2026-03-31",
+      },
+      records: [{
+        claimId: "nv-claim:flow",
+        concept: "nv-candidate:facility-design-capacity",
+        subjectId: "nv-subject:stp",
+        subjectLabel: "Existing STP reported under CMC Kanakapura",
+        value: { kind: "quantity", value: 6.29, unit: "MLD", qualifier: "reported" },
+        pageNumber: 37,
+      }],
+    }],
+    summary: { editionCount: 1, recordCount: 1 },
+  };
+}
+
+test("accepts the released Arkavathi MPR contract and formats its values", () => {
+  const parsed = parseReviewedMprSeries(fixture());
+  assert.ok(parsed);
+  assert.equal(parsed.editions[0].records[0].pageNumber, 37);
+  assert.equal(reviewedMprConceptLabel("nv-candidate:facility-design-capacity"), "Design capacity");
+  assert.equal(reviewedMprValueLabel(parsed.editions[0].records[0].value), "6.29 MLD");
+});
+
+test("fails closed when declared release counts do not match the records", () => {
+  const changed = fixture();
+  changed.summary.recordCount = 2;
+  assert.equal(parseReviewedMprSeries(changed), null);
+});
+
+test("fails closed on a non-HTTPS source", () => {
+  const changed = fixture();
+  changed.editions[0].source.url = "http://example.test/march.pdf";
+  assert.equal(parseReviewedMprSeries(changed), null);
+});

--- a/src/lib/basins/reviewed-mpr.ts
+++ b/src/lib/basins/reviewed-mpr.ts
@@ -1,0 +1,186 @@
+export type ReviewedMprValue =
+  | { kind: "quantity"; value: number; unit: string; qualifier: string }
+  | { kind: "text"; value: string }
+  | { kind: "relationship"; objectId: string; objectLabel: string };
+
+export type ReviewedMprRecord = {
+  claimId: string;
+  concept: string;
+  subjectId: string;
+  subjectLabel: string;
+  value: ReviewedMprValue;
+  pageNumber: number;
+};
+
+export type ReviewedMprEdition = {
+  editionId: string;
+  period: { start: string; end: string };
+  source: { title: string; publisher: string; url: string; asOf: string };
+  records: ReviewedMprRecord[];
+};
+
+export type ReviewedMprSeries = {
+  schema: "neer-vazhvu.public-mpr-series";
+  schemaVersion: "1";
+  surfaceId: "arkavathi-progress";
+  scope: { kind: "basin"; id: "arkavathi" };
+  editions: ReviewedMprEdition[];
+  summary: { editionCount: number; recordCount: number };
+};
+
+const CONCEPT_LABELS: Record<string, string> = {
+  "alternate-treatment-quantity": "Alternate treatment",
+  "capacity-utilized": "Capacity utilised",
+  "complying-treatment-facility-count": "Complying STPs",
+  "estimated-sewage-generation": "Estimated sewage generation",
+  "facility-design-capacity": "Design capacity",
+  "facility-location": "Location",
+  "facility-operational-status": "Operational status",
+  "non-complying-treatment-facility-count": "Non-complying STPs",
+  "operational-treatment-facility-count": "Operational STPs",
+  "pollution-priority": "Pollution priority",
+  "population": "Population",
+  "reported-local-body-context": "Local body",
+  "sewage-treatment-capacity-gap": "Treatment capacity gap",
+  "solid-waste-collected": "Solid waste collected",
+  "solid-waste-management-gap": "Solid-waste management gap",
+  "solid-waste-processed": "Solid waste processed",
+  "solid-waste-secured-landfill": "Secured landfill",
+  "solid-waste-segregated-and-transported": "Segregated and transported",
+  "treatment-capacity": "Treatment capacity",
+  "treatment-facility-count": "STPs",
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function parseValue(value: unknown): ReviewedMprValue | null {
+  const candidate = record(value);
+  if (!candidate) return null;
+  if (candidate.kind === "quantity") {
+    if (!Number.isFinite(candidate.value) || !text(candidate.unit) || !text(candidate.qualifier)) return null;
+    return {
+      kind: "quantity",
+      value: Number(candidate.value),
+      unit: String(candidate.unit),
+      qualifier: String(candidate.qualifier),
+    };
+  }
+  if (candidate.kind === "text" && text(candidate.value)) {
+    return { kind: "text", value: String(candidate.value) };
+  }
+  if (candidate.kind === "relationship" && text(candidate.objectId) && text(candidate.objectLabel)) {
+    return {
+      kind: "relationship",
+      objectId: String(candidate.objectId),
+      objectLabel: String(candidate.objectLabel),
+    };
+  }
+  return null;
+}
+
+function parseRecord(value: unknown): ReviewedMprRecord | null {
+  const candidate = record(value);
+  if (!candidate) return null;
+  const parsedValue = parseValue(candidate.value);
+  if (
+    !text(candidate.claimId)
+    || !text(candidate.concept)
+    || !text(candidate.subjectId)
+    || !text(candidate.subjectLabel)
+    || !Number.isInteger(candidate.pageNumber)
+    || Number(candidate.pageNumber) < 1
+    || !parsedValue
+  ) return null;
+  return {
+    claimId: String(candidate.claimId),
+    concept: String(candidate.concept),
+    subjectId: String(candidate.subjectId),
+    subjectLabel: String(candidate.subjectLabel),
+    value: parsedValue,
+    pageNumber: Number(candidate.pageNumber),
+  };
+}
+
+function parseEdition(value: unknown): ReviewedMprEdition | null {
+  const candidate = record(value);
+  const period = record(candidate?.period);
+  const source = record(candidate?.source);
+  if (!candidate || !period || !source || !Array.isArray(candidate.records)) return null;
+  const records = candidate.records.map(parseRecord);
+  if (
+    !text(candidate.editionId)
+    || !text(period.start)
+    || !text(period.end)
+    || !text(source.title)
+    || !text(source.publisher)
+    || !text(source.url)
+    || !String(source.url).startsWith("https://")
+    || !text(source.asOf)
+    || records.some((item) => item === null)
+  ) return null;
+  return {
+    editionId: String(candidate.editionId),
+    period: { start: String(period.start), end: String(period.end) },
+    source: {
+      title: String(source.title),
+      publisher: String(source.publisher),
+      url: String(source.url),
+      asOf: String(source.asOf),
+    },
+    records: records as ReviewedMprRecord[],
+  };
+}
+
+export function parseReviewedMprSeries(value: unknown): ReviewedMprSeries | null {
+  const candidate = record(value);
+  const scope = record(candidate?.scope);
+  const summary = record(candidate?.summary);
+  if (
+    !candidate
+    || candidate.schema !== "neer-vazhvu.public-mpr-series"
+    || candidate.schemaVersion !== "1"
+    || candidate.surfaceId !== "arkavathi-progress"
+    || scope?.kind !== "basin"
+    || scope.id !== "arkavathi"
+    || !summary
+    || !Array.isArray(candidate.editions)
+  ) return null;
+  const editions = candidate.editions.map(parseEdition);
+  const editionCount = Number(summary.editionCount);
+  const recordCount = Number(summary.recordCount);
+  if (
+    editions.some((item) => item === null)
+    || !Number.isInteger(editionCount)
+    || !Number.isInteger(recordCount)
+    || editionCount !== editions.length
+    || recordCount !== editions.reduce((total, edition) => total + (edition?.records.length ?? 0), 0)
+  ) return null;
+  return {
+    schema: "neer-vazhvu.public-mpr-series",
+    schemaVersion: "1",
+    surfaceId: "arkavathi-progress",
+    scope: { kind: "basin", id: "arkavathi" },
+    editions: editions as ReviewedMprEdition[],
+    summary: { editionCount, recordCount },
+  };
+}
+
+export function reviewedMprConceptLabel(concept: string): string {
+  const local = concept.includes(":") ? concept.slice(concept.lastIndexOf(":") + 1) : concept;
+  return CONCEPT_LABELS[local]
+    ?? local.replaceAll("-", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+export function reviewedMprValueLabel(value: ReviewedMprValue): string {
+  if (value.kind === "text") return value.value;
+  if (value.kind === "relationship") return value.objectLabel;
+  return `${new Intl.NumberFormat("en-IN", { maximumFractionDigits: 2 }).format(value.value)} ${value.unit}`;
+}


### PR DESCRIPTION
## What changed

- add a fail-soft reader for the governed `neer-vazhvu.public-mpr-series` contract
- show reviewed MPR editions inside the existing Arkavathi polluted-river-stretch view
- let readers move between report months and inspect values grouped by subject, with source PDF and page evidence

## Why

The platform can already produce and approve reviewed MPR data, but a data-repository release would otherwise change only a JSON file. This gives the governed artifact one visible public consumer and connects monthly report evidence to the existing cross-source Arkavathi view.

The surface remains absent when no reviewed release exists. It does not replace the editorial `prs.json`, `accountability.json`, or `gaps.json` analysis.

## Verification

- focused contract tests: 3 passed
- parser accepts the real 2-edition, 108-record publication artifact
- TypeScript passes
- focused ESLint passes
- production build passes
- `git diff --check` passes

No corpus lock, data artifact, publication authority, or deployment changes in this PR.
