### PR TITLE
The rivers panel again, properly this time: the reading type was lying

### DIFF
--- a/src/components/rivers/river-panel.tsx
+++ b/src/components/rivers/river-panel.tsx
@@ -487,9 +487,10 @@ export function RiverPanel({
               );
             })()}
             {/* Fecal Coliform */}
-            {latestReading.fecal_coliform_mpn != null && (() => {
+            {measureWorst(latestReading.fecal_coliform_mpn, "higher-is-worse") != null && (() => {
               const limit = 500;
-              const val = latestReading.fecal_coliform_mpn;
+              const val = measureWorst(latestReading.fecal_coliform_mpn, "higher-is-worse") as number;
+              const shown = measureLabel(latestReading.fecal_coliform_mpn);
               const ratio = val / limit;
               const exceeded = val > limit;
               const severe = val > 10000;
@@ -500,7 +501,7 @@ export function RiverPanel({
                     <span className="text-[10px] text-slate-400 dark:text-slate-500">{t("rivers.limit")}: {limit} MPN</span>
                   </div>
                   <div className={`font-mono font-bold ${severe ? "text-red-600 dark:text-red-400" : exceeded ? "text-orange-600 dark:text-orange-400" : "text-green-600 dark:text-green-400"}`}>
-                    {val.toLocaleString()} <span className="font-normal text-slate-400">MPN</span>
+                    {shown} <span className="font-normal text-slate-400">MPN</span>
                     {exceeded && <span className="ml-1 text-[10px] font-semibold text-red-500 dark:text-red-400">{ratio.toFixed(0)}x</span>}
                   </div>
                   <div className="mt-1 h-1 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
@@ -538,9 +539,10 @@ export function RiverPanel({
               );
             })()}
             {/* Nitrate */}
-            {latestReading.nitrate_mgl != null && (() => {
+            {measureWorst(latestReading.nitrate_mgl, "higher-is-worse") != null && (() => {
               const limit = 45;
-              const val = latestReading.nitrate_mgl;
+              const val = measureWorst(latestReading.nitrate_mgl, "higher-is-worse") as number;
+              const shown = measureLabel(latestReading.nitrate_mgl);
               const ratio = val / limit;
               const exceeded = val > limit;
               const warning = val > 20;
@@ -551,7 +553,7 @@ export function RiverPanel({
                     <span className="text-[10px] text-slate-400 dark:text-slate-500">{t("rivers.limit")}: {limit} mg/L</span>
                   </div>
                   <div className={`font-mono font-bold ${exceeded ? "text-red-600 dark:text-red-400" : warning ? "text-orange-600 dark:text-orange-400" : "text-slate-900 dark:text-slate-100"}`}>
-                    {val} <span className="font-normal text-slate-400">mg/L</span>
+                    {shown} <span className="font-normal text-slate-400">mg/L</span>
                     {exceeded && <span className="ml-1 text-[10px] font-semibold text-red-500 dark:text-red-400">{ratio.toFixed(1)}x</span>}
                   </div>
                   <div className="mt-1 h-1 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">

--- a/src/types/river-quality.ts
+++ b/src/types/river-quality.ts
@@ -55,17 +55,23 @@ export interface RiverQualityReading {
   // invent a midpoint to flatten them. Renderers must handle both.
   do_mgl: Measure; // Dissolved oxygen mg/L
   bod_mgl: Measure; // Biochemical oxygen demand mg/L
-  ph: number | null;
+  // CPCB NWMP publishes these as annual min-max too, exactly like DO and BOD.
+  // They were left as `number` when Measure was introduced, so every renderer
+  // treated a {min,max} object as a number: React refused to render one as a
+  // child ("object with keys {min, max}", error #31) and the Hyderabad rivers
+  // panel died on click. The type has to tell the truth or nothing downstream
+  // can be correct.
+  ph: Measure;
   conductivity_us: number | null; // µS/cm
   cod_mgl: number | null; // Chemical oxygen demand mg/L
-  fecal_coliform_mpn: number | null; // Fecal coliform MPN/100ml
+  fecal_coliform_mpn: Measure; // Fecal coliform MPN/100ml
   /** Set when the published figure itself is disputed (e.g. the Mithi's
    *  2023 CPCB value, publicly flagged by Praja as a likely recording
    *  error). Rendered as a footnote under the FC tile - the number is
    *  shown as published, never silently corrected. */
   fecal_coliform_note?: string | null;
   tds_mgl: number | null; // Total dissolved solids mg/L
-  nitrate_mgl: number | null; // Nitrate mg/L
+  nitrate_mgl: Measure; // Nitrate mg/L
   chromium_mgl: number | null; // Chromium mg/L (heavy metal)
   lead_mgl: number | null; // Lead mg/L (heavy metal)
   cadmium_mgl: number | null; // Cadmium mg/L (heavy metal)


### PR DESCRIPTION
#260 fixed the chart and I called it done. It was not — clicking Musi still broke, with a **different** error. Fixing the first crash only revealed the second.

## What it actually is

Driving a real browser at the live page — which I should have done before claiming the first fix worked — gives:

```
React #31: object with keys {min, max}
```

Not `.toFixed()` this time. React refusing to render an object as a child.

## Root cause

`src/types/river-quality.ts`. When `Measure` was introduced for CPCB's annual min-max ranges, **only `do_mgl` and `bod_mgl` were widened.** `ph`, `nitrate_mgl` and `fecal_coliform_mpn` stayed `number | null`.

The real Hyderabad file carries ranges for all of them. Checked against the corpus, not assumed:

| field | shape in the actual data | declared type |
|---|---|---|
| `do_mgl` | `{min,max}` | `Measure` ✓ |
| `bod_mgl` | `{min,max}` | `Measure` ✓ |
| `ph` | `{min,max}` | `number \| null` ✗ |
| `nitrate_mgl` | `{min,max}` | `number \| null` ✗ |
| `fecal_coliform_mpn` | `{min,max}` | `number \| null` ✗ |
| `conductivity_umhos` | `{min,max}` | not in the type at all |

TypeScript could not catch this: the corpus is JSON cast at load, so the type was a claim nobody had verified against the data. Every renderer trusted it and treated a `{min,max}` object as a number.

## The fix

**The type first**, so it tells the truth — then the two renderers it was hiding. Faecal coliform and nitrate now go through `measureWorst()` / `measureLabel()` exactly as DO and BOD already did.

COD, TDS and the heavy metals are deliberately untouched: they are absent from the Hyderabad file entirely and are genuine point values in the cities that do carry them.

Widening the type is also what makes this the last round — TypeScript now fails the build on any future renderer that treats these as plain numbers, which is the check that was missing all along.

## Verified by clicking

A real browser, all four rivers, on this branch:

| river | page errors |
|---|---|
| Esi | **none** |
| Musi | **none** |
| Manjira | **none** |
| Krishna at Wadapally | **none** |

Against `main`, the first click throws React #31.

Build, lint (0 errors), 83 frontend tests, API ruff + 152 pytest all pass.

## What this cost, and what I'm changing

Two rounds, and a fix I announced as verified when it was not. Both crashes lived past a green build, a full route sweep and a merged PR, because **nothing clicked and nothing checked the type against the corpus.** A 200 is not a working page and a type is not evidence. The click-through pass goes into the onboarding checklist before Surat.