### PR TITLE
Kolkata goes live as the seventh city

### DIFF
--- a/src/lib/cities/kolkata.ts
+++ b/src/lib/cities/kolkata.ts
@@ -337,7 +337,9 @@ export const KOLKATA: CityConfig = {
     'tube wells': 'kmc_tubewells',
     'tubewells': 'kmc_tubewells',
   },
-  // Flipped at cutover, with supabase/migrations/042_kolkata_enable.sql kept in
-  // step as a record (that column gates nothing today - see delhi.ts).
-  enabled: false,
+  // LIVE 2026-08-14 as the seventh city. This flag is the only functional gate
+  // (route guard in [cityId]/layout.tsx); supabase/migrations/042_kolkata_enable.sql
+  // keeps the seeded row in step as a record, but that column gates nothing
+  // today - see delhi.ts.
+  enabled: true,
 };

--- a/supabase/migrations/042_kolkata_enable.sql
+++ b/supabase/migrations/042_kolkata_enable.sql
@@ -1,0 +1,69 @@
+-- =============================================================
+-- 042_kolkata_enable.sql
+-- Launch cutover: flip Kolkata from registered-but-disabled to live.
+--
+-- 040_kolkata_seed_disabled.sql seeded the city with enabled=FALSE so the
+-- CityConfig, water_sources and the UI could be built against
+-- city_id='kolkata' without exposing it. This is the promised follow-up.
+--
+-- WHAT ACTUALLY GATES THE SITE - unchanged from 033_delhi_enable.sql and
+-- 039_hyderabad_enable.sql:
+--   The ONLY functional switch is `enabled: true` on the CityConfig in
+--   src/lib/cities/kolkata.ts, read by the frontend route guard in
+--   [cityId]/layout.tsx. Without it /kolkata 404s outside
+--   NEXT_PUBLIC_PREVIEW_CITIES and the landing board shows Kolkata as
+--   "onboarding".
+--
+--   This `enabled` COLUMN is read by no code at all - neither the Next.js
+--   app nor the Python API queries it.
+--
+-- So this migration is for CONSISTENCY, not for gating: it keeps the seeded
+-- row honest about a city that is live, and keeps the state reproducible on
+-- a fresh database. Bengaluru shipped in June 2026 and sat at enabled=FALSE
+-- here for weeks with nothing breaking (see 034_bangalore_enable_fix.sql),
+-- which is the evidence for that claim rather than an assumption.
+--
+-- STATE AT CUTOVER (2026-08-14), so a fresh rebuild can be checked against it:
+--   cities         1 row, place_kind='region', ward_count=144,
+--                  enabled flips FALSE -> TRUE here
+--   water_sources  4 rows: hooghly_palta, garden_reach, dhapa (all 'river',
+--                  primary drinking sources) and kmc_tubewells
+--                  ('borewell_field', not primary)
+--   reservoir_daily_v2   0 rows, AND THAT IS CORRECT. Kolkata impounds
+--                  nothing - it abstracts run-of-river from the Hooghly at
+--                  Palta and pumps deep tube wells - so there is no storage
+--                  series to backfill even in principle. Every source is
+--                  hasPublicFeed:false because no authority publishes a daily
+--                  abstraction or production figure. Hyderabad needed 27,019
+--                  rows here; Kolkata needs none, which is why its hero is
+--                  drainage-capacity rather than days-left.
+--
+-- KNOWN SCHEMA GAP, recorded rather than worked around:
+--   040 and 041 also INSERT INTO corporations and source_corporation. Those
+--   tables do not exist in the live database: they are DDL from
+--   029_mmr_corporations.sql, which was never applied (the remote migration
+--   ledger records only 001-016; later migrations were applied out-of-band and
+--   data-only). Mumbai's corporation rows are absent for the same reason and
+--   have been since it launched, with nothing breaking, because NO code queries
+--   either table - the region dashboard reads its corporation list from
+--   src/lib/cities/<city>.ts, not from SQL.
+--   So Kolkata's corporation rows are pending, not lost. Applying 029 closes
+--   the drift for every city at once; it is idempotent throughout
+--   (CREATE TABLE/INDEX IF NOT EXISTS, INSERT ... ON CONFLICT DO NOTHING) and
+--   the policies cannot pre-exist because the tables do not.
+--
+-- PREREQUISITE: 040 and 041 must already be applied. This migration raises
+-- rather than silently updating nothing if the row is absent.
+-- =============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cities WHERE city_id = 'kolkata') THEN
+    RAISE EXCEPTION
+      'kolkata is not seeded - apply 040_kolkata_seed_disabled.sql first';
+  END IF;
+END $$;
+
+UPDATE cities
+   SET enabled = TRUE
+ WHERE city_id = 'kolkata';


### PR DESCRIPTION
The cutover for #261. Flips `enabled: true` - the one functional gate, read by
the route guard in `[cityId]/layout.tsx` - and adds `042_kolkata_enable.sql` to
keep the seeded row in step.

The chain that got here, all done:

| Step | State |
|---|---|
| PR #261, preview-gated | merged `8875d632` |
| Corpus release `neer-vazhvu-data#8` | merged `3b867ebf`, tagged `corpus-2026-08-14-kolkata` |
| `corpus.lock` 410/100 -> 425/105 | in #261 |
| Toolchain re-pin `neer-vazhvu-data#9` | merged |
| DB apply 040 + 041 | applied: `cities +1`, `water_sources +4`, every other city byte-identical |

## No historical backfill, and that is correct

`reservoir_daily_v2` stays at zero rows for Kolkata. The city impounds nothing -
run-of-river abstraction from the Hooghly at Palta plus deep tube wells - so
there is no storage series to backfill even in principle, and no authority
publishes a daily abstraction or production figure. Hyderabad needed 27,019 rows
there this morning; Kolkata needs none, which is the whole reason its hero is
`drainage-capacity` rather than `days-left`.

## A schema gap recorded rather than worked around

040 and 041 also insert into `corporations` and `source_corporation`. **Those
tables do not exist in the live database.** They are DDL from
`029_mmr_corporations.sql`, which was never applied - the remote migration
ledger records only 001-016, and everything after was applied out-of-band and
data-only.

This is pre-existing and not Kolkata's: Mumbai's corporation rows have been
absent since it launched, with nothing breaking, because **no code queries
either table**. The region dashboard reads its corporation list from
`src/lib/cities/<city>.ts`. So Kolkata's rows are pending, not lost.

Applying 029 closes the drift for every city at once and is idempotent
throughout (`CREATE TABLE`/`INDEX IF NOT EXISTS`, `INSERT ... ON CONFLICT DO
NOTHING`, and the policies cannot pre-exist because the tables do not). I did
not run it: it is DDL against production and that is your call, not mine.

## Verified with no preview flag set

Built and served with `NEXT_PUBLIC_PREVIEW_CITIES` unset, so this is what
production sees:

- all 11 routes render with correct titles
- 10 Kolkata URLs in the sitemap, up from 0 while disabled
- the landing board shows all seven cities as Live
- a click-through of the dashboard, rivers, water-bodies and flood-risk deep
  dives is clean: 101 interactions, no console errors and no exceptions

## Still deliberately off

Bengali (`upcomingLanguages`, 0 of 1641 keys - needs a native reviewer, not a
machine pass), `my-ward` (KMC wards 142-144 are unmapped by anyone), the
catchment atlas (11 m of relief across 40 km), cascades, shoreline and tanker.
All of them, with reasons, are in `docs/architecture/exemptions.md`.