### PR TITLE
Promote governed Arkavathi MPR release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -12,7 +12,7 @@
     "success."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "24a84a44e4623916469f4c5e9a419513d53b0334",
+  "sha": "bfc7a26d602a9c0d7abd6c4a42206262874cfc04",
   "expected_files": {
     "data": 383,
     "geojson": 92


### PR DESCRIPTION
## Summary

- advance the public application's locked corpus from the first Arkavathi MPR release to the governed second release
- consume the exact reviewed data commit behind `corpus-2026-08-08-mpr-2`
- add five MPR editions and 136 reviewed values to the existing Arkavathi public series

## Release boundary

This changes only `corpus.lock`. The governed data is reviewed and merged in `neer-vazhvu-data` PR #4; the public build continues to fetch and validate the exact immutable commit before rendering.

## Verification

- governed corpus validation passed on data PR #4 and on data `main`
- locked commit: `bfc7a26d602a9c0d7abd6c4a42206262874cfc04`
- expected corpus shape remains 383 data files and 92 GeoJSON files
