### PR TITLE
Restore Arkavathi MPR corpus release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -12,9 +12,9 @@
     "success."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "6c665154a92b794c8c0bbce73dca91b0864412ca",
+  "sha": "24a84a44e4623916469f4c5e9a419513d53b0334",
   "expected_files": {
-    "data": 382,
+    "data": 383,
     "geojson": 92
   }
 }


### PR DESCRIPTION
## Purpose

Restore the first reviewed MPR release after the successful Production rollback rehearsal.

## Verified rollback

- pre-release corpus commit: `6c665154a92b794c8c0bbce73dca91b0864412ca`
- live MPR artifact: 404
- live `/bangalore/rivers`: 200
- live `/api/health`: healthy, database connected

## Restoration

- return `corpus.lock` to release tag `corpus-2026-08-08-mpr-1`
- pin exact data commit `24a84a44e4623916469f4c5e9a419513d53b0334`
- expect 383 data and 92 GeoJSON files

After Production deploys, the live artifact must again report 3 editions and 118 records.