### PR TITLE
Two things Hyderabad's launch surfaced: a crashing rivers chart, and a roster that lists cities forever

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,17 +5,17 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { ThemeProvider } from "@/components/theme-provider";
 import { LanguageProvider } from "@/lib/i18n/context";
-import { cityKeywords, cityRoster, liveCityList } from "@/lib/cities/roster";
+import { cityKeywords, liveCityPhrase, liveCityPhraseWithOnboarding } from "@/lib/cities/roster";
 
-const ROSTER = cityRoster();
-const LIVE_CITIES = liveCityList();
+const CITIES = liveCityPhrase();
+const CITIES_WITH_ONBOARDING = liveCityPhraseWithOnboarding();
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://neervazhvu.org"),
   title: "Neer Vazhvu | Urban Water Intelligence",
   description:
     `Open-source platform tracking reservoirs, groundwater, river health, flood risk, drainage, ` +
-    `and water bodies across Indian cities - ${LIVE_CITIES} - with AI-powered summaries in ` +
+    `and water bodies across ${CITIES}, with AI-powered summaries in ` +
     `English and regional languages.`,
   keywords: [
     "urban water",
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Neer Vazhvu | Urban Water Intelligence",
-    description: `Reservoirs, groundwater, rivers, flood risk, and water bodies across Indian cities - ${ROSTER}.`,
+    description: `Reservoirs, groundwater, rivers, flood risk, and water bodies across ${CITIES_WITH_ONBOARDING}.`,
     type: "website",
     locale: "en_IN",
     siteName: "Neer Vazhvu",
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Neer Vazhvu | Urban Water Intelligence",
-    description: `Reservoirs, groundwater, rivers, flood risk, and water bodies across Indian cities - ${ROSTER}.`,
+    description: `Reservoirs, groundwater, rivers, flood risk, and water bodies across ${CITIES_WITH_ONBOARDING}.`,
   },
   icons: {
     icon: [
@@ -80,7 +80,7 @@ export default function RootLayout({
               url: "https://neervazhvu.org",
               description:
                 `Open-source platform tracking reservoirs, groundwater, river health, flood ` +
-                `risk, drainage, and water bodies across Indian cities - ${LIVE_CITIES}.`,
+                `risk, drainage, and water bodies across ${CITIES}.`,
               applicationCategory: "UtilitiesApplication",
               operatingSystem: "Any",
               offers: {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { liveCityList } from "@/lib/cities/roster";
+import { liveCityPhrase } from "@/lib/cities/roster";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
@@ -7,7 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: "Neer Vazhvu",
     description:
       `Open-source platform tracking reservoirs, groundwater, river health, flood risk, ` +
-      `drainage, and water bodies across Indian cities - ${liveCityList()}.`,
+      `drainage, and water bodies across ${liveCityPhrase()}.`,
     start_url: "/",
     display: "standalone",
     background_color: "#0f172a",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,28 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { listAllPlaces } from "@/lib/cities";
+import { liveCityPhrase } from "@/lib/cities/roster";
 import { CityLandmark, CITY_ACCENT, DEFAULT_ACCENT } from "@/components/landing/city-landmark";
+
+// The landing page kept its OWN three copies of the city roster, so it was
+// still advertising three live cities on the day the sixth launched - the same
+// rot src/lib/cities/roster.ts was written to end, in the one place a reader is
+// most likely to see it. Derived from the registry now, like layout.tsx and
+// manifest.ts. A new city needs no edit here.
+const CITIES = liveCityPhrase();
+const SHORT_DESCRIPTION = `Open-source urban water intelligence across ${CITIES}.`;
 
 export const metadata: Metadata = {
   title: "Neer Vazhvu | Urban Water Intelligence",
   description:
-    "Open-source urban water intelligence across Indian cities. Reservoirs, groundwater, rivers, floods, and water bodies made legible city by city - Chennai, Madurai, and Bengaluru live, more onboarding.",
+    `Open-source urban water intelligence across ${CITIES}. Reservoirs, groundwater, ` +
+    `rivers, floods, and water bodies made legible city by city.`,
   alternates: {
     canonical: "/",
   },
   openGraph: {
     title: "Neer Vazhvu | Urban Water Intelligence",
-    description:
-      "Open-source urban water intelligence across Indian cities - Chennai, Madurai, and Bengaluru live, more onboarding.",
+    description: SHORT_DESCRIPTION,
     type: "website",
     locale: "en_IN",
     siteName: "Neer Vazhvu",
@@ -22,8 +31,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Neer Vazhvu | Urban Water Intelligence",
-    description:
-      "Open-source urban water intelligence across Indian cities - Chennai, Madurai, and Bengaluru live, more onboarding.",
+    description: SHORT_DESCRIPTION,
   },
 };
 

--- a/src/components/rivers/river-quality-chart.tsx
+++ b/src/components/rivers/river-quality-chart.tsx
@@ -13,7 +13,8 @@ import {
 } from "recharts";
 import { useState, useEffect } from "react";
 import { useTheme } from "@/components/theme-provider";
-import type { RiverQualityReading } from "@/types/river-quality";
+import type { Measure, RiverQualityReading } from "@/types/river-quality";
+import { measureWorst, measureLabel } from "@/lib/rivers/measure";
 import { useLanguage } from "@/lib/i18n/context";
 
 const MONTH_ABBR = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
@@ -23,11 +24,30 @@ interface RiverQualityChartProps {
   stationName: string;
 }
 
+/** The raw measures for a plotted point, so the tooltip can print the RANGE
+ *  the source published rather than the single end this chart plots. */
+type RawMeasures = {
+  do_mgl: Measure;
+  bod_mgl: Measure;
+  nitrate_mgl: Measure;
+  fecal_coliform_mpn: Measure;
+};
+
 interface TooltipPayloadItem {
   dataKey: string;
   value: number;
   color: string;
   name: string;
+  payload?: { raw?: RawMeasures };
+}
+
+/** What to print for one series: the published range ("22-43") where there is
+ *  one, else the plotted number. Falls back to the number so a point-value
+ *  city is unchanged. */
+function seriesLabel(item: TooltipPayloadItem | undefined, digits: number): string | null {
+  if (!item || item.value == null) return null;
+  const raw = item.payload?.raw?.[item.dataKey as keyof RawMeasures] ?? null;
+  return measureLabel(raw) ?? item.value.toFixed(digits);
 }
 
 function renderTooltip({
@@ -57,7 +77,7 @@ function renderTooltip({
           <span className="text-slate-600 dark:text-slate-400">
             DO:{" "}
             <span className="font-medium text-sky-600 dark:text-sky-400">
-              {do_val.value.toFixed(1)} mg/L
+              {seriesLabel(do_val, 1)} mg/L
             </span>
           </span>
         </div>
@@ -68,7 +88,7 @@ function renderTooltip({
           <span className="text-slate-600 dark:text-slate-400">
             BOD:{" "}
             <span className="font-medium text-orange-600 dark:text-orange-400">
-              {bod_val.value.toFixed(0)} mg/L
+              {seriesLabel(bod_val, 0)} mg/L
             </span>
           </span>
         </div>
@@ -79,7 +99,7 @@ function renderTooltip({
           <span className="text-slate-600 dark:text-slate-400">
             NO₃:{" "}
             <span className="font-medium text-emerald-600 dark:text-emerald-400">
-              {nitrate_val.value.toFixed(1)} mg/L
+              {seriesLabel(nitrate_val, 1)} mg/L
             </span>
           </span>
         </div>
@@ -90,7 +110,7 @@ function renderTooltip({
           <span className="text-slate-600 dark:text-slate-400">
             FC:{" "}
             <span className="font-medium text-rose-600 dark:text-rose-400">
-              {fc_val.value.toLocaleString()} MPN
+              {seriesLabel(fc_val, 0) ?? fc_val.value.toLocaleString()} MPN
             </span>
           </span>
         </div>
@@ -124,6 +144,24 @@ export function RiverQualityChart({ readings, stationName }: RiverQualityChartPr
   const sorted = [...readings]
     .map((r) => ({
       ...r,
+      // Recharts scales numbers. Hyderabad's CPCB NWMP readings are annual
+      // {min,max} ranges, so spreading them raw handed Recharts an object to
+      // plot and the tooltip an object to call .toFixed() on - which is what
+      // broke the Musi and Manjira panels (the two rivers that HAVE readings;
+      // rivers without any returned early and looked fine). Plot the
+      // threshold-relevant end, per src/lib/rivers/measure.ts, and keep the
+      // raw measures for the tooltip so the reader still sees the published
+      // range. No midpoint is invented - CPCB never measured one.
+      do_mgl: measureWorst(r.do_mgl, "lower-is-worse"),
+      bod_mgl: measureWorst(r.bod_mgl, "higher-is-worse"),
+      nitrate_mgl: measureWorst(r.nitrate_mgl, "higher-is-worse"),
+      fecal_coliform_mpn: measureWorst(r.fecal_coliform_mpn, "higher-is-worse"),
+      raw: {
+        do_mgl: r.do_mgl,
+        bod_mgl: r.bod_mgl,
+        nitrate_mgl: r.nitrate_mgl,
+        fecal_coliform_mpn: r.fecal_coliform_mpn,
+      },
       period: r.month ?? String(r.year),
       // "2026-04" -> "Apr 26" keeps the axis readable at 9px.
       periodLabel: r.month

--- a/src/lib/cities/roster.ts
+++ b/src/lib/cities/roster.ts
@@ -4,40 +4,52 @@ import { listAllPlaces } from "./index";
  * City roster strings for site-wide metadata, derived from the registry so
  * they can never go stale the way the hard-coded "Chennai, Madurai, and
  * onboarding Bengaluru" string did. That string survived three launches
- * (Bengaluru, Mumbai, Delhi) because it was copied into four places while
- * only one of them read the registry.
+ * because it was copied into several places while only one read the registry.
  *
- * Lives here rather than in layout.tsx because manifest.ts and the JSON-LD
- * blob need the same roster, and a second copy is how the first one rotted.
+ * These return a COUNT, not a list of names. An enumerated roster is stale the
+ * moment it is written and unreadable once the platform passes a handful of
+ * cities: "Chennai, Madurai, Bengaluru, Mumbai, Delhi and Hyderabad" is already
+ * most of a description, and every onboarding adds to it. "six Indian cities"
+ * stays the same length forever and is still true the day the seventh lands.
+ *
+ * City NAMES still belong in `cityKeywords()`, where a search engine wants
+ * them individually and where a list is the right shape.
  */
 
-/** "Chennai, Madurai, Bengaluru live; Hyderabad onboarding" */
-export function cityRoster(): string {
-  const all = listAllPlaces();
-  const live = all.filter((p) => p.enabled !== false).map((p) => p.displayName);
-  const onboarding = all.filter((p) => p.enabled === false).map((p) => p.displayName);
-  const parts = [`${live.join(", ")} live`];
-  if (onboarding.length) parts.push(`${onboarding.join(", ")} onboarding`);
-  return parts.join("; ");
+const NUMBER_WORDS = [
+  "zero", "one", "two", "three", "four", "five", "six",
+  "seven", "eight", "nine", "ten", "eleven", "twelve",
+];
+
+function liveCities() {
+  return listAllPlaces().filter((p) => p.enabled !== false);
+}
+
+/** How many cities are live right now. */
+export function liveCityCount(): number {
+  return liveCities().length;
 }
 
 /**
- * Prose form for the site description, where "live; onboarding" reads as
- * machine output: "Chennai, Madurai, Bengaluru, Mumbai and Delhi".
- * Onboarding cities are omitted - a description is a promise to a reader,
- * and a preview-gated city 404s for them.
+ * "six Indian cities" - the phrase that goes in prose descriptions.
+ * Spelled out through twelve, then numerals, which is ordinary prose style.
  */
-export function liveCityList(): string {
-  const live = listAllPlaces()
-    .filter((p) => p.enabled !== false)
-    .map((p) => p.displayName);
-  if (live.length <= 1) return live[0] ?? "";
-  return `${live.slice(0, -1).join(", ")} and ${live[live.length - 1]}`;
+export function liveCityPhrase(): string {
+  const n = liveCityCount();
+  const word = n < NUMBER_WORDS.length ? NUMBER_WORDS[n] : String(n);
+  return `${word} Indian ${n === 1 ? "city" : "cities"}`;
+}
+
+/**
+ * Same phrase, plus a stable tail when any registered city is still
+ * preview-gated. "more onboarding" does not grow with the roster.
+ */
+export function liveCityPhraseWithOnboarding(): string {
+  const onboarding = listAllPlaces().some((p) => p.enabled === false);
+  return onboarding ? `${liveCityPhrase()}, more onboarding` : liveCityPhrase();
 }
 
 /** Search keywords for the live cities: ["Chennai water", "Madurai water", ...] */
 export function cityKeywords(): string[] {
-  return listAllPlaces()
-    .filter((p) => p.enabled !== false)
-    .map((p) => `${p.displayName} water`);
+  return liveCities().map((p) => `${p.displayName} water`);
 }


### PR DESCRIPTION
Two fixes from the first hour of Hyderabad being live. Different areas, same origin, so they travel together.

---

# 1. Clicking Musi or Manjira broke the rivers page

Reported within an hour of launch.

Esi and Haldi were fine, which made it look arbitrary — but it is exactly the split between rivers that **have** readings and ones that do not. Rivers with no quality record return `null` before the chart ever renders.

CPCB's national NWMP tables publish an annual **min and max** per station per year, not point values. So a Hyderabad reading is `{min, max}` where every other city's is a number. `src/lib/rivers/measure.ts` exists for precisely this and the panel already uses it — but the chart never adopted it. It spread readings straight into Recharts, which cannot scale an object, and its tooltip called `.toFixed()` on one.

The error is literally:

```
bod_mgl.toFixed is not a function
```

### The fix

The chart plots the **threshold-relevant end** via `measureWorst()`: the low end for DO, the high end for BOD, nitrate and faecal coliform. That keeps the colour coding and the reference lines meaning what they say — a range that touches the limit still reads as touching the limit.

**No midpoint is invented.** CPCB never measured one, and averaging the ends would be making up a number to fit a renderer. That is the rule `measure.ts` was written to enforce, quoted in its own docstring.

The raw measures ride along on each point, so the tooltip shows what the source actually published rather than only the end being plotted:

> Musi 2019 · BOD **22-43** mg/L

Point-value cities are untouched: `measureLabel()` returns a plain number for them and the tooltip falls back to the previous formatting.

### Verified

Ran the chart's data path over the real `river-quality-hyderabad.json`:

| | |
|---|---|
| plotted values across all three rivers | 204 |
| values still objects (would crash Recharts) | **0** |
| old code path on the first Musi reading | throws `bod_mgl.toFixed is not a function` |

---

# 2. Site metadata counted to three on the day the sixth city launched

The landing page kept its **own three copies** of the city roster, so the most-read page on the site still said *"Chennai, Madurai, and Bengaluru live, more onboarding"* hours after Hyderabad went up. #256 derived `layout.tsx` and `manifest.ts` from the registry and missed these, because they use a different phrasing than the grep that found the others.

And an enumerated roster does not scale. *"Chennai, Madurai, Bengaluru, Mumbai, Delhi and Hyderabad"* is already most of a description, it grows with every onboarding, and it is stale the moment a city lands.

So the helpers return a **count**:

```
liveCityPhrase()               -> "six Indian cities"
liveCityPhraseWithOnboarding() -> "six Indian cities, more onboarding"
```

Same length forever, still true the day the seventh arrives. City **names** stay in `cityKeywords()`, where a search engine wants them individually and a list is the right shape.

All six metadata sites now derive from the registry — `page.tsx` description + openGraph + twitter, `layout.tsx` description + openGraph + twitter + JSON-LD, and `manifest.ts`. A new city needs no edit in any of them.

---

## Worth noting for the next city

The rivers crash was invisible until launch for the same reason as the two bugs fixed during cutover: **a page returning 200 is not a page that works.** The route sweep checks HTTP status and renders the default view; nothing clicks a river. Worth a click-through pass for Surat rather than trusting the status codes.

## Verified

Both CI jobs locally: lint 0 errors, `i18n:check` OK, 83 frontend tests, `data:check`, build, and the API job (ruff, 152 pytest).