### PR TITLE
Activate Arkavathi MPR corpus release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -12,9 +12,9 @@
     "success."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "9ac54136e16046dbda6d2f00e5fd3271e4744856",
+  "sha": "24a84a44e4623916469f4c5e9a419513d53b0334",
   "expected_files": {
-    "data": 382,
+    "data": 383,
     "geojson": 92
   }
 }


### PR DESCRIPTION
## Summary

- pin the public app to the merged private corpus revision
- include the reviewed Arkavathi MPR artifact: 3 editions and 118 records
- update the fail-closed data file count from 382 to 383

## Verification

- private corpus contract check: passed (475 artifacts)
- remote corpus fetch: passed (383 data files, 92 GeoJSON files)
- production build with the fetched corpus: passed

## Rollback

Restore the lock to the pre-release tag `corpus-2026-08-08-pre-mpr` (`6c665154a92b794c8c0bbce73dca91b0864412ca`).