### PR TITLE
Arkavathi deep dive: one-click PDF export of the atlas state

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,13 @@ import type { NextConfig } from "next";
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
+    // connect-src data: + worker-src blob: are for the basin atlas PDF export:
+    // @react-pdf/renderer fetches its wasm layout engine as a data: URL and
+    // renders the document in a blob: worker. Both are self-contained (no
+    // network reach), and script-src already concedes 'unsafe-eval', so the
+    // marginal exposure is nil - without them the export dies at click time.
     value:
-      "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://qlwnafrcfajosvbdswyf.supabase.co https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; font-src 'self'; connect-src 'self' https://qlwnafrcfajosvbdswyf.supabase.co https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+      "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://qlwnafrcfajosvbdswyf.supabase.co https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; font-src 'self'; connect-src 'self' data: https://qlwnafrcfajosvbdswyf.supabase.co https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; worker-src 'self' blob:; base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
   },
   {
     key: "Permissions-Policy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
+        "@react-pdf/renderer": "^4.6.0",
         "@supabase/supabase-js": "^2.98.0",
         "@turf/along": "^7.3.4",
         "@turf/area": "^7.3.4",
@@ -24,6 +25,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "csv-parse": "^6.1.0",
+        "html-to-image": "^1.11.13",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.575.0",
         "next": "^16.2.1",
@@ -2405,7 +2407,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -2434,7 +2435,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4032,6 +4032,183 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.9.tgz",
+      "integrity": "sha512-aKi0+c5MCRfAQtKllCB8KHKW9eM4ybkUBtI7mF5J8Ogbp/FuLJGAmZP/ZWI/EgxepFJe0ryn96Bt9drjO5HjbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^6.0.0",
+        "@react-pdf/types": "^2.11.2",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.1.tgz",
+      "integrity": "sha512-pbeb2qUs+lDZsvNpWSjoVkAm10WjXsoYd5jIB3utqkfWwwMkh3qo2Iz4By08AptAcRINPXaG6ICT3zsrXBMb6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.7.0.tgz",
+      "integrity": "sha512-snTm+6TLPz5U/PDeTu4id5ZuUBD+o7F3W/iHSFuS1Ue10aXpt05bcJICFwsaUZOyCHL1JZazAgqyI/gLW6iqkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.2",
+        "@react-pdf/textkit": "^6.4.0",
+        "@react-pdf/types": "^2.11.2",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-6.0.0.tgz",
+      "integrity": "sha512-VG4L83leBinqnBKIdWSm3REdtEpMh38zcj09kOgqP+w6kNW+mIWSBhAtgOPjKJYWnbh5vSipZ9RIspyRXZV/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "pako": "^1.0.11",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.6.0.tgz",
+      "integrity": "sha512-ZDT7CZWOplU7vI4TfrD1PHHgz6F20G0yeORt+qyBzgADMBzjaKLkhr10rkYn3IlRhUhosXLxWyg/R56z/AFAzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.4.0",
+        "@react-pdf/types": "^2.11.2",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.6.0.tgz",
+      "integrity": "sha512-6dgzuO/46I2jySQjfmzagCJSrjKAOjpihca0BNqFrrP/HK1jg7+/UTTukI0BlZMIkBUm2b0mapoRZTrtF0Uv4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.9",
+        "@react-pdf/layout": "^4.7.0",
+        "@react-pdf/pdfkit": "^6.0.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.6.0",
+        "@react-pdf/types": "^2.11.2",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.2.tgz",
+      "integrity": "sha512-w0BY4WCHhEfLuQQU7fAwdZcaVnWMviO4bIiC+F2rhGYVcQsIin0FtO92W3PQE6QVKeG9jGmATPiKuSSx7NP+MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.2",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.4.0.tgz",
+      "integrity": "sha512-+5JZC5j2Q7cBDxYy7qrb2dGhDHexjwUlavAZkzGQbSQlZbrxHn75/oZ6REhlHk0hmTKEu6SXyycq1AnUd75XUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.2.tgz",
+      "integrity": "sha512-Fb62VHChxq40+SbATjOIqc+x8rncng2Yt/k1Cks7UteCYQf4kdY32koGhuC9SlK6PB5p7Q2F+vjC/mYaJ4WgnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.9",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.2"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -5772,6 +5949,12 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6179,6 +6362,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -6189,6 +6392,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/body-parser": {
@@ -6261,6 +6473,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -6604,6 +6834,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6639,6 +6878,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/color2k": {
       "version": "2.0.3",
@@ -7219,6 +7479,12 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
@@ -7362,6 +7628,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -8152,6 +8424,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8269,7 +8550,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -8474,6 +8754,23 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8976,6 +9273,27 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -9051,6 +9369,12 @@
       "engines": {
         "node": ">=18.18.0"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -9145,7 +9469,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -9718,6 +10041,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -9812,6 +10141,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9832,11 +10170,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10308,6 +10651,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10385,7 +10747,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10432,6 +10793,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -10844,6 +11211,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -10890,7 +11266,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11318,6 +11693,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11362,6 +11743,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -11516,6 +11903,14 @@
         "fflate": "^0.8.0"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/point-in-polygon-hao": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
@@ -11577,6 +11972,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/potpack": {
       "version": "1.0.2",
@@ -11651,7 +12052,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11733,6 +12133,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -12159,7 +12568,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12237,6 +12645,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rettime": {
       "version": "0.10.1",
@@ -12351,7 +12765,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12881,7 +13294,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13144,6 +13556,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -13199,7 +13617,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {
@@ -13626,6 +14043,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -13801,7 +14244,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
@@ -13844,6 +14286,20 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -14237,6 +14693,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
+    "@react-pdf/renderer": "^4.6.0",
     "@supabase/supabase-js": "^2.98.0",
     "@turf/along": "^7.3.4",
     "@turf/area": "^7.3.4",
@@ -33,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "csv-parse": "^6.1.0",
+    "html-to-image": "^1.11.13",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.575.0",
     "next": "^16.2.1",

--- a/scripts/check-basin-pdf-render.tsx
+++ b/scripts/check-basin-pdf-render.tsx
@@ -69,9 +69,17 @@ const legendItems: LegendItem[] = [
 ];
 
 async function main() {
+  // Every manifest layer gets a table row here (broadest coverage); the app
+  // passes only the layers visible at export.
+  const inventoryRows = manifest.layers.flatMap((l) => {
+    const fam = inventory?.families[l.family];
+    if (!fam) return [];
+    const count = (l.kindFilter && fam.sources.find((sc) => sc.kind === l.kindFilter)?.count) || fam.featureCount;
+    return [{ label: l.label, count }];
+  });
   const data = sanitizeForPdf({
     manifest,
-    inventory,
+    inventoryRows,
     scopeLabel: "Whole basin",
     legendItems,
     legendNotes: ["≈8 of 18 industrial areas have no CETP within ~5 km - CAG-flagged gap, spatial estimate"],

--- a/scripts/check-basin-pdf-render.tsx
+++ b/scripts/check-basin-pdf-render.tsx
@@ -1,0 +1,106 @@
+// Smoke-render of the Basin Atlas PDF export against the REAL basin data.
+//
+// The PDF report is data-driven: an edit to prs.json / accountability.json /
+// gaps.json that the atlas panels tolerate could still break the export at
+// click time (react-pdf is far stricter than the DOM). This renders the full
+// document in Node - map page, PRS pages, DEP gap pages, credits - and fails
+// loudly if any page throws. Run locally after touching basin data or the
+// report layout:
+//
+//   npx tsx scripts/check-basin-pdf-render.tsx [basinId=arkavathi]
+//
+// Output lands in .tmp/<basinId>-report-check.pdf for a visual once-over.
+// The map is a placeholder PNG (the real capture needs a browser); the
+// partner logo is fetched from the live site and falls back to a warning.
+import fs from "node:fs";
+import React from "react";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { tryGetBasinManifest } from "../src/lib/basins";
+import { parseReviewedMprSeries } from "../src/lib/basins/reviewed-mpr";
+import { sanitizeForPdf } from "../src/lib/basins/export-pdf";
+import { BasinReportDocument } from "../src/components/basin/basin-pdf-report";
+import type { BasinInventory } from "../src/lib/basins";
+import type {
+  AccountabilityData,
+  DepData,
+  GapUnit,
+  LegendItem,
+  PrsData,
+} from "../src/components/basin/basin-atlas";
+
+const basinId = process.argv[2] ?? "arkavathi";
+const maybeManifest = tryGetBasinManifest(basinId);
+if (!maybeManifest) {
+  console.error(`FAIL: no basin manifest registered for "${basinId}"`);
+  process.exit(1);
+}
+const manifest = maybeManifest!;
+
+function read<T>(file: string): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(`public/data/basins/${basinId}/${file}`, "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+const prs = read<PrsData>("prs.json");
+const acc = read<AccountabilityData>("accountability.json");
+const gapsRaw = read<Record<string, unknown>>("gaps.json");
+const inventory = read<BasinInventory>("inventory.json");
+const reviewedMpr = parseReviewedMprSeries(read("mpr-reviewed.json"));
+const dep = gapsRaw?.version === 2 ? (gapsRaw as unknown as DepData) : null;
+const gapUnits: GapUnit[] = dep ? [] : Object.values((gapsRaw?.units as Record<string, GapUnit>) ?? {});
+
+// 40x25 grey PNG standing in for the browser-captured map.
+const MAP_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAZCAIAAADMuvsyAAAAKklEQVR4nGO4cOPBgCCGUYtHLR61eNTiUYtHLR61eNTiUYtHLR61mGIEAF1j48j++xGlAAAAAElFTkSuQmCC";
+
+// One entry per swatch shape so every LegendSwatch branch renders.
+const legendItems: LegendItem[] = [
+  { sym: "box", color: "#0284c7", label: "Tanks & reservoirs (named)" },
+  { sym: "dot", color: "#eab308", label: "Polluting drains (KSPCB)" },
+  { sym: "ring", color: "#059669", label: "Monitoring (not in public domain)" },
+  { sym: "line", color: "#2563eb", label: "River" },
+  { sym: "dash", color: "#818cf8", label: "Sub-catchment" },
+  { sym: "outline", color: "#a855f7", label: "STP (not yet functional)" },
+  { sym: "tri", color: "#0891b2", label: "FSTP (operational)" },
+  { sym: "tri-ring", color: "#0891b2", label: "FSTP (not yet functional)" },
+];
+
+async function main() {
+  const data = sanitizeForPdf({
+    manifest,
+    inventory,
+    scopeLabel: "Whole basin",
+    legendItems,
+    legendNotes: ["≈8 of 18 industrial areas have no CETP within ~5 km - CAG-flagged gap, spatial estimate"],
+    selectedRiver: manifest.rivers[0] ?? null,
+    prs,
+    acc,
+    reviewedMpr,
+    dep,
+    gapUnits,
+    gapNote: null,
+    generatedAt: "(smoke check)",
+  });
+  const buf = await renderToBuffer(
+    <BasinReportDocument
+      {...data}
+      includeGaps
+      mapPng={MAP_PNG}
+      mapAspect={0.62}
+      shareUrl={`https://neervazhvu.org/embed/basins/${basinId}`}
+      origin="https://neervazhvu.org"
+    />,
+  );
+  fs.mkdirSync(".tmp", { recursive: true });
+  const out = `.tmp/${basinId}-report-check.pdf`;
+  fs.writeFileSync(out, buf);
+  console.log(`OK: ${basinId} report rendered, ${buf.length} bytes -> ${out}`);
+}
+
+main().catch((e) => {
+  console.error(`FAIL: ${basinId} PDF report did not render:`, e);
+  process.exit(1);
+});

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -964,17 +964,30 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
         .map(layerKey)
         .filter((k) => effectiveEnabled[k])
         .join(",");
+      // State-faithful contract: the data table lists only what is on the
+      // exported map (rail counts), and the PRS pages ship only when the
+      // stretch is actually rendered (toggled on, or its panel open) - the
+      // same rule the gap pages follow.
+      const inventoryRows = visibleLayers.flatMap((l) => {
+        const inv = inventory?.families[l.family];
+        if (!inv) return [];
+        const count =
+          (l.kindFilter && inv.sources.find((sc) => sc.kind === l.kindFilter)?.count) ||
+          inv.featureCount;
+        return [{ label: l.label, count }];
+      });
+      const prsOnMap = visibleLayers.some((l) => l.prs);
       await exportBasinAtlasPdf({
         mapEl,
         manifest,
-        inventory,
+        inventoryRows,
         scopeLabel: selectedRiver ? `${selectedRiver.displayName} (river-scoped)` : "Whole basin",
         legendItems: items,
         legendNotes,
         selectedRiver,
-        prs: prsData,
-        acc: accData,
-        reviewedMpr,
+        prs: prsOnMap ? prsData : null,
+        acc: prsOnMap ? accData : null,
+        reviewedMpr: prsOnMap ? reviewedMpr : null,
         dep: depData,
         gapUnits: Object.values(gapData),
         gapNote,

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -9,6 +9,20 @@ import { MapResizer } from "@/components/map-resizer";
 import { BottomSheet } from "@/components/map/bottom-sheet";
 import { useMapTiles } from "@/lib/utils/map-tiles";
 import { ELEVATION_BAND_COLORS, elevationLegendEntries } from "@/components/map/elevation-bands";
+import { exportBasinAtlasPdf } from "@/lib/basins/export-pdf";
+import {
+  buildAtlasShareUrl,
+  encodeLayersParam,
+  layerKey,
+  parseLayersParam,
+} from "@/lib/basins/atlas-url-state";
+import {
+  ACC_KIND_LABEL,
+  ACC_VERDICT_LABEL,
+  DEP_STATUS_LABEL,
+  DEP_THEME_ORDER,
+  depThemeTitle,
+} from "@/lib/basins/panel-labels";
 import type {
   BasinFloor,
   BasinInventory,
@@ -62,10 +76,10 @@ const FLOORS: { id: BasinFloor; label: string; sub: string }[] = [
 ];
 
 // gaps.json shape (cross-source treatment-gap intelligence per admin unit).
-interface GapSource { source: string; says: string; citation: string; url?: string }
+export interface GapSource { source: string; says: string; citation: string; url?: string }
 type GapMedium = "liquid" | "solid";
 type GapSector = "public" | "industry" | "institutional" | "construction";
-interface GapStream {
+export interface GapStream {
   stream: string;
   summary: string;
   /** Which waste medium this stream belongs to (groups the panel). */
@@ -108,7 +122,7 @@ function polygonOuterRings(geom: Feature["geometry"] | null | undefined): [numbe
 // Min bbox area (deg²) for a detached gap part to earn its own badge: includes
 // the ~0.36 km² Harohalli/Kaggalahalli exclave, excludes hair-thin slivers.
 const GAP_BADGE_MIN_AREA = 1.2e-5;
-interface GapUnit { name: string; level?: string; coverage?: string; conflicts?: string[]; caveats?: string[]; headline: string; streams: GapStream[] }
+export interface GapUnit { name: string; level?: string; coverage?: string; conflicts?: string[]; caveats?: string[]; headline: string; streams: GapStream[] }
 
 // ── DEP Snapshot v2 (gaps.json `version: 2`; district-first) ─────────────────
 // One tab per district whose DEP covers part of the basin (Paani review,
@@ -119,7 +133,7 @@ interface GapUnit { name: string; level?: string; coverage?: string; conflicts?:
 /** How to find a region on the map (shared by accountability + DEP panels). */
 type MapMatch = { family: string; prop?: string; values?: string[]; contains?: string[]; kinds?: string[] };
 type DepThemeStatus = "covered" | "district-level" | "not-covered";
-interface DepTheme {
+export interface DepTheme {
   theme: string;
   subtheme?: string;
   /** covered = unit-specific data; district-level = reported district-wide
@@ -135,7 +149,7 @@ interface DepTheme {
   /** Value read via OCR from a scanned plan; treat as approximate. */
   ocrUncertain?: boolean;
 }
-interface DepUlb {
+export interface DepUlb {
   key: string;
   name: string;
   type: string;
@@ -150,8 +164,8 @@ interface DepUlb {
 /** A taluk tab carries only what the DEP reports at taluk grain - ULB-level
  *  data lives on the ULB tabs (Paani round 4: the old cross-source unit here
  *  duplicated the ULB content). */
-interface DepTaluk { key: string; label: string; mapMatch?: MapMatch; note?: string; themes: DepTheme[] }
-interface DepDistrict {
+export interface DepTaluk { key: string; label: string; mapMatch?: MapMatch; note?: string; themes: DepTheme[] }
+export interface DepDistrict {
   key: string;
   name: string;
   dep: { label: string; url: string; note?: string };
@@ -171,20 +185,20 @@ interface DepDistrict {
   /** Cross-source contradictions about the district's industrial areas. */
   industrialAreasConflicts?: string[];
 }
-interface DepGovernance {
+export interface DepGovernance {
   items: { heading: string; body: string; source?: GapSource }[];
   gaps: string[];
 }
-interface DepData { version: 2; title?: string; note?: string; governance?: DepGovernance; districts: DepDistrict[] }
+export interface DepData { version: 2; title?: string; note?: string; governance?: DepGovernance; districts: DepDistrict[] }
 
 // ── PRS (Polluted River Stretch) entry-point panel (prs.json) ────────────────
 // Tabbed surface: each tab is a stressor theme; the subtab axis differs per
 // theme (Sewage = admin units along the stretch; Industrial/Solid/PRS = named
 // sub-categories). The selected tab+subtab shows two parallel 2021-2025 tracks:
 // generation and the infrastructure built (per the partner's PDF, page 3).
-interface PrsYearPoint { year: number; value: number }
-interface PrsInfraItem { label: string; status: string; tone?: "good" | "bad" | "neutral" }
-interface PrsUnit {
+export interface PrsYearPoint { year: number; value: number }
+export interface PrsInfraItem { label: string; status: string; tone?: "good" | "bad" | "neutral" }
+export interface PrsUnit {
   key: string;
   name: string;
   /** Admin level this unit's figures are reported at (ULB / taluk / district /
@@ -222,7 +236,7 @@ interface PrsUnit {
 }
 /** A narrative sub-theme (Industrial: Discharges/Areas/Clusters; PRS:
  *  PRS/E-flow/Flood/Evidence) - text + key points, not a per-year timeline. */
-interface PrsCategory {
+export interface PrsCategory {
   key: string;
   label: string;
   /** Admin level this category's figures are reported at (shown as a chip). */
@@ -239,7 +253,7 @@ interface PrsCategory {
   /** No known public data yet - shown as an explicit honest gap. */
   noData?: boolean;
 }
-interface PrsTab {
+export interface PrsTab {
   key: string;
   label: string;
   status: "built" | "soon";
@@ -261,7 +275,7 @@ interface PrsTab {
   /** "categories" tabs: narrative sub-themes. */
   categories?: PrsCategory[];
 }
-interface PrsData {
+export interface PrsData {
   river: string;
   stretchName: string;
   comparison: { y2020: { length_km: number; priority: string }; y2025: { length_km: number; priority: string } };
@@ -361,12 +375,6 @@ type FC = FeatureCollection;
 /** Draw order on the shared canvas (lower = drawn first = underneath). Base
  *  outlines and sub-catchments sit below thematic fills, lines, and points so
  *  the layers on top receive hover/click, not the catchment beneath them. */
-/** Toggle/state key for a layer: kind-filtered entries get their own key so
- *  two entries sharing a data family toggle independently. */
-function layerKey(l: BasinLayer): string {
-  return l.kindFilter ? `${l.family}:${l.kindFilter}` : l.family;
-}
-
 function drawRank(l: BasinLayer): number {
   if (l.elevation) return -2; // terrain underneath everything, even the gap choropleth
   if (l.gap) return -1; // gap choropleth at the very bottom - all data (incl. STPs) sits above it
@@ -475,7 +483,9 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
   // only the entry floor's default-on layers + always-on context + the PRS
   // spine on. Rendering is then checkbox-only, so the user can freely combine
   // layers from other floors (e.g. PRS + treatment gaps) by toggling them on.
-  const [enabled, setEnabled] = useState<Record<string, boolean>>(() => {
+  // Kept as a memo (not just the useState initialiser) because the URL sync
+  // compares against it: ?layers= is written only once the set is customised.
+  const defaultEnabled = useMemo(() => {
     const startFloor = initialFloor ?? "hydrology";
     return Object.fromEntries(
       manifest.layers.map((l) => [
@@ -483,7 +493,8 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
         l.defaultOn && (l.context || l.prs || l.floor === startFloor),
       ]),
     );
-  });
+  }, [manifest.layers, initialFloor]);
+  const [enabled, setEnabled] = useState<Record<string, boolean>>(defaultEnabled);
   // Which floors' toggle lists are expanded in the rail. Only the entry floor
   // opens by default (a calm landing); others collapse with a chevron so it's
   // clear they open. Collapsing only hides the list - layers stay rendered.
@@ -700,15 +711,37 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     return depData ? depHighlight : selectedGapUnit;
   }, [selectedGapUnit, depData, depHighlight]);
 
+  // ?layers= / ?growth= restore in EVERY context, embedded included - the PDF
+  // export links back to the embed page with these params, and the embed's
+  // server component only forwards ?river/?floor as props. Applied once per
+  // mount: basin-stack navigation swaps the manifest without remounting, and
+  // another basin's layer keys must not be re-parsed against this one.
+  const appliedUrlLayersRef = useRef(false);
   useEffect(() => {
     setCoachDismissed(localStorage.getItem(COACH_KEY) === "1");
-    if (embedded) return;
     const p = new URLSearchParams(window.location.search);
+    if (!appliedUrlLayersRef.current) {
+      appliedUrlLayersRef.current = true;
+      const fromUrl = parseLayersParam(p.get("layers"), manifest.layers);
+      if (fromUrl) setEnabled(fromUrl);
+      if (p.get("growth") === "1") setShowGrowth(true);
+    }
+    if (embedded) return;
     const r = p.get("river");
     const lvl = p.get("level") as BasinFloor | null;
     if (r && manifest.rivers.some((x) => x.riverId === r)) setSelectedRiverId(r);
     if (lvl && FLOORS.some((f) => f.id === lvl)) setFocusedFloor(lvl);
-  }, [manifest.rivers, embedded]);
+  }, [manifest.rivers, manifest.layers, embedded]);
+
+  // The full toggle map with the defaultOn fallback applied for layers added
+  // after `enabled` was initialised - what the URL and the PDF export read.
+  const effectiveEnabled = useMemo(
+    () =>
+      Object.fromEntries(
+        manifest.layers.map((l) => [layerKey(l), enabled[layerKey(l)] ?? l.defaultOn]),
+      ),
+    [manifest.layers, enabled],
+  );
 
   useEffect(() => {
     if (embedded) return;
@@ -716,9 +749,14 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     if (selectedRiverId) p.set("river", selectedRiverId);
     else p.delete("river");
     p.set("level", focusedFloor);
+    const layersParam = encodeLayersParam(effectiveEnabled, defaultEnabled);
+    if (layersParam !== null) p.set("layers", layersParam);
+    else p.delete("layers");
+    if (showGrowth) p.set("growth", "1");
+    else p.delete("growth");
     const qs = p.toString();
     window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
-  }, [selectedRiverId, focusedFloor, embedded]);
+  }, [selectedRiverId, focusedFloor, effectiveEnabled, defaultEnabled, showGrowth, embedded]);
 
   // A layer is visible iff its checkbox is on (and, for non-context layers,
   // its floor is focused). The checkbox is the single source of truth - zoom
@@ -892,6 +930,72 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
     return out;
   }, [visibleLayers, data]);
 
+  // ── One-click PDF export: capture the map as-is, then re-render the PRS
+  // story and the treatment-gap snapshot as text pages (see export-pdf.tsx).
+  const mapWrapRef = useRef<HTMLDivElement | null>(null);
+  const [pdfBusy, setPdfBusy] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  async function downloadPdf() {
+    const mapEl = mapWrapRef.current?.querySelector<HTMLElement>(".leaflet-container");
+    if (!mapEl) {
+      setPdfError("The map hasn't finished loading yet - try again in a moment.");
+      return;
+    }
+    setPdfBusy(true);
+    setPdfError(null);
+    try {
+      // The PDF legend = the on-map legend + the PRS-year entries (which the
+      // map shows in their own inline box next to the growth toggle).
+      const items = buildLegendItems(visibleLayers, elevationLegend);
+      if (prsVisible) {
+        if (showGrowth) {
+          items.push(
+            { sym: "line", color: "#f97316", label: "Polluted by 2020 (Priority III)" },
+            { sym: "line", color: "#dc2626", label: "Added by 2025 - now Priority I" },
+          );
+        } else {
+          items.push({ sym: "line", color: "#dc2626", label: "Polluted stretch, 2025 (Priority I)" });
+        }
+      }
+      // Share URL: the ON set spelled out explicitly (not the defaults-elided
+      // form the address bar uses), so the embed page restores this exact view
+      // whatever its own entry-floor defaults are.
+      const layersParam = manifest.layers
+        .map(layerKey)
+        .filter((k) => effectiveEnabled[k])
+        .join(",");
+      await exportBasinAtlasPdf({
+        mapEl,
+        manifest,
+        inventory,
+        scopeLabel: selectedRiver ? `${selectedRiver.displayName} (river-scoped)` : "Whole basin",
+        legendItems: items,
+        legendNotes,
+        selectedRiver,
+        prs: prsData,
+        acc: accData,
+        reviewedMpr,
+        dep: depData,
+        gapUnits: Object.values(gapData),
+        gapNote,
+        includeGaps: visibleLayers.some((l) => l.gap),
+        shareUrl: buildAtlasShareUrl({
+          origin: window.location.origin,
+          basinId: manifest.basinId,
+          riverId: selectedRiverId,
+          floor: focusedFloor,
+          layersParam: layersParam || null,
+          growth: showGrowth,
+        }),
+      });
+    } catch (err) {
+      console.error("Basin atlas PDF export failed", err);
+      setPdfError("Couldn't prepare the PDF. Please try again.");
+    } finally {
+      setPdfBusy(false);
+    }
+  }
+
   return (
     <div className="h-full w-full flex flex-col md:flex-row">
       {/* ── Elevator rail: off-canvas left drawer on mobile, in-flow sidebar on
@@ -952,6 +1056,19 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
               <p className="mt-1 text-[11px] text-slate-400">Basin area ~{manifest.areaKm2.toLocaleString()} km².</p>
             )}
           </details>
+          {/* One-click export: the map exactly as configured + the PRS story
+              + the treatment-gap snapshot as searchable text pages. */}
+          <button
+            onClick={downloadPdf}
+            disabled={pdfBusy}
+            className="mt-2 w-full inline-flex items-center justify-center gap-1.5 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-60"
+          >
+            <span aria-hidden>⤓</span>
+            {pdfBusy ? "Preparing PDF…" : "Download as PDF"}
+          </button>
+          {pdfError && (
+            <p role="alert" className="mt-1 text-[10px] leading-snug text-rose-600 dark:text-rose-400">{pdfError}</p>
+          )}
           {selectedRiver && (
             <button
               onClick={() => selectRiver(null)}
@@ -1072,7 +1189,7 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
       )}
 
       {/* ── Map ── */}
-      <div className="relative flex-1 h-full min-h-[320px]">
+      <div ref={mapWrapRef} className="relative flex-1 h-full min-h-[320px]">
         <MapContainer center={manifest.mapCenter} zoom={manifest.mapZoom} className="h-full w-full" preferCanvas zoomControl={false}>
           <ZoomControl position="bottomright" />
           <MapResizer />
@@ -1080,7 +1197,10 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
               flies back to the overview instead of staying zoomed into the
               estate the HighlightFlyer framed. */}
           <MapController fitBounds={fitBounds} defaultFocus={manifest.defaultFocus} hasSelection={selectedRiverId != null || mapHighlight != null} />
-          <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} />
+          {/* crossOrigin so the tile <img>s load CORS-clean (OSM sends
+              Access-Control-Allow-Origin:*) - required for the PDF export's
+              canvas capture to read them without tainting. */}
+          <TileLayer key={tiles.url} url={tiles.url} attribution={tiles.attribution} crossOrigin="anonymous" />
 
           {/* One shared canvas, stacked by DRAW ORDER (not panes): base outlines
               and sub-catchments first (bottom), then thematic fills, lines, and
@@ -1547,17 +1667,17 @@ export function BasinAtlas({ cityDisplayName, manifest, inventory, initialRiverI
 
 // ── legend ───────────────────────────────────────────────────────────────
 
-type LegendSym = "box" | "dot" | "ring" | "line" | "dash" | "outline" | "tri" | "tri-ring";
+export type LegendSym = "box" | "dot" | "ring" | "line" | "dash" | "outline" | "tri" | "tri-ring";
+export interface LegendItem { sym: LegendSym; color: string; label: string }
 
-/** Dynamic legend: one entry per symbol actually on the map right now,
- *  expanding pressures into its kinds and showing the monitoring public-domain
- *  cue (filled vs hollow). */
-function MapLegend({ layers, elevation, notes, raised }: { layers: BasinLayer[]; elevation?: { band: string; color: string }[]; notes?: string[]; raised?: boolean }) {
-  const [open, setOpen] = useState(true);
-  // Every entry's color comes from the layer's manifest `color` or the shared
-  // PRESSURE_KIND_COLOR map - the same sources the map styles read - so the
-  // legend can never disagree with what's drawn.
-  const items: { sym: LegendSym; color: string; label: string }[] = [];
+/** One legend entry per symbol actually on the map right now, expanding
+ *  pressures into its kinds and showing the monitoring public-domain cue
+ *  (filled vs hollow). Every entry's color comes from the layer's manifest
+ *  `color` or the shared PRESSURE_KIND_COLOR map - the same sources the map
+ *  styles read - so the legend can never disagree with what's drawn. Shared
+ *  by the on-map MapLegend and the PDF export's page-1 legend. */
+export function buildLegendItems(layers: BasinLayer[], elevation?: { band: string; color: string }[]): LegendItem[] {
+  const items: LegendItem[] = [];
   for (const l of layers) {
     if (l.elevation) {
       // Band labels come from the data (they differ per basin), matching the
@@ -1606,6 +1726,13 @@ function MapLegend({ layers, elevation, notes, raised }: { layers: BasinLayer[];
     else if (l.geom === "point") items.push({ sym: "dot", color: l.color, label: l.label });
     else items.push({ sym: "box", color: l.color, label: l.label });
   }
+  return items;
+}
+
+/** Dynamic legend: reflects what's currently visible on the map. */
+function MapLegend({ layers, elevation, notes, raised }: { layers: BasinLayer[]; elevation?: { band: string; color: string }[]; notes?: string[]; raised?: boolean }) {
+  const [open, setOpen] = useState(true);
+  const items = buildLegendItems(layers, elevation);
   if (!items.length) return null;
   return (
     <div className={`absolute ${raised ? "bottom-[156px] md:bottom-3" : "bottom-3"} left-3 z-[800] bg-white/95 dark:bg-slate-900/95 border border-slate-200 dark:border-slate-700 rounded-lg shadow text-[11px] max-w-[230px] transition-[bottom] duration-200`}>
@@ -2498,13 +2625,12 @@ function ReviewedMprSection({ series }: { series: ReviewedMprSeries }) {
 // Verdict chips for the accountability matrix. Plain-language labels: the
 // value of the matrix is making "exists in MPR vs doesn't" explicit per
 // region x category, so absence reads as a finding, not a blank.
-const ACC_VERDICT: Record<AccCategory["verdict"], { label: string; cls: string }> = {
-  tracked: { label: "In plan + MPR", cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300" },
-  "in-plan-not-reported": { label: "In plan, not in MPR", cls: "bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300" },
-  "reported-not-in-plan": { label: "In MPR, not in plan", cls: "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300" },
-  silent: { label: "Not in plan or MPR", cls: "bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300" },
+const ACC_VERDICT_CLS: Record<AccCategory["verdict"], string> = {
+  tracked: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+  "in-plan-not-reported": "bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300",
+  "reported-not-in-plan": "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+  silent: "bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300",
 };
-const ACC_KIND_LABEL: Record<AccRegion["kind"], string> = { ulb: "ULBs", ia: "Industrial Areas", gp: "Gram Panchayats" };
 
 export function AccountabilityMatrix({ data, onShowRegion }: { data: AccountabilityData; onShowRegion?: (r: AccRegion) => void }) {
   const kinds = (["ulb", "ia", "gp"] as const).filter((k) => data.regions.some((r) => r.kind === k));
@@ -2578,7 +2704,7 @@ export function AccountabilityMatrix({ data, onShowRegion }: { data: Accountabil
 
           {region.silentNote ? (
             <p className="text-[12px] leading-snug rounded-md bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-900/60 text-rose-900 dark:text-rose-100 px-2 py-1.5">
-              <span className={`inline-block align-middle mr-1.5 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${ACC_VERDICT.silent.cls}`}>{ACC_VERDICT.silent.label}</span>
+              <span className={`inline-block align-middle mr-1.5 text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded ${ACC_VERDICT_CLS.silent}`}>{ACC_VERDICT_LABEL.silent}</span>
               {region.silentNote}
             </p>
           ) : (
@@ -2588,7 +2714,7 @@ export function AccountabilityMatrix({ data, onShowRegion }: { data: Accountabil
                   <summary className="cursor-pointer list-none flex items-center gap-2">
                     <span aria-hidden className="text-slate-400 group-open:rotate-90 transition-transform text-[10px]">▸</span>
                     <span className="flex-1 text-[13px] font-semibold text-slate-800 dark:text-slate-100">{c.label}</span>
-                    <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${ACC_VERDICT[c.verdict].cls}`}>{ACC_VERDICT[c.verdict].label}</span>
+                    <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${ACC_VERDICT_CLS[c.verdict]}`}>{ACC_VERDICT_LABEL[c.verdict]}</span>
                   </summary>
                   <div className="mt-1.5 ml-4 space-y-1.5">
                     <div className="rounded-md bg-slate-50 dark:bg-slate-800/60 px-2 py-1.5">
@@ -2938,35 +3064,13 @@ function GapStreamsBody({ unit }: { unit: GapUnit }) {
 }
 
 // ── DEP Snapshot v2 panel (district-first) ───────────────────────────────────
-// Display order and labels of the 7 NGT thematic areas (OA 360/2018).
-const DEP_THEME_LABEL: Record<string, string> = {
-  "waste-management": "Waste Management",
-  "water-quality": "Water Quality",
-  "domestic-sewage": "Domestic Sewage",
-  "industrial-wastewater": "Industrial Wastewater",
-  "air-quality": "Air Quality",
-  mining: "Mining Activity",
-  noise: "Noise Pollution",
+// Theme labels/order live in @/lib/basins/panel-labels (shared with the PDF
+// export); only the Tailwind chip classes are local to this surface.
+const DEP_STATUS_CLS: Record<DepThemeStatus, string> = {
+  covered: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+  "district-level": "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+  "not-covered": "bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300",
 };
-const DEP_THEME_ORDER = Object.keys(DEP_THEME_LABEL);
-const DEP_SUBTHEME_LABEL: Record<string, string> = {
-  "solid-waste": "Solid Waste",
-  "plastic-waste": "Plastic Waste",
-  "cd-waste": "C&D Waste",
-  "biomedical-waste": "Biomedical Waste",
-  "hazardous-waste": "Hazardous Waste",
-  "e-waste": "E-Waste",
-};
-const DEP_STATUS: Record<DepThemeStatus, { label: string; cls: string }> = {
-  covered: { label: "In the plan", cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300" },
-  "district-level": { label: "District-level only", cls: "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300" },
-  "not-covered": { label: "Not covered", cls: "bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300" },
-};
-
-function depThemeTitle(t: DepTheme): string {
-  const base = DEP_THEME_LABEL[t.theme] ?? t.theme;
-  return t.subtheme ? `${base}: ${DEP_SUBTHEME_LABEL[t.subtheme] ?? t.subtheme}` : base;
-}
 
 /** One thematic-area entry: status chip, summary, metrics, and the plan's own
  *  action items (the accountability payload). Collapsible - a unit has up to
@@ -2978,7 +3082,7 @@ function DepThemeCard({ t, defaultOpen = false }: { t: DepTheme; defaultOpen?: b
       <summary className={`list-none flex items-center gap-2 ${hasBody ? "cursor-pointer" : "cursor-default"}`}>
         {hasBody && <span aria-hidden className="text-slate-400 text-[10px] transition-transform group-open:rotate-90">▶</span>}
         <span className="text-[13px] font-semibold text-slate-800 dark:text-slate-200 flex-1">{depThemeTitle(t)}</span>
-        <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${DEP_STATUS[t.status].cls}`}>{DEP_STATUS[t.status].label}</span>
+        <span className={`text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${DEP_STATUS_CLS[t.status]}`}>{DEP_STATUS_LABEL[t.status]}</span>
       </summary>
       {hasBody && (
         <div className="pl-4 pt-1.5 space-y-2">

--- a/src/components/basin/basin-pdf-report.tsx
+++ b/src/components/basin/basin-pdf-report.tsx
@@ -1,0 +1,1019 @@
+// The Basin Atlas PDF report - a text-native @react-pdf/renderer document.
+//
+// Page 1 mirrors the map as configured at export (captured PNG + the same
+// legend the on-screen MapLegend derives), then the PRS story and the DEP
+// treatment-gap snapshot re-render as REAL text - searchable, quotable and
+// citable - never screenshots of the panels. Content comes from the same
+// loaded data objects the panels render (prs.json / accountability.json /
+// gaps.json / mpr-reviewed.json), so the PDF can never say something the
+// atlas doesn't.
+//
+// This module is only ever loaded through the dynamic import in
+// lib/basins/export-pdf.tsx, keeping @react-pdf/renderer out of the main
+// bundle. Fonts: the built-in Helvetica family - every string is passed
+// through the WinAnsi sanitizer in export-pdf before it reaches this
+// document, so no font files ship with the app.
+
+import type { ReactNode } from "react";
+import {
+  Document,
+  Image,
+  Link,
+  Page,
+  StyleSheet,
+  Svg,
+  Polygon,
+  Text,
+  View,
+} from "@react-pdf/renderer";
+import type { BasinInventory, BasinManifest, BasinRiver } from "@/lib/basins";
+import {
+  reviewedMprConceptLabel,
+  reviewedMprValueLabel,
+  type ReviewedMprSeries,
+} from "@/lib/basins/reviewed-mpr";
+import {
+  ACC_KIND_LABEL,
+  ACC_VERDICT_LABEL,
+  DEP_STATUS_LABEL,
+  depThemeTitle,
+} from "@/lib/basins/panel-labels";
+// Type-only: erased at compile time, so this module never pulls the Leaflet
+// component tree in at runtime (which also keeps it renderable in Node tests).
+import type {
+  AccountabilityData,
+  AccRegion,
+  DepData,
+  DepTheme,
+  GapUnit,
+  LegendItem,
+  PrsData,
+  PrsTab,
+  PrsUnit,
+} from "@/components/basin/basin-atlas";
+
+export interface BasinReportProps {
+  manifest: BasinManifest;
+  inventory: BasinInventory | null;
+  generatedAt: string;
+  scopeLabel: string;
+  mapPng: string;
+  /** Captured map height / width. */
+  mapAspect: number;
+  legendItems: LegendItem[];
+  legendNotes: string[];
+  selectedRiver: BasinRiver | null;
+  prs: PrsData | null;
+  acc: AccountabilityData | null;
+  reviewedMpr: ReviewedMprSeries | null;
+  dep: DepData | null;
+  /** v1 gaps.json units (empty for v2/DEP basins). */
+  gapUnits: GapUnit[];
+  gapNote: string | null;
+  includeGaps: boolean;
+  shareUrl: string;
+  origin: string;
+}
+
+const C = {
+  text: "#111827",
+  muted: "#64748b",
+  faint: "#94a3b8",
+  border: "#e2e8f0",
+  soft: "#f8fafc",
+  rose: "#be123c",
+  roseBg: "#fff1f2",
+  roseBorder: "#fecdd3",
+  amber: "#b45309",
+  amberBg: "#fffbeb",
+  amberBorder: "#fde68a",
+  emerald: "#047857",
+  emeraldBg: "#ecfdf5",
+  sky: "#0369a1",
+  skyBg: "#f0f9ff",
+  blue: "#1d4ed8",
+  slateChipBg: "#f1f5f9",
+};
+
+const VERDICT_COLOR: Record<string, { fg: string; bg: string }> = {
+  tracked: { fg: C.emerald, bg: C.emeraldBg },
+  "in-plan-not-reported": { fg: C.amber, bg: C.amberBg },
+  "reported-not-in-plan": { fg: C.sky, bg: C.skyBg },
+  silent: { fg: C.rose, bg: C.roseBg },
+};
+const DEP_STATUS_COLOR: Record<string, { fg: string; bg: string }> = {
+  covered: { fg: C.emerald, bg: C.emeraldBg },
+  "district-level": { fg: C.sky, bg: C.skyBg },
+  "not-covered": { fg: C.rose, bg: C.roseBg },
+};
+const TONE_COLOR: Record<string, { fg: string; bg: string }> = {
+  bad: { fg: C.rose, bg: C.roseBg },
+  warn: { fg: C.amber, bg: C.amberBg },
+  neutral: { fg: C.muted, bg: C.slateChipBg },
+  good: { fg: C.emerald, bg: C.emeraldBg },
+};
+
+const s = StyleSheet.create({
+  page: {
+    paddingTop: 36,
+    paddingHorizontal: 36,
+    paddingBottom: 52,
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    color: C.text,
+    // NO lineHeight here (and none on the footer styles below): fixed
+    // per-page elements (the page number's render callback) re-resolve
+    // inherited styles on every page, and react-pdf compounds an inherited
+    // lineHeight exponentially until pdfkit throws "unsupported number".
+    // Every flowing text style carries its own lineHeight instead.
+  },
+  // Header / title block
+  titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+  title: { fontSize: 19, fontFamily: "Helvetica-Bold", lineHeight: 1.15 },
+  brand: { fontSize: 9, color: C.muted, textAlign: "right", lineHeight: 1.3 },
+  collabRow: { flexDirection: "row", alignItems: "center", marginTop: 6 },
+  collabLabel: { fontSize: 8.5, color: C.muted, marginRight: 6, lineHeight: 1.2 },
+  collabLogo: { height: 22, objectFit: "contain" },
+  metaLine: { fontSize: 8.5, color: C.muted, marginTop: 8, lineHeight: 1.3 },
+  // Sections
+  section: { marginTop: 9 },
+  h2: {
+    fontSize: 8,
+    fontFamily: "Helvetica-Bold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    color: C.muted,
+    marginBottom: 4,
+    lineHeight: 1.2,
+  },
+  h2Rose: { color: C.rose },
+  h3: { fontSize: 11, fontFamily: "Helvetica-Bold", marginBottom: 2, lineHeight: 1.2 },
+  body: { fontSize: 9, color: C.text, lineHeight: 1.3 },
+  small: { fontSize: 8, color: C.muted, lineHeight: 1.3 },
+  tiny: { fontSize: 7, color: C.faint, lineHeight: 1.25 },
+  // Map
+  mapImage: { borderWidth: 1, borderColor: C.border, borderRadius: 3 },
+  // Legend
+  legendWrap: { flexDirection: "row", flexWrap: "wrap", marginTop: 2 },
+  legendItem: { flexDirection: "row", alignItems: "center", width: "33.33%", paddingRight: 8, marginBottom: 3 },
+  legendLabel: { fontSize: 7.5, color: C.text, marginLeft: 4, flex: 1, lineHeight: 1.2 },
+  // Key-value rows
+  kvBox: { borderWidth: 1, borderColor: C.border, borderRadius: 4, marginTop: 4 },
+  kvRow: { flexDirection: "row", paddingVertical: 3, paddingHorizontal: 6, borderTopWidth: 1, borderTopColor: "#f1f5f9" },
+  kvRowFirst: { borderTopWidth: 0 },
+  kvLabel: { width: 110, fontSize: 8, color: C.muted, lineHeight: 1.25 },
+  kvValue: { flex: 1, fontSize: 8.5, lineHeight: 1.25 },
+  // Callouts
+  callout: { borderWidth: 1, borderRadius: 4, padding: 5, marginTop: 4 },
+  // Chips
+  chip: { borderRadius: 3, paddingHorizontal: 4, paddingVertical: 1.5, alignSelf: "flex-start" },
+  chipText: { fontSize: 6.5, fontFamily: "Helvetica-Bold", textTransform: "uppercase", letterSpacing: 0.4, lineHeight: 1.1 },
+  // Bars
+  barRow: { flexDirection: "row", alignItems: "center", marginBottom: 3 },
+  barYear: { width: 26, fontSize: 7.5, color: C.muted, lineHeight: 1.2 },
+  barTrack: { flex: 1, height: 9, backgroundColor: "#f1f5f9", borderRadius: 2, flexDirection: "row", overflow: "hidden" },
+  barValue: { width: 84, fontSize: 7.5, color: C.muted, textAlign: "right", paddingLeft: 4, lineHeight: 1.2 },
+  // Bullets
+  bulletRow: { flexDirection: "row", marginBottom: 2 },
+  bulletDot: { width: 10, fontSize: 8.5, color: C.faint, lineHeight: 1.3 },
+  bulletText: { flex: 1, fontSize: 8.5, lineHeight: 1.3 },
+  // Footer
+  footer: {
+    position: "absolute",
+    left: 36,
+    right: 36,
+    bottom: 20,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    borderTopWidth: 1,
+    borderTopColor: C.border,
+    paddingTop: 5,
+  },
+  footerText: { fontSize: 7, color: C.faint },
+  footerLink: { fontSize: 7, color: C.blue, textDecoration: "none" },
+  pageNum: { position: "absolute", right: 36, bottom: 8, fontSize: 7, color: C.faint },
+  link: { color: C.blue, textDecoration: "none" },
+});
+
+function Chip({ label, fg, bg }: { label: string; fg: string; bg: string }) {
+  return (
+    <View style={[s.chip, { backgroundColor: bg }]}>
+      <Text style={[s.chipText, { color: fg }]}>{label}</Text>
+    </View>
+  );
+}
+
+function Bullet({ children, color = C.faint }: { children: ReactNode; color?: string }) {
+  return (
+    <View style={s.bulletRow}>
+      <Text style={[s.bulletDot, { color }]}>{"•"}</Text>
+      <Text style={s.bulletText}>{children}</Text>
+    </View>
+  );
+}
+
+function KvRows({ rows }: { rows: { label: string; value: string }[] }) {
+  if (!rows.length) return null;
+  return (
+    <View style={s.kvBox}>
+      {rows.map((r, i) => (
+        <View key={i} style={[s.kvRow, ...(i === 0 ? [s.kvRowFirst] : [])]} wrap={false}>
+          <Text style={s.kvLabel}>{r.label}</Text>
+          <Text style={s.kvValue}>{r.value}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function LegendSwatch({ sym, color }: { sym: string; color: string }) {
+  const base = { width: 7, height: 7 };
+  if (sym === "dot") return <View style={{ ...base, borderRadius: 3.5, backgroundColor: color }} />;
+  if (sym === "ring") return <View style={{ ...base, borderRadius: 3.5, borderWidth: 1.4, borderColor: color }} />;
+  if (sym === "line") return <View style={{ width: 10, height: 2, backgroundColor: color }} />;
+  if (sym === "dash")
+    return (
+      <View style={{ width: 10, height: 2, flexDirection: "row", justifyContent: "space-between" }}>
+        <View style={{ width: 4, height: 2, backgroundColor: color }} />
+        <View style={{ width: 4, height: 2, backgroundColor: color }} />
+      </View>
+    );
+  if (sym === "outline") return <View style={{ ...base, borderWidth: 1, borderColor: color }} />;
+  if (sym === "tri" || sym === "tri-ring")
+    return (
+      <Svg width={8} height={8} viewBox="0 0 12 12">
+        <Polygon
+          points="6,1 11.5,11 0.5,11"
+          fill={sym === "tri" ? color : "none"}
+          stroke={color}
+          strokeWidth={sym === "tri" ? 0 : 1.8}
+        />
+      </Svg>
+    );
+  return <View style={{ ...base, borderRadius: 1, backgroundColor: color }} />;
+}
+
+/** One year's generated-vs-treated bar - the PDF twin of GenTreatedBar. */
+function GenBar({ year, gen, treated, max, unit }: { year: number; gen?: number; treated?: number; max: number; unit: string }) {
+  const pct = (v: number) => `${Math.max(0, (v / max) * 100)}%` as const;
+  let segments: ReactNode = null;
+  let value = "n/r";
+  if (gen != null && treated != null) {
+    const tr = Math.min(treated, gen);
+    segments = (
+      <>
+        <View style={{ width: pct(tr), backgroundColor: "#3b82f6" }} />
+        <View style={{ width: pct(gen - tr), backgroundColor: "#b91c1c" }} />
+      </>
+    );
+    value = `${treated} / ${gen} ${unit}`;
+  } else if (gen != null) {
+    segments = <View style={{ width: pct(gen), backgroundColor: "#94a3b8" }} />;
+    value = `${gen} ${unit} gen`;
+  } else if (treated != null) {
+    segments = <View style={{ width: pct(treated), backgroundColor: "#3b82f6" }} />;
+    value = `${treated} ${unit}`;
+  }
+  return (
+    <View style={s.barRow} wrap={false}>
+      <Text style={s.barYear}>{year}</Text>
+      <View style={s.barTrack}>{segments}</View>
+      <Text style={s.barValue}>{value}</Text>
+    </View>
+  );
+}
+
+function Footer({ shareUrl }: { shareUrl: string }) {
+  return (
+    <>
+      <View fixed style={s.footer}>
+        <Link src={shareUrl} style={s.footerLink}>
+          View the live interactive map (link)
+        </Link>
+        <Text style={s.footerText}>Neer Vazhvu · neervazhvu.org</Text>
+      </View>
+      <Text fixed style={s.pageNum} render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} />
+    </>
+  );
+}
+
+// ── Page 1: the map as configured ────────────────────────────────────────────
+
+function MapPage(p: BasinReportProps) {
+  const contentW = 595.28 - 72; // A4 minus margins
+  const maxH = 380;
+  let w = contentW;
+  let h = w * p.mapAspect;
+  if (h > maxH) {
+    h = maxH;
+    w = h / p.mapAspect;
+  }
+  return (
+    <Page size="A4" style={s.page}>
+      <View style={s.titleRow}>
+        <View style={{ flex: 1 }}>
+          <Text style={s.title}>{p.manifest.displayName} Atlas</Text>
+          {p.manifest.collaboration && (
+            <View style={s.collabRow}>
+              <Text style={s.collabLabel}>
+                {p.manifest.collaboration.label} {p.manifest.collaboration.name}
+              </Text>
+              {/* eslint-disable-next-line jsx-a11y/alt-text -- react-pdf Image has no alt prop */}
+              <Image src={`${p.origin}${p.manifest.collaboration.logo}`} style={s.collabLogo} />
+            </View>
+          )}
+        </View>
+        <Text style={s.brand}>Neer Vazhvu{"\n"}neervazhvu.org</Text>
+      </View>
+      <Text style={s.metaLine}>
+        Generated {p.generatedAt} · Scope: {p.scopeLabel} · Map and layer selection exactly as configured in the atlas at export.
+      </Text>
+
+      <View style={{ marginTop: 10, alignItems: "center" }}>
+        {/* eslint-disable-next-line jsx-a11y/alt-text -- react-pdf Image has no alt prop */}
+        <Image src={p.mapPng} style={[s.mapImage, { width: w, height: h }]} />
+      </View>
+      <Text style={[s.tiny, { marginTop: 3 }]}>
+        Basemap (c) OpenStreetMap contributors. Live version of this exact view: {p.shareUrl}
+      </Text>
+
+      {p.legendItems.length > 0 && (
+        <View style={s.section}>
+          <Text style={s.h2}>Legend - layers on this map</Text>
+          <View style={s.legendWrap}>
+            {p.legendItems.map((it, i) => (
+              <View key={i} style={s.legendItem} wrap={false}>
+                <LegendSwatch sym={it.sym} color={it.color} />
+                <Text style={s.legendLabel}>{it.label}</Text>
+              </View>
+            ))}
+          </View>
+          {p.legendNotes.map((n, i) => (
+            <Text key={i} style={[s.small, { marginTop: 2 }]}>
+              {n}
+            </Text>
+          ))}
+        </View>
+      )}
+
+      {p.selectedRiver && (
+        <View style={s.section} wrap={false}>
+          <Text style={s.h2}>Selected river: {p.selectedRiver.displayName}</Text>
+          {p.selectedRiver.attributes && (
+            <KvRows
+              rows={[
+                { label: "Origin", value: p.selectedRiver.attributes.origin ?? "" },
+                { label: "Length", value: p.selectedRiver.attributes.length ?? "" },
+                { label: "Tributaries", value: p.selectedRiver.attributes.tributaries ?? "" },
+                { label: "Flows into", value: p.selectedRiver.attributes.flowsInto ?? "" },
+                { label: "Polluted river stretch", value: p.selectedRiver.attributes.pollutedStretch ?? "" },
+                { label: "Restoration initiatives", value: p.selectedRiver.attributes.restorationInitiatives ?? "" },
+              ].filter((r) => r.value)}
+            />
+          )}
+          {p.selectedRiver.narrative && <Text style={[s.small, { marginTop: 3 }]}>{p.selectedRiver.narrative}</Text>}
+        </View>
+      )}
+
+      <View style={s.section}>
+        <Text style={s.h2}>About this basin</Text>
+        <Text style={s.small}>{p.manifest.blurb}</Text>
+        {p.manifest.areaKm2 && (
+          <Text style={[s.tiny, { marginTop: 2 }]}>
+            Basin area ~{p.manifest.areaKm2.toLocaleString("en-IN")} km squared.{p.manifest.areaNote ? ` ${p.manifest.areaNote}` : ""}
+          </Text>
+        )}
+      </View>
+
+      <Footer shareUrl={p.shareUrl} />
+    </Page>
+  );
+}
+
+// ── PRS pages ────────────────────────────────────────────────────────────────
+
+function PrsUnitBlock({ unit, tab }: { unit: PrsUnit; tab: PrsTab }) {
+  const unitLabel = tab.unitLabel ?? "MLD";
+  const treatedVerb = tab.treatedVerb ?? "treated";
+  const gapWord = treatedVerb === "processed" ? "unprocessed" : "untreated";
+  const genBy = new Map(unit.generation.map((pt) => [pt.year, pt.value]));
+  const trBy = new Map(unit.treated.map((pt) => [pt.year, pt.value]));
+  const years = Array.from(new Set([...genBy.keys(), ...trBy.keys()])).sort((a, b) => a - b);
+  const maxV = Math.max(1, ...unit.generation.map((pt) => pt.value), ...unit.treated.map((pt) => pt.value));
+  return (
+    // wrap: a unit block (BBMP: five years of bars + a long infrastructure
+    // list) can exceed a page; wrap={false} here would clip it.
+    <View style={[s.callout, { borderColor: C.border }]}>
+      <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 2 }}>
+        <Text style={[s.h3, { flex: 1, fontSize: 9.5, marginBottom: 0 }]}>{unit.name}</Text>
+        {unit.level && <Chip label={`Reported at: ${unit.level}`} fg={C.muted} bg={C.slateChipBg} />}
+      </View>
+      {unit.sourceTier === "other" && (
+        <Text style={[s.tiny, { marginBottom: 2 }]}>
+          {unit.mprNote ?? `Not itemised in any MPR edition we hold - figures below are from other public documents.`}
+        </Text>
+      )}
+      {unit.caveat && <Text style={[s.tiny, { color: C.amber, marginBottom: 2 }]}>{unit.caveat}</Text>}
+      {years.length > 0 ? (
+        <>
+          <Text style={[s.tiny, { marginBottom: 2 }]}>
+            Generated vs {treatedVerb} ({unitLabel}/year) - blue = {treatedVerb}, red = {gapWord} gap, grey = treatment not reported
+          </Text>
+          {years.map((y) => (
+            <GenBar key={y} year={y} gen={genBy.get(y)} treated={trBy.get(y)} max={maxV} unit={unitLabel} />
+          ))}
+        </>
+      ) : (
+        <Text style={s.tiny}>{unit.generationNote ?? "Generation not separately reported."}</Text>
+      )}
+      {years.length > 0 && unit.generationNote && <Text style={s.tiny}>{unit.generationNote}</Text>}
+      {typeof unit.gapValue === "number" && (
+        <Text style={[s.small, { color: C.rose, marginTop: 2 }]}>
+          {gapWord.charAt(0).toUpperCase() + gapWord.slice(1)} gap {unit.gapValue} {unitLabel}
+          {unit.gapNote ? ` - ${unit.gapNote}` : ""}
+        </Text>
+      )}
+      {unit.capacity && <Text style={[s.small, { marginTop: 2 }]}>Capacity: {unit.capacity}</Text>}
+      {unit.infrastructure?.map((it, i) => (
+        <Bullet key={i} color={it.tone === "good" ? C.emerald : it.tone === "bad" ? C.rose : C.faint}>
+          {it.label}: {it.status}
+        </Bullet>
+      ))}
+      {unit.otherStreams?.map((st, i) => (
+        <Text key={i} style={s.small}>
+          {st.label}: {st.value}
+        </Text>
+      ))}
+      {unit.dashboard && <Text style={s.tiny}>Public dashboard: {unit.dashboard}</Text>}
+      {unit.sourceNote && <Text style={s.tiny}>Source: {unit.sourceNote}</Text>}
+    </View>
+  );
+}
+
+function PrsTabDetail({ tab }: { tab: PrsTab }) {
+  return (
+    <View style={{ marginTop: 8 }}>
+      <Text style={s.h3}>{tab.label}</Text>
+      {tab.intro && <Text style={[s.small, { marginBottom: 2 }]}>{tab.intro}</Text>}
+      {tab.units?.map((u) => <PrsUnitBlock key={u.key} unit={u} tab={tab} />)}
+      {tab.categories?.map((c) => (
+        <View key={c.key} style={[s.callout, { borderColor: C.border }]}>
+          <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 2 }}>
+            <Text style={[s.h3, { flex: 1, fontSize: 9.5, marginBottom: 0 }]}>{c.label}</Text>
+            {c.level && <Chip label={`Reported at: ${c.level}`} fg={C.muted} bg={C.slateChipBg} />}
+          </View>
+          {c.noData ? (
+            <Text style={s.small}>No known public data yet for {c.label} along this stretch.</Text>
+          ) : (
+            <>
+              {c.body && <Text style={[s.small, { color: C.text, marginBottom: 2 }]}>{c.body}</Text>}
+              {c.points?.map((pt, i) => (
+                <Bullet key={i} color={C.rose}>
+                  {pt}
+                </Bullet>
+              ))}
+              {c.link && (
+                <Text wrap={false} style={s.tiny}>
+                  {c.link.label}: <Link src={c.link.url} style={s.link}>{c.link.url}</Link>
+                </Text>
+              )}
+            </>
+          )}
+        </View>
+      ))}
+      {tab.source && <Text style={[s.tiny, { marginTop: 2 }]}>Source: {tab.source}</Text>}
+    </View>
+  );
+}
+
+function AccRegionBlock({ region, acc }: { region: AccRegion; acc: AccountabilityData }) {
+  return (
+    <View style={[s.callout, { borderColor: C.border }]}>
+      <Text style={[s.h3, { fontSize: 10 }]}>{region.name}</Text>
+      {region.inBasinNote && <Text style={[s.tiny, { marginBottom: 2 }]}>{region.inBasinNote}</Text>}
+      {region.silentNote ? (
+        <View>
+          <Chip label={ACC_VERDICT_LABEL.silent} fg={VERDICT_COLOR.silent.fg} bg={VERDICT_COLOR.silent.bg} />
+          <Text style={[s.small, { marginTop: 2 }]}>{region.silentNote}</Text>
+        </View>
+      ) : (
+        region.categories.map((c) => (
+          <View key={c.key} style={{ marginTop: 4, paddingTop: 3, borderTopWidth: 1, borderTopColor: "#f1f5f9" }} wrap={false}>
+            <View style={{ flexDirection: "row", alignItems: "center" }}>
+              <Text style={[s.body, { fontFamily: "Helvetica-Bold", flex: 1 }]}>{c.label}</Text>
+              <Chip
+                label={ACC_VERDICT_LABEL[c.verdict]}
+                fg={VERDICT_COLOR[c.verdict]?.fg ?? C.muted}
+                bg={VERDICT_COLOR[c.verdict]?.bg ?? C.slateChipBg}
+              />
+            </View>
+            <Text style={[s.small, { marginTop: 1.5 }]}>
+              Action Plan (2019): {c.actionPlan.summary}
+              {c.actionPlan.cite ? ` [${c.actionPlan.cite}]` : ""}
+            </Text>
+            <Text style={s.small}>
+              MPR status (as of {c.mpr.asOf}): {c.mpr.summary}
+            </Text>
+            {c.gaps?.map((g, i) => (
+              <Bullet key={i} color={C.rose}>
+                Gap identified: {g}
+              </Bullet>
+            ))}
+            {c.legalRef &&
+              acc.legalLibrary?.[c.legalRef]?.map((l, i) => (
+                <Text wrap={false} key={i} style={s.tiny}>
+                  Legal requirement: <Link src={l.url} style={s.link}>{l.label}</Link>
+                </Text>
+              ))}
+            {c.media?.map((m, i) => (
+              <Text wrap={false} key={i} style={s.tiny}>
+                Media: <Link src={m.url} style={s.link}>{m.label}</Link>
+              </Text>
+            ))}
+          </View>
+        ))
+      )}
+      {region.grievance && (
+        <Text wrap={false} style={[s.tiny, { marginTop: 3 }]}>
+          {region.grievance.label}: <Link src={region.grievance.url} style={s.link}>{region.grievance.url}</Link>
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function PrsPages(p: BasinReportProps) {
+  const prs = p.prs!;
+  const maxKm = Math.max(prs.comparison.y2020.length_km, prs.comparison.y2025.length_km) || 1;
+  const rows = [
+    { year: "2020", ...prs.comparison.y2020, accent: "#fb7185" },
+    { year: "2025", ...prs.comparison.y2025, accent: "#b91c1c" },
+  ];
+  const stretchTabs = prs.tabs.filter((t) => t.scope === "stretch");
+  const latestMpr = p.reviewedMpr?.editions.at(-1);
+  return (
+    <Page size="A4" style={s.page}>
+      <Text style={[s.h2, s.h2Rose]}>Polluted River Stretch (PRS) - CPCB / NGT</Text>
+      <Text style={s.title}>{prs.river}</Text>
+      <Text style={[s.small, { marginBottom: 6 }]}>{prs.stretchName}</Text>
+
+      {/* Current status: 2020 vs 2025 */}
+      <Text style={s.h2}>Current status</Text>
+      {rows.map((r) => (
+        <View key={r.year} style={s.barRow} wrap={false}>
+          <Text style={s.barYear}>{r.year}</Text>
+          <View style={s.barTrack}>
+            <View style={{ width: `${(r.length_km / maxKm) * 100}%`, backgroundColor: r.accent }} />
+          </View>
+          <Text style={s.barValue}>
+            {r.length_km} km · P{r.priority}
+          </Text>
+        </View>
+      ))}
+      {prs.statusLine && (
+        <View style={[s.callout, { borderColor: C.roseBorder, backgroundColor: C.roseBg }]}>
+          <Text style={[s.body, { fontFamily: "Helvetica-Bold", color: "#881337" }]}>{prs.statusLine}</Text>
+        </View>
+      )}
+      {!prs.statusFacts && prs.conclusion && (
+        <View style={[s.callout, { borderColor: C.roseBorder, backgroundColor: C.roseBg }]}>
+          <Text style={[s.body, { fontFamily: "Helvetica-Bold", color: "#881337" }]}>{prs.conclusion}</Text>
+        </View>
+      )}
+      {prs.statusFacts && <KvRows rows={prs.statusFacts} />}
+
+      {/* Governance & compliance */}
+      {prs.governance && (
+        <View style={s.section}>
+          <Text style={s.h2}>Governance &amp; compliance</Text>
+          <KvRows rows={prs.governance.rows} />
+          {prs.governance.actionPlan && (
+            <Text wrap={false} style={[s.tiny, { marginTop: 2 }]}>
+              {prs.governance.actionPlan.label ?? "Action Plan"}:{" "}
+              <Link src={prs.governance.actionPlan.url} style={s.link}>{prs.governance.actionPlan.url}</Link>
+            </Text>
+          )}
+          {prs.governance.compliance?.map((c, i) => (
+            <Text wrap={false} key={i} style={[s.small, { marginTop: 1.5 }]}>
+              Compliance: {c.value}
+              {c.link ? " - " : ""}
+              {c.link && <Link src={c.link.url} style={s.link}>{c.link.label}</Link>}
+              {c.note ? ` (${c.note})` : ""}
+            </Text>
+          ))}
+          {prs.governance.note && <Text style={[s.tiny, { marginTop: 2 }]}>{prs.governance.note}</Text>}
+        </View>
+      )}
+
+      {/* Stretch-level obligations: status list + full detail per theme */}
+      {stretchTabs.length > 0 && (
+        <View style={s.section}>
+          <Text style={s.h2}>Stretch-level obligations (reported for the stretch as a whole)</Text>
+          {stretchTabs.map((t) => (
+            <View key={t.key} style={{ flexDirection: "row", alignItems: "center", marginBottom: 3 }} wrap={false}>
+              {t.summaryBadge && (
+                <View style={{ width: 92, marginRight: 6 }}>
+                  <Chip
+                    label={t.summaryBadge}
+                    fg={TONE_COLOR[t.summaryTone ?? "neutral"].fg}
+                    bg={TONE_COLOR[t.summaryTone ?? "neutral"].bg}
+                  />
+                </View>
+              )}
+              <View style={{ flex: 1 }}>
+                <Text style={[s.body, { fontFamily: "Helvetica-Bold" }]}>{t.label}</Text>
+                {t.summaryLine && <Text style={s.tiny}>{t.summaryLine}</Text>}
+              </View>
+            </View>
+          ))}
+          {stretchTabs.map((t) => (
+            <PrsTabDetail key={t.key} tab={t} />
+          ))}
+        </View>
+      )}
+
+      {/* Evidence of pollution */}
+      {prs.evidence && (
+        <View style={s.section}>
+          <Text style={[s.h2, s.h2Rose]}>Evidence of pollution</Text>
+          <Text style={[s.body, { fontFamily: "Helvetica-Bold", marginBottom: 2 }]}>{prs.evidence.headline}</Text>
+          {prs.evidence.points.map((pt, i) => (
+            <Bullet key={i}>{pt}</Bullet>
+          ))}
+          {prs.evidence.link && (
+            <Text wrap={false} style={s.tiny}>
+              {prs.evidence.link.label}: <Link src={prs.evidence.link.url} style={s.link}>{prs.evidence.link.url}</Link>
+            </Text>
+          )}
+        </View>
+      )}
+
+      {/* Reviewed monthly progress (latest edition) */}
+      {latestMpr && (
+        <View style={s.section}>
+          <Text style={s.h2}>Reviewed monthly progress - {latestMpr.source.title}</Text>
+          <Text wrap={false} style={s.tiny}>
+            Values published after platform review; page numbers cite the report.{" "}
+            <Link src={latestMpr.source.url} style={s.link}>Source PDF</Link>
+          </Text>
+          {(() => {
+            const groups = new Map<string, typeof latestMpr.records>();
+            for (const r of latestMpr.records) {
+              groups.set(r.subjectLabel, [...(groups.get(r.subjectLabel) ?? []), r]);
+            }
+            return [...groups.entries()].map(([subject, records]) => (
+              <View key={subject} style={{ marginTop: 3 }} wrap={false}>
+                <Text style={[s.small, { fontFamily: "Helvetica-Bold", color: C.text }]}>{subject}</Text>
+                {records.map((r) => (
+                  <Text key={r.claimId} style={s.small}>
+                    {reviewedMprConceptLabel(r.concept)}: {reviewedMprValueLabel(r.value)} (p. {r.pageNumber})
+                  </Text>
+                ))}
+              </View>
+            ));
+          })()}
+        </View>
+      )}
+
+      {/* Accountability matrix */}
+      {p.acc && (
+        <View style={s.section}>
+          <Text style={s.h2}>Accountability: plan vs progress reports</Text>
+          <Text style={[s.body, { fontFamily: "Helvetica-Bold", marginBottom: 2 }]}>{p.acc.question}</Text>
+          {p.acc.baseline.banner && (
+            <View style={[s.callout, { borderColor: C.amberBorder, backgroundColor: C.amberBg, marginBottom: 3 }]}>
+              <Text style={[s.small, { color: "#78350f" }]}>{p.acc.baseline.banner}</Text>
+            </View>
+          )}
+          {(["ulb", "ia", "gp"] as const)
+            .filter((k) => p.acc!.regions.some((r) => r.kind === k))
+            .map((k) => (
+              <View key={k} style={{ marginTop: 5 }}>
+                <Text style={[s.h2, { color: C.text }]}>{ACC_KIND_LABEL[k]}</Text>
+                {p.acc!.regions
+                  .filter((r) => r.kind === k)
+                  .map((r) => (
+                    <AccRegionBlock key={r.key} region={r} acc={p.acc!} />
+                  ))}
+              </View>
+            ))}
+          <Text wrap={false} style={[s.tiny, { marginTop: 3 }]}>
+            Baseline: {p.acc.baseline.primary.label}, {p.acc.baseline.primary.asOf}.{" "}
+            <Link src={p.acc.baseline.actionPlan.url} style={s.link}>{p.acc.baseline.actionPlan.label}</Link>
+            {p.acc.baseline.primary.note ? ` ${p.acc.baseline.primary.note}` : ""}
+          </Text>
+        </View>
+      )}
+
+      {/* Key terms, methodology, sources */}
+      {prs.keyTerms && prs.keyTerms.length > 0 && (
+        <View style={s.section}>
+          <Text style={s.h2}>Key terms used in this report</Text>
+          {prs.keyTerms.map((t) => (
+            <Text key={t.term} style={[s.small, { marginBottom: 1.5 }]} wrap={false}>
+              <Text style={{ fontFamily: "Helvetica-Bold", color: C.text }}>{t.term}</Text> - {t.full}
+              {t.note ? `. ${t.note}` : ""}
+            </Text>
+          ))}
+        </View>
+      )}
+      <View style={s.section}>
+        <Text style={s.h2}>Priority, methodology &amp; data coverage</Text>
+        {[prs.reportingCaveat, prs.growthNote, prs.priorityNote, prs.bodCaveat, prs.mprOverview]
+          .filter((x): x is string => !!x)
+          .map((x, i) => (
+            <Text key={i} style={[s.small, { marginBottom: 2 }]}>
+              {x}
+            </Text>
+          ))}
+        {prs.levelCoverage && (
+          <Text style={[s.small, { marginBottom: 2 }]}>Reporting level: {prs.levelCoverage}</Text>
+        )}
+        {prs.citeSource && (
+          <Text wrap={false} style={s.tiny}>
+            {prs.citeSource.label ?? "Cite this data source"}:{" "}
+            <Link src={prs.citeSource.url} style={s.link}>{prs.citeSource.url}</Link>
+          </Text>
+        )}
+      </View>
+      {prs.sources && prs.sources.length > 0 && (
+        <View style={s.section}>
+          <Text style={s.h2}>Sources</Text>
+          {prs.sources.map((src, i) => (
+            <Text key={i} style={[s.tiny, { marginBottom: 1 }]}>
+              {src}
+            </Text>
+          ))}
+        </View>
+      )}
+      {prs.grievance && (
+        <Text wrap={false} style={[s.small, { marginTop: 6 }]}>
+          {prs.grievance.label}: <Link src={prs.grievance.url} style={s.link}>{prs.grievance.url}</Link>
+          {prs.grievance.urlNote ? ` (${prs.grievance.urlNote})` : ""}
+        </Text>
+      )}
+
+      <Footer shareUrl={p.shareUrl} />
+    </Page>
+  );
+}
+
+// ── Treatment & waste gaps (DEP snapshot v2 / v1 units) ─────────────────────
+
+function DepThemeRows({ themes }: { themes: DepTheme[] }) {
+  return (
+    <View>
+      {themes.map((t, i) => (
+        <View key={i} style={{ marginTop: 3, paddingTop: 2, borderTopWidth: i ? 1 : 0, borderTopColor: "#f1f5f9" }} wrap={false}>
+          <View style={{ flexDirection: "row", alignItems: "center" }}>
+            <Text style={[s.body, { fontFamily: "Helvetica-Bold", flex: 1 }]}>{depThemeTitle(t)}</Text>
+            <Chip
+              label={DEP_STATUS_LABEL[t.status]}
+              fg={DEP_STATUS_COLOR[t.status]?.fg ?? C.muted}
+              bg={DEP_STATUS_COLOR[t.status]?.bg ?? C.slateChipBg}
+            />
+          </View>
+          {t.summary && <Text style={s.small}>{t.summary}</Text>}
+          {t.metrics?.map((m, j) => (
+            <View key={j} style={{ flexDirection: "row", justifyContent: "space-between" }}>
+              <Text style={s.small}>{m.label}</Text>
+              <Text
+                style={[
+                  s.small,
+                  {
+                    textAlign: "right",
+                    color: m.emphasis === "good" ? C.emerald : m.emphasis ? C.rose : C.text,
+                    fontFamily: m.emphasis ? "Helvetica-Bold" : "Helvetica",
+                  },
+                ]}
+              >
+                {m.value}
+              </Text>
+            </View>
+          ))}
+          {t.openActions?.map((a, j) => (
+            <Bullet key={j} color={C.amber}>
+              Action item in the plan: {a}
+            </Bullet>
+          ))}
+          {(t.pages?.length || t.ocrUncertain) && (
+            <Text style={s.tiny}>
+              {t.pages?.length ? `DEP p. ${t.pages.join(", ")}` : ""}
+              {t.ocrUncertain ? `${t.pages?.length ? " - " : ""}read via OCR from a scanned plan; values approximate` : ""}
+            </Text>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function ConflictList({ title, items }: { title: string; items?: string[] }) {
+  if (!items?.length) return null;
+  return (
+    <View style={[s.callout, { borderColor: C.amberBorder, backgroundColor: C.amberBg }]}>
+      <Text style={[s.tiny, { color: C.amber, fontFamily: "Helvetica-Bold", marginBottom: 1 }]}>{title}</Text>
+      {items.map((c, i) => (
+        <Bullet key={i} color={C.amber}>
+          {c}
+        </Bullet>
+      ))}
+    </View>
+  );
+}
+
+function GapsPages(p: BasinReportProps) {
+  const dep = p.dep;
+  return (
+    <Page size="A4" style={s.page}>
+      <Text style={[s.h2, s.h2Rose]}>Treatment &amp; waste gaps</Text>
+      <Text style={s.title}>{dep?.title ?? "District Environment Plan (DEP) 2022 Snapshot"}</Text>
+      {dep?.note && <Text style={[s.small, { marginTop: 2 }]}>{dep.note}</Text>}
+      {p.gapNote && !dep && <Text style={[s.small, { marginTop: 2 }]}>{p.gapNote}</Text>}
+
+      {dep?.districts.map((d) => (
+        <View key={d.key} style={s.section}>
+          <Text style={[s.h3, { fontSize: 12 }]}>{d.name}</Text>
+          <Text wrap={false} style={s.tiny}>
+            {d.dep.label}
+            {d.dep.note ? ` - ${d.dep.note}` : ""} · <Link src={d.dep.url} style={s.link}>source document</Link> · ~
+            {Math.round(d.pctInBasin * 100)}% of the district lies in the basin
+          </Text>
+          {d.counts && <KvRows rows={d.counts} />}
+          {d.countsNote && <Text style={[s.tiny, { marginTop: 1 }]}>{d.countsNote}</Text>}
+          <ConflictList title="Internal contradictions of the plan" items={d.conflicts} />
+          {d.districtThemes.length > 0 && (
+            <View style={{ marginTop: 3 }}>
+              <Text style={s.h2}>Reported district-wide</Text>
+              <DepThemeRows themes={d.districtThemes} />
+            </View>
+          )}
+          {d.ulbs.map((u) => (
+            <View key={u.key} style={[s.callout, { borderColor: C.border }]}>
+              <Text style={[s.h3, { fontSize: 10 }]}>
+                {u.name} ({u.type})
+              </Text>
+              {u.note && <Text style={s.tiny}>{u.note}</Text>}
+              {u.gazette && (
+                <Text wrap={false} style={s.tiny}>
+                  Gazette: <Link src={u.gazette.url} style={s.link}>{u.gazette.label}</Link>
+                </Text>
+              )}
+              <ConflictList title="Internal contradictions of the plan" items={u.conflicts} />
+              <DepThemeRows themes={u.themes} />
+            </View>
+          ))}
+          {d.taluks.map((t) => (
+            <View key={t.key} style={[s.callout, { borderColor: C.border }]}>
+              <Text style={[s.h3, { fontSize: 10 }]}>{t.label}</Text>
+              {t.note && <Text style={s.tiny}>{t.note}</Text>}
+              <DepThemeRows themes={t.themes} />
+            </View>
+          ))}
+          {d.industrialAreas && d.industrialAreas.length > 0 && (
+            <View style={{ marginTop: 3 }}>
+              <Text style={s.h2}>Industrial areas named in the plan</Text>
+              <Text style={s.small}>{d.industrialAreas.map((a) => a.name).join(" · ")}</Text>
+              {d.industrialAreasNote && <Text style={s.tiny}>{d.industrialAreasNote}</Text>}
+              <ConflictList title="Cross-source contradictions" items={d.industrialAreasConflicts} />
+            </View>
+          )}
+        </View>
+      ))}
+
+      {dep?.governance && (
+        <View style={s.section}>
+          <Text style={s.h2}>Governance</Text>
+          {dep.governance.items.map((it, i) => (
+            <View key={i} style={{ marginBottom: 3 }} wrap={false}>
+              <Text style={[s.body, { fontFamily: "Helvetica-Bold" }]}>{it.heading}</Text>
+              <Text style={s.small}>{it.body}</Text>
+              {it.source && (
+                <Text wrap={false} style={s.tiny}>
+                  {it.source.source}: {it.source.citation}
+                  {it.source.url ? " - " : ""}
+                  {it.source.url && <Link src={it.source.url} style={s.link}>{it.source.url}</Link>}
+                </Text>
+              )}
+            </View>
+          ))}
+          {dep.governance.gaps.map((g, i) => (
+            <Bullet key={i} color={C.rose}>
+              {g}
+            </Bullet>
+          ))}
+        </View>
+      )}
+
+      {/* v1 basins: flat cross-source gap units */}
+      {!dep &&
+        p.gapUnits.map((u) => (
+          <View key={u.name} style={s.section}>
+            <Text style={[s.h3, { fontSize: 12 }]}>{u.name}</Text>
+            {u.headline && (
+              <View style={[s.callout, { borderColor: C.roseBorder, backgroundColor: C.roseBg }]}>
+                <Text style={[s.body, { fontFamily: "Helvetica-Bold", color: "#881337" }]}>{u.headline}</Text>
+              </View>
+            )}
+            {u.coverage && <Text style={s.tiny}>Data coverage: {u.coverage}</Text>}
+            <ConflictList title="Points to reconcile across sources" items={u.conflicts} />
+            <ConflictList title="Notes & caveats" items={u.caveats} />
+            {u.streams.map((st, i) => (
+              <View key={i} style={[s.callout, { borderColor: C.border }]} wrap={false}>
+                <Text style={[s.body, { fontFamily: "Helvetica-Bold" }]}>{st.stream}</Text>
+                <Text style={s.small}>{st.summary}</Text>
+                {st.metrics.map((m, j) => (
+                  <View key={j} style={{ flexDirection: "row", justifyContent: "space-between" }}>
+                    <Text style={s.small}>{m.label}</Text>
+                    <Text
+                      style={[
+                        s.small,
+                        {
+                          color: m.emphasis === "good" ? C.emerald : m.emphasis ? C.rose : C.text,
+                          fontFamily: m.emphasis ? "Helvetica-Bold" : "Helvetica",
+                        },
+                      ]}
+                    >
+                      {m.value}
+                    </Text>
+                  </View>
+                ))}
+                {st.sources.map((src, j) => (
+                  <Text wrap={false} key={j} style={s.tiny}>
+                    {src.source}: {src.says} ({src.citation}){src.url ? " - " : ""}
+                    {src.url && <Link src={src.url} style={s.link}>{src.url}</Link>}
+                  </Text>
+                ))}
+              </View>
+            ))}
+          </View>
+        ))}
+
+      <Footer shareUrl={p.shareUrl} />
+    </Page>
+  );
+}
+
+// ── Final page: data & attribution ───────────────────────────────────────────
+
+function CreditsPage(p: BasinReportProps) {
+  return (
+    <Page size="A4" style={s.page}>
+      <Text style={s.h2}>Data on this map</Text>
+      {p.manifest.collaboration && (
+        <Text style={[s.small, { marginBottom: 4 }]}>
+          {p.manifest.collaboration.label} {p.manifest.collaboration.name}
+          {p.manifest.collaboration.url ? ` (${p.manifest.collaboration.url})` : ""}.
+        </Text>
+      )}
+      {p.inventory && (
+        <View style={s.kvBox}>
+          {p.manifest.layers
+            .filter((l) => !l.kindFilter)
+            .map((l, i) => {
+              const fam = p.inventory!.families[l.family];
+              if (!fam) return null;
+              return (
+                <View key={l.family} style={[s.kvRow, ...(i === 0 ? [s.kvRowFirst] : [])]} wrap={false}>
+                  <Text style={[s.kvLabel, { width: 220 }]}>{l.label}</Text>
+                  <Text style={s.kvValue}>{fam.featureCount.toLocaleString("en-IN")} features</Text>
+                </View>
+              );
+            })}
+        </View>
+      )}
+      <View style={s.section}>
+        <Text style={s.h2}>Attribution</Text>
+        {p.manifest.credits.map((c, i) => (
+          <Bullet key={i}>{c}</Bullet>
+        ))}
+        <Bullet>Basemap: (c) OpenStreetMap contributors (openstreetmap.org/copyright).</Bullet>
+      </View>
+      <View style={s.section}>
+        <Text style={s.h2}>About this document</Text>
+        <Text style={s.small}>
+          Generated {p.generatedAt} from the live Neer Vazhvu Basin Atlas. The map image reflects the exact layer
+          selection and viewport at export; every figure in the text pages carries its source. The live, interactive
+          version of this exact view: {p.shareUrl}
+        </Text>
+      </View>
+      <Footer shareUrl={p.shareUrl} />
+    </Page>
+  );
+}
+
+export function BasinReportDocument(p: BasinReportProps) {
+  return (
+    <Document
+      title={`${p.manifest.displayName} Atlas - Neer Vazhvu`}
+      author="Neer Vazhvu"
+      subject={`${p.manifest.displayName} - map state, polluted river stretch and treatment-gap report`}
+      creator="Neer Vazhvu Basin Atlas"
+    >
+      <MapPage {...p} />
+      {p.prs && <PrsPages {...p} />}
+      {p.includeGaps && (p.dep || p.gapUnits.length > 0) && <GapsPages {...p} />}
+      <CreditsPage {...p} />
+    </Document>
+  );
+}

--- a/src/components/basin/basin-pdf-report.tsx
+++ b/src/components/basin/basin-pdf-report.tsx
@@ -26,7 +26,7 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import type { BasinInventory, BasinManifest, BasinRiver } from "@/lib/basins";
+import type { BasinManifest, BasinRiver } from "@/lib/basins";
 import {
   reviewedMprConceptLabel,
   reviewedMprValueLabel,
@@ -54,7 +54,9 @@ import type {
 
 export interface BasinReportProps {
   manifest: BasinManifest;
-  inventory: BasinInventory | null;
+  /** One row per layer VISIBLE at export (label + feature count) - the PDF is
+   *  state-faithful, so the data table never lists layers that aren't shown. */
+  inventoryRows: { label: string; count: number }[];
   generatedAt: string;
   scopeLabel: string;
   mapPng: string;
@@ -959,27 +961,21 @@ function GapsPages(p: BasinReportProps) {
 function CreditsPage(p: BasinReportProps) {
   return (
     <Page size="A4" style={s.page}>
-      <Text style={s.h2}>Data on this map</Text>
+      <Text style={s.h2}>Data on this map - layers in this export</Text>
       {p.manifest.collaboration && (
         <Text style={[s.small, { marginBottom: 4 }]}>
           {p.manifest.collaboration.label} {p.manifest.collaboration.name}
           {p.manifest.collaboration.url ? ` (${p.manifest.collaboration.url})` : ""}.
         </Text>
       )}
-      {p.inventory && (
+      {p.inventoryRows.length > 0 && (
         <View style={s.kvBox}>
-          {p.manifest.layers
-            .filter((l) => !l.kindFilter)
-            .map((l, i) => {
-              const fam = p.inventory!.families[l.family];
-              if (!fam) return null;
-              return (
-                <View key={l.family} style={[s.kvRow, ...(i === 0 ? [s.kvRowFirst] : [])]} wrap={false}>
-                  <Text style={[s.kvLabel, { width: 220 }]}>{l.label}</Text>
-                  <Text style={s.kvValue}>{fam.featureCount.toLocaleString("en-IN")} features</Text>
-                </View>
-              );
-            })}
+          {p.inventoryRows.map((r, i) => (
+            <View key={r.label} style={[s.kvRow, ...(i === 0 ? [s.kvRowFirst] : [])]} wrap={false}>
+              <Text style={[s.kvLabel, { width: 220 }]}>{r.label}</Text>
+              <Text style={s.kvValue}>{r.count.toLocaleString("en-IN")} features</Text>
+            </View>
+          ))}
         </View>
       )}
       <View style={s.section}>

--- a/src/lib/basins/atlas-url-state.test.ts
+++ b/src/lib/basins/atlas-url-state.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BasinLayer } from "./types";
+import {
+  buildAtlasShareUrl,
+  encodeLayersParam,
+  layerKey,
+  parseLayersParam,
+} from "./atlas-url-state";
+
+const layers: BasinLayer[] = [
+  { family: "boundary", label: "Basin boundary", floor: "hydrology", geom: "fill", color: "#000", defaultOn: true },
+  { family: "prs", label: "Polluted stretch", floor: "hydrology", geom: "line", color: "#000", defaultOn: false, prs: true },
+  { family: "pressures-industrial", label: "17-category", floor: "pressures", geom: "point", color: "#000", defaultOn: true, kindFilter: "major-industry" },
+  { family: "pressures-industrial", label: "Areas", floor: "pressures", geom: "fill", color: "#000", defaultOn: true, kindFilter: "industrial-area" },
+];
+
+test("layerKey splits kind-filtered entries sharing a family", () => {
+  assert.equal(layerKey(layers[0]), "boundary");
+  assert.equal(layerKey(layers[2]), "pressures-industrial:major-industry");
+  assert.equal(layerKey(layers[3]), "pressures-industrial:industrial-area");
+});
+
+test("encodeLayersParam omits the param while state matches defaults", () => {
+  const defaults = { boundary: true, prs: false };
+  assert.equal(encodeLayersParam({ boundary: true, prs: false }, defaults), null);
+  // Same ON set spelled differently (missing key vs explicit false) still matches.
+  assert.equal(encodeLayersParam({ boundary: true }, defaults), null);
+});
+
+test("encodeLayersParam lists the ON set exhaustively once customised", () => {
+  const defaults = { boundary: true, prs: false };
+  assert.equal(encodeLayersParam({ boundary: true, prs: true }, defaults), "boundary,prs");
+  assert.equal(encodeLayersParam({ boundary: false, prs: false }, defaults), "");
+});
+
+test("parseLayersParam turns the ON list into a full toggle map", () => {
+  const state = parseLayersParam("prs,pressures-industrial:major-industry", layers);
+  assert.deepEqual(state, {
+    boundary: false,
+    prs: true,
+    "pressures-industrial:major-industry": true,
+    "pressures-industrial:industrial-area": false,
+  });
+});
+
+test("parseLayersParam ignores unknown keys and passes through empty as null", () => {
+  const state = parseLayersParam("prs,got-removed", layers);
+  assert.ok(state);
+  assert.equal(state!["prs"], true);
+  assert.ok(!("got-removed" in state!));
+  assert.equal(parseLayersParam(null, layers), null);
+  assert.equal(parseLayersParam("", layers), null);
+});
+
+test("round-trip: encode -> parse restores the same ON set", () => {
+  const defaults = Object.fromEntries(layers.map((l) => [layerKey(l), l.defaultOn]));
+  const custom: Record<string, boolean> = { ...defaults, prs: true, "pressures-industrial:industrial-area": false };
+  const param = encodeLayersParam(custom, defaults);
+  assert.ok(param);
+  const restored = parseLayersParam(param, layers)!;
+  for (const l of layers) {
+    assert.equal(restored[layerKey(l)], !!custom[layerKey(l)], layerKey(l));
+  }
+});
+
+test("buildAtlasShareUrl targets the embed page with only the set params", () => {
+  assert.equal(
+    buildAtlasShareUrl({ origin: "https://neervazhvu.org", basinId: "arkavathi" }),
+    "https://neervazhvu.org/embed/basins/arkavathi",
+  );
+  const url = buildAtlasShareUrl({
+    origin: "https://neervazhvu.org",
+    basinId: "arkavathi",
+    riverId: "vrishabhavathi",
+    floor: "governance",
+    layersParam: "boundary,prs",
+    growth: true,
+  });
+  assert.equal(
+    url,
+    "https://neervazhvu.org/embed/basins/arkavathi?river=vrishabhavathi&floor=governance&layers=boundary%2Cprs&growth=1",
+  );
+});

--- a/src/lib/basins/atlas-url-state.ts
+++ b/src/lib/basins/atlas-url-state.ts
@@ -1,0 +1,68 @@
+// Layer-toggle state <-> URL for the Basin Atlas.
+//
+// The atlas historically synced only ?river= and ?level=; layer checkboxes
+// lived in ephemeral React state, so a configured map could not be shared or
+// linked back to from an exported PDF. These helpers give the toggle set a
+// canonical, order-independent URL form:
+//
+//   ?layers=<comma-joined layer keys that are ON>   (absent = manifest defaults)
+//   &growth=1                                       (PRS 2020-vs-2025 overlay)
+//
+// The layers param lists the ON set exhaustively - every manifest layer not
+// named is off - so a link renders the same map regardless of which defaults
+// ship later. When the current set equals the passed defaults the param is
+// omitted, keeping untouched URLs clean.
+
+import type { BasinLayer } from "./types";
+
+/** Toggle/state key for a layer: kind-filtered entries get their own key so
+ *  two entries sharing a data family toggle independently. */
+export function layerKey(l: BasinLayer): string {
+  return l.kindFilter ? `${l.family}:${l.kindFilter}` : l.family;
+}
+
+/** The ?layers= value for a toggle state, or null when it matches the given
+ *  defaults (param omitted - the URL stays clean until the user customises). */
+export function encodeLayersParam(
+  enabled: Record<string, boolean>,
+  defaults: Record<string, boolean>,
+): string | null {
+  const on = Object.keys(enabled).filter((k) => enabled[k]).sort();
+  const defOn = Object.keys(defaults).filter((k) => defaults[k]).sort();
+  if (on.length === defOn.length && on.every((k, i) => k === defOn[i])) return null;
+  return on.join(",");
+}
+
+/** Toggle state from a ?layers= value: named keys on, every other manifest
+ *  layer off. Unknown keys are ignored (stale links survive manifest edits).
+ *  null/empty param -> null (caller keeps its defaults). */
+export function parseLayersParam(
+  param: string | null,
+  layers: BasinLayer[],
+): Record<string, boolean> | null {
+  if (!param) return null;
+  const valid = new Set(layers.map(layerKey));
+  const on = new Set(param.split(",").filter((k) => valid.has(k)));
+  return Object.fromEntries([...valid].map((k) => [k, on.has(k)]));
+}
+
+/** Canonical live-map URL for a configured atlas view - the chrome-less embed
+ *  page, which restores river, floor, layer set and the growth overlay in
+ *  every context (the city-page overlay can't carry layer state in its own
+ *  URL). Used as the "view this map live" link in the exported PDF. */
+export function buildAtlasShareUrl(args: {
+  origin: string;
+  basinId: string;
+  riverId?: string | null;
+  floor?: string | null;
+  layersParam?: string | null;
+  growth?: boolean;
+}): string {
+  const p = new URLSearchParams();
+  if (args.riverId) p.set("river", args.riverId);
+  if (args.floor) p.set("floor", args.floor);
+  if (args.layersParam) p.set("layers", args.layersParam);
+  if (args.growth) p.set("growth", "1");
+  const qs = p.toString();
+  return `${args.origin}/embed/basins/${args.basinId}${qs ? `?${qs}` : ""}`;
+}

--- a/src/lib/basins/export-pdf.tsx
+++ b/src/lib/basins/export-pdf.tsx
@@ -14,7 +14,7 @@
 // crashing the render. The basin JSON is ASCII + curly quotes today; this is
 // the guard for tomorrow's data edits.
 
-import type { BasinInventory, BasinManifest, BasinRiver } from "@/lib/basins";
+import type { BasinManifest, BasinRiver } from "@/lib/basins";
 import type { ReviewedMprSeries } from "@/lib/basins/reviewed-mpr";
 import type {
   AccountabilityData,
@@ -108,7 +108,8 @@ export interface ExportBasinPdfArgs {
   /** The .leaflet-container element to capture. */
   mapEl: HTMLElement;
   manifest: BasinManifest;
-  inventory: BasinInventory | null;
+  /** Label + feature count for each layer visible at export. */
+  inventoryRows: { label: string; count: number }[];
   scopeLabel: string;
   legendItems: LegendItem[];
   legendNotes: string[];
@@ -143,7 +144,7 @@ export async function exportBasinAtlasPdf(args: ExportBasinPdfArgs): Promise<voi
   // URL-encoded share link are ASCII already and skip the (expensive) walk.
   const data = sanitizeForPdf({
     manifest: args.manifest,
-    inventory: args.inventory,
+    inventoryRows: args.inventoryRows,
     scopeLabel: args.scopeLabel,
     legendItems: args.legendItems,
     legendNotes: args.legendNotes,

--- a/src/lib/basins/export-pdf.tsx
+++ b/src/lib/basins/export-pdf.tsx
@@ -1,0 +1,173 @@
+// One-click "Download as PDF" for the Basin Atlas.
+//
+// Pipeline: capture the live Leaflet map container to a PNG (html-to-image -
+// the OSM tile server sends Access-Control-Allow-Origin:*, and the atlas tile
+// layer loads with crossOrigin so the capture fetch hits a CORS-clean cache),
+// then compose a text-native PDF with @react-pdf/renderer from the same data
+// objects the on-screen panels render. Both libraries are heavy and load only
+// here, behind dynamic import, when the button is actually clicked.
+//
+// Fonts: the PDF uses the built-in Helvetica family (no font files shipped).
+// Helvetica is WinAnsi-encoded, so every data string is passed through
+// toWinAnsi() first: known typographic characters are mapped to close ASCII
+// equivalents and anything else outside the encoding is dropped rather than
+// crashing the render. The basin JSON is ASCII + curly quotes today; this is
+// the guard for tomorrow's data edits.
+
+import type { BasinInventory, BasinManifest, BasinRiver } from "@/lib/basins";
+import type { ReviewedMprSeries } from "@/lib/basins/reviewed-mpr";
+import type {
+  AccountabilityData,
+  DepData,
+  GapUnit,
+  LegendItem,
+  PrsData,
+} from "@/components/basin/basin-atlas";
+
+// Characters WinAnsi (CP1252) can encode: ASCII + Latin-1 + the 0x80-0x9F
+// typographic extras (curly quotes, dashes, ellipsis, bullet, euro...).
+const NOT_WIN_ANSI =
+  /[^\t\n\r\x20-\x7e\u00a0-\u00ff\u20ac\u201a\u0192\u201e\u2026\u2020\u2021\u02c6\u2030\u0160\u2039\u0152\u017d\u2018\u2019\u201c\u201d\u2022\u2013\u2014\u02dc\u2122\u0161\u203a\u0153\u017e\u0178]/g;
+
+const REPLACEMENTS: [RegExp, string][] = [
+  [/≈/g, "~"], // almost-equal (the CETP legend note)
+  [/[→⇒➜]/g, "->"],
+  [/←/g, "<-"],
+  [/[↑↗▸▶▾▼⌘●○⬆]/g, ""], // decorative arrows/glyphs
+  [/₹/g, "Rs "],
+  [/[✕✖❌]/g, "x"],
+  [/[′‵]/g, "'"],
+  [/″/g, '"'],
+  [/[\u200b\u200c\u200d\ufeff]/g, ""], // zero-width characters
+  [/⚠️?/g, "(!)"], // warning sign used by data caveats
+];
+
+export function toWinAnsi(input: string): string {
+  let out = input;
+  for (const [re, sub] of REPLACEMENTS) out = out.replace(re, sub);
+  return out.replace(NOT_WIN_ANSI, "");
+}
+
+/** Recursively map every string in a plain-data value through toWinAnsi. */
+export function sanitizeForPdf<T>(value: T): T {
+  if (typeof value === "string") return toWinAnsi(value) as T;
+  if (Array.isArray(value)) return value.map(sanitizeForPdf) as T;
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, sanitizeForPdf(v)]),
+    ) as T;
+  }
+  return value;
+}
+
+/** Leaflet chrome that must not appear in the exported image. The overlay
+ *  buttons/legend live OUTSIDE the .leaflet-container, so they are already
+ *  excluded by capturing the container itself; the attribution control stays
+ *  in deliberately (OSM licence). */
+function captureFilter(node: Node): boolean {
+  if (!(node instanceof Element)) return true;
+  const cls = node.classList;
+  return !(
+    cls.contains("leaflet-control-zoom") ||
+    cls.contains("leaflet-tooltip") ||
+    cls.contains("leaflet-popup") ||
+    cls.contains("leaflet-tooltip-pane") ||
+    cls.contains("leaflet-popup-pane")
+  );
+}
+
+async function captureMapPng(mapEl: HTMLElement): Promise<string> {
+  const { toPng } = await import("html-to-image");
+  const opts = {
+    pixelRatio: 2,
+    backgroundColor: "#ffffff",
+    filter: captureFilter,
+  };
+  // Safari sometimes returns a blank/partial image on the first render of a
+  // cloned SVG tree (html-to-image #361); a warm-up pass fixes it.
+  const isSafari = typeof navigator !== "undefined" && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  if (isSafari) {
+    await toPng(mapEl, opts);
+    await toPng(mapEl, opts);
+  }
+  return toPng(mapEl, opts);
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 30_000);
+}
+
+export interface ExportBasinPdfArgs {
+  /** The .leaflet-container element to capture. */
+  mapEl: HTMLElement;
+  manifest: BasinManifest;
+  inventory: BasinInventory | null;
+  scopeLabel: string;
+  legendItems: LegendItem[];
+  legendNotes: string[];
+  selectedRiver: BasinRiver | null;
+  prs: PrsData | null;
+  acc: AccountabilityData | null;
+  reviewedMpr: ReviewedMprSeries | null;
+  dep: DepData | null;
+  gapUnits: GapUnit[];
+  gapNote: string | null;
+  includeGaps: boolean;
+  shareUrl: string;
+}
+
+export async function exportBasinAtlasPdf(args: ExportBasinPdfArgs): Promise<void> {
+  const mapAspect = args.mapEl.clientWidth > 0 ? args.mapEl.clientHeight / args.mapEl.clientWidth : 0.7;
+  const mapPng = await captureMapPng(args.mapEl);
+
+  const [{ pdf }, { BasinReportDocument }] = await Promise.all([
+    import("@react-pdf/renderer"),
+    import("@/components/basin/basin-pdf-report"),
+  ]);
+
+  const generatedAt = new Intl.DateTimeFormat("en-IN", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(new Date());
+
+  // Sanitize the data payload once, at this single choke point, so the PDF
+  // components never have to think about encodings. The captured PNG and the
+  // URL-encoded share link are ASCII already and skip the (expensive) walk.
+  const data = sanitizeForPdf({
+    manifest: args.manifest,
+    inventory: args.inventory,
+    scopeLabel: args.scopeLabel,
+    legendItems: args.legendItems,
+    legendNotes: args.legendNotes,
+    selectedRiver: args.selectedRiver,
+    prs: args.prs,
+    acc: args.acc,
+    reviewedMpr: args.reviewedMpr,
+    dep: args.dep,
+    gapUnits: args.gapUnits,
+    gapNote: args.gapNote,
+    generatedAt,
+  });
+
+  const blob = await pdf(
+    <BasinReportDocument
+      {...data}
+      includeGaps={args.includeGaps}
+      mapPng={mapPng}
+      mapAspect={mapAspect}
+      shareUrl={args.shareUrl}
+      origin={window.location.origin}
+    />,
+  ).toBlob();
+
+  const day = new Date().toISOString().slice(0, 10);
+  downloadBlob(blob, `neer-vazhvu-${args.manifest.basinId}-atlas-${day}.pdf`);
+}

--- a/src/lib/basins/panel-labels.ts
+++ b/src/lib/basins/panel-labels.ts
@@ -1,0 +1,55 @@
+// Shared plain-language labels for the Basin Atlas panels AND the PDF export.
+//
+// The atlas component (basin-atlas.tsx) pairs these with its Tailwind chip
+// classes; the PDF report (basin-pdf-report.tsx) pairs them with its own print
+// colors. Keeping the words here - and only the words - means the two surfaces
+// can never drift apart, and the PDF module never has to import the Leaflet
+// component tree at runtime.
+
+/** Accountability-matrix verdict labels: the value of the matrix is making
+ *  "exists in MPR vs doesn't" explicit per region x category, so absence
+ *  reads as a finding, not a blank. */
+export const ACC_VERDICT_LABEL: Record<"tracked" | "in-plan-not-reported" | "reported-not-in-plan" | "silent", string> = {
+  tracked: "In plan + MPR",
+  "in-plan-not-reported": "In plan, not in MPR",
+  "reported-not-in-plan": "In MPR, not in plan",
+  silent: "Not in plan or MPR",
+};
+
+export const ACC_KIND_LABEL: Record<"ulb" | "ia" | "gp", string> = {
+  ulb: "ULBs",
+  ia: "Industrial Areas",
+  gp: "Gram Panchayats",
+};
+
+/** DEP thematic-area coverage labels (covered / district-level / not-covered). */
+export const DEP_STATUS_LABEL: Record<"covered" | "district-level" | "not-covered", string> = {
+  covered: "In the plan",
+  "district-level": "District-level only",
+  "not-covered": "Not covered",
+};
+
+// Display order and labels of the 7 NGT thematic areas (OA 360/2018).
+export const DEP_THEME_LABEL: Record<string, string> = {
+  "waste-management": "Waste Management",
+  "water-quality": "Water Quality",
+  "domestic-sewage": "Domestic Sewage",
+  "industrial-wastewater": "Industrial Wastewater",
+  "air-quality": "Air Quality",
+  mining: "Mining Activity",
+  noise: "Noise Pollution",
+};
+export const DEP_THEME_ORDER = Object.keys(DEP_THEME_LABEL);
+export const DEP_SUBTHEME_LABEL: Record<string, string> = {
+  "solid-waste": "Solid Waste",
+  "plastic-waste": "Plastic Waste",
+  "cd-waste": "C&D Waste",
+  "biomedical-waste": "Biomedical Waste",
+  "hazardous-waste": "Hazardous Waste",
+  "e-waste": "E-Waste",
+};
+
+export function depThemeTitle(t: { theme: string; subtheme?: string }): string {
+  const base = DEP_THEME_LABEL[t.theme] ?? t.theme;
+  return t.subtheme ? `${base}: ${DEP_SUBTHEME_LABEL[t.subtheme] ?? t.subtheme}` : base;
+}


### PR DESCRIPTION
## What

A **Download as PDF** button in the Basin Atlas rail. It captures the map exactly as configured - layer toggles, viewport, growth overlay, river scope - and composes a text-native A4 report client-side, downloaded in one click. Nothing loads until the button is pressed: html-to-image (capture) and @react-pdf/renderer (compose) are dynamic imports.

**Report structure** (state-faithful):
- **Page 1** - the captured map, the same legend the on-screen MapLegend derives (shared `buildLegendItems`), the live CETP note, selected-river card, OSM attribution, and the share URL of the exact view.
- **PRS pages** - the polluted-stretch story as searchable text: 2020-vs-2025 status bars, structured facts, governance & compliance, stretch-level obligations with per-town generated-vs-treated bars, evidence, the full accountability matrix (plan-vs-MPR verdicts per region), key terms, methodology, sources.
- **Gap pages** (when the DEP layer is on) - the District Environment Plan snapshot: per-district themes, ULB/taluk cards, conflicts, governance items.
- **Last page** - layer inventory feature counts + every credit line, so the PDF carries its own provenance.

All text pages render from the same prs.json / accountability.json / gaps.json the panels read - the PDF cannot say something the atlas doesn't. Fonts are built-in Helvetica behind a WinAnsi sanitizer (no font files shipped; the basin JSON is ASCII + curly quotes today).

## Supporting changes

- **Shareable layer state**: `?layers=` and `?growth=` now round-trip through the URL (new `lib/basins/atlas-url-state`, unit-tested). The embed page restores them, so the PDF's footer link reopens the exact view. The address bar stays clean until the layer set is customised.
- **Panel labels to lib** (`panel-labels.ts`): verdict/DEP-status/NGT-theme wording shared by the atlas chips and the PDF so they can't drift - and the PDF module never imports the Leaflet tree at runtime.
- **CSP**: `connect-src data:` + `worker-src 'self' blob:` - react-pdf fetches its wasm layout engine as a data: URL and renders in a blob worker. Both are self-contained and script-src already concedes unsafe-eval; without them the export dies at click time (caught by the E2E run below).
- **Tiles load with `crossOrigin`** so the capture reads them without tainting (OSM sends ACAO:*).
- **react-pdf traps documented in code**: a page-level lineHeight compounds exponentially on fixed per-page elements until pdfkit throws; an inline Link split across a page break crashes the renderer. Line heights live on text styles; link-bearing Texts are atomic.
- **`scripts/check-basin-pdf-render.tsx`**: smoke-renders the full document from the real basin JSON (`npx tsx scripts/check-basin-pdf-render.tsx [basinId]`) so a data edit that breaks the export fails loudly before it ships. Basin-generic, like the report itself - Kabini gets this for free.

## Verified

- lint 0 errors, tsc clean, all 83 tests pass (7 new), production build passes.
- Node smoke-render of the full 46-page all-layers document from real Arkavathi data.
- **End-to-end in headless Chrome** against the production build: opened `/embed/basins/arkavathi`, toggled PRS + terrain on, clicked the button, got a 5.8 MB 14-page PDF whose page 1 shows the real captured tiles + elevation bands + red stretch with the matching legend. Page count tracks the state (gap layer off -> no DEP pages).
- API untouched (byte-identical to main); its CI job runs unchanged.

## Known limits (deliberate for v1)

- Kannada names are omitted from the PDF (Helvetica is Latin-only; vendoring Noto Sans Kannada is a follow-up if wanted).
- With every layer + panel on, the report runs ~46 pages - faithful to the panels by design; a digest mode (summaries only) is a small follow-up knob if it feels heavy.
- Safari gets a warm-up double-capture (documented html-to-image quirk); verified in Chrome, worth one manual click in Safari after deploy.