### PR TITLE
Rehearse Arkavathi MPR corpus rollback

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -12,9 +12,9 @@
     "success."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "24a84a44e4623916469f4c5e9a419513d53b0334",
+  "sha": "6c665154a92b794c8c0bbce73dca91b0864412ca",
   "expected_files": {
-    "data": 383,
+    "data": 382,
     "geojson": 92
   }
 }


### PR DESCRIPTION
## Purpose

Perform the exact versioned rollback rehearsal for the first changed private-corpus release.

## Change

- move `corpus.lock` to annotated pre-release tag `corpus-2026-08-08-pre-mpr`
- pin exact data commit `6c665154a92b794c8c0bbce73dca91b0864412ca`
- restore the expected data count from 383 to 382; GeoJSON remains 92

## Acceptance

After green CI and Production deployment, the reviewed Arkavathi MPR artifact must return 404 while the public site remains healthy. A follow-up PR will immediately restore release tag `corpus-2026-08-08-mpr-1`.