### PR TITLE
Hyderabad goes live as the sixth city

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,8 @@ const CITY_HOOKS: Record<string, string> = {
     "Seven BMC lakes, the Mithi river, and the parallel water systems behind the city's taps.",
   delhi:
     "The Yamuna, 237 groundwater wells, 250 MCD wards, and the five-state paper trail behind the city's taps.",
+  hyderabad:
+    "The Musi and its tank cascade, a 2,978-lake gazetted register, the utility's own tanker ledger, and a daily statement that publishes the draw as well as the storage.",
   kolkata:
     "The Hooghly, groundwater arsenic, and a delta city's drainage and flooding.",
 };

--- a/src/lib/cities/hyderabad.ts
+++ b/src/lib/cities/hyderabad.ts
@@ -1,9 +1,10 @@
 import type { CityConfig } from './types';
 
-// Hyderabad is registered DISABLED through the onboarding window. It flips to
-// enabled: true on the cutover commit once data + UI land; the Supabase
-// `cities` table must agree. Until then /hyderabad is reachable only via
-// NEXT_PUBLIC_PREVIEW_CITIES=hyderabad.
+// Hyderabad went LIVE on 2026-08-14 as the sixth city. This flag is the only
+// functional switch: the route guard in [cityId]/layout.tsx reads it, and the
+// `enabled` column in the Supabase `cities` table is read by no code at all
+// (039_hyderabad_enable.sql keeps that row honest for a fresh rebuild, but it
+// is consistency, not a gate).
 //
 // Research backing every claim below: docs/research/
 // hyderabad-kolkata-onboarding-research-2026-07.md (2026-07-26), with raw
@@ -383,5 +384,5 @@ export const HYDERABAD: CityConfig = {
     NagarjunSagar: 'nagarjuna_sagar',
     Srisailam: 'srisailam',
   },
-  enabled: false,
+  enabled: true,
 };

--- a/supabase/migrations/039_hyderabad_enable.sql
+++ b/supabase/migrations/039_hyderabad_enable.sql
@@ -1,0 +1,52 @@
+-- =============================================================
+-- 039_hyderabad_enable.sql
+-- Launch cutover: flip Hyderabad from registered-but-disabled to live.
+--
+-- 037_hyderabad_seed_disabled.sql seeded the city with enabled=FALSE so the
+-- CityConfig, water_sources and the 12.5-year ingest could be built against
+-- city_id='hyderabad' without exposing it. This is the promised follow-up.
+--
+-- WHAT ACTUALLY GATES THE SITE - unchanged from 033_delhi_enable.sql, and
+-- restated because the older comments in this repo get it wrong:
+--   The ONLY functional switch is `enabled: true` on the CityConfig in
+--   src/lib/cities/hyderabad.ts, read by the frontend route guard in
+--   [cityId]/layout.tsx. Without it /hyderabad 404s outside
+--   NEXT_PUBLIC_PREVIEW_CITIES and the landing board shows Hyderabad as
+--   "onboarding".
+--
+--   This `enabled` COLUMN is read by no code at all - neither the Next.js
+--   app nor the Python API queries it.
+--
+-- So this migration is for CONSISTENCY, not for gating: it keeps the seeded
+-- row honest about a city that is live, and keeps the state reproducible on
+-- a fresh database. Bengaluru shipped in June 2026 and sat at enabled=FALSE
+-- here for weeks with nothing breaking (see 034_bangalore_enable_fix.sql),
+-- which is the evidence for that claim rather than an assumption.
+--
+-- STATE AT CUTOVER (2026-08-14), so a fresh rebuild can be checked against it:
+--   cities                    1 row,  enabled flips FALSE -> TRUE here
+--   water_sources             8 rows, 6 city sources + 2 context-only
+--   water_source_name_aliases 23 rows
+--   reservoir_daily_v2        27,019 rows, 2014-01-01 .. 2026-08-14,
+--                             6 city sources (the 2 parent Krishna storages
+--                             are excluded by the scraper's is_city_source
+--                             filter - at 312,045 and 215,807 mcft they are
+--                             ~5x the city's whole impounded volume and would
+--                             swamp every total they entered)
+--
+-- PREREQUISITE: 037 and 038 must already be applied. This migration raises
+-- rather than silently updating nothing if the row is absent.
+-- =============================================================
+
+DO $$
+DECLARE
+  updated INT;
+BEGIN
+  UPDATE cities SET enabled = TRUE WHERE city_id = 'hyderabad';
+  GET DIAGNOSTICS updated = ROW_COUNT;
+
+  IF updated = 0 THEN
+    RAISE EXCEPTION
+      'No cities row for city_id=hyderabad. Apply 037_hyderabad_seed_disabled.sql (and 038_hyderabad_water_sources.sql) before this migration.';
+  END IF;
+END $$;


### PR DESCRIPTION
The cutover. Follows [#258](https://github.com/SundareshPrasanna/neer-vazhvu/pull/258), which landed Hyderabad preview-gated, and the corpus release [neer-vazhvu-data#6](https://github.com/SundareshPrasanna/neer-vazhvu-data/pull/6) (`corpus-2026-08-14-hyderabad`).

## The switch

`enabled: true` on the CityConfig is the only functional switch. The route guard in `[cityId]/layout.tsx` reads it; the `enabled` column in the `cities` table is read by no code at all. That is not an assumption: 033's comment established it when Delhi shipped, and Bengaluru sat at `FALSE` in that column for weeks after going live with nothing breaking.

Verified by running the dev server with **no preview flag at all**: 13 of 13 nav routes return 200, `cascades` redirects to the catchments view as designed, `my-ward` and `shoreline` still 404 as intended, and 12 Hyderabad URLs enter the sitemap.

`039_hyderabad_enable.sql` flips the same flag in the database for consistency and reproducibility on a fresh build. **Already applied.** It raises rather than silently no-opping if the row is absent, and its header records the state at cutover so a rebuild has something to check itself against.

## The landing board bug

Hyderabad rendered in the Live section with a Live badge and a working link, and **no description whatsoever** — the only card on the board with nothing to say for itself, because `CITY_HOOKS` had no entry for it.

This is the same failure Mumbai's card had, and the comment two lines above `CITY_HOOKS` already warns about it: status belongs to the badge, not the tagline. Mumbai's hook still read "Onboarding." after it went live, so its card carried a green Live badge and the word Onboarding simultaneously. Hyderabad's now leads on what actually distinguishes the city — HMWSSB publishes the draw alongside the storage, which is precisely what lets this be the one days-left hero on a measured divisor rather than an assumed one.

## Live state

| | |
|---|---|
| reservoir_daily_v2 | 27,019 rows, 2014-01-01 to 2026-08-14 |
| city sources reporting today | 6 of 6 |
| days-left hero | 276 days, on a measured 2,628 MLD divisor |
| false statements on the dashboard | 0 |
| freshness | every Hyderabad feed 0 days old |

## Known and deliberate at launch

`my-ward` stays off: the 300-ward delimitation gazetted 25 Dec 2025 has no public geometry, and a division bench narrowed the disclosure order from 300 wards to two. RTI to GHMC is the route. Telugu renders in English — the dictionary is at 0% `te` and the contract is that a missing language falls back rather than blocks. Both are stated honestly on the pages that touch them.

## Verified

Both CI jobs locally: lint 0 errors, 83 frontend tests, `data:check`, build, and the API job (ruff check, ruff format, 152 pytest).