### PR TITLE
Gurugram: city config, first three surfaces, and three defects the UI sweep found

### DIFF
--- a/docs/architecture/exemptions.md
+++ b/docs/architecture/exemptions.md
@@ -9,11 +9,11 @@ This exists because a platform that treats data gaps as first-class has to be ab
 
 | Kind | Entries |
 |---|---|
-| Suppressed freshness checks | 0 |
+| Suppressed freshness checks | 1 |
 | Artifacts with no registered upstream | 76 |
-| Routes a city deliberately does not ship | 22 |
-| Absences the product states on the page | 18 |
-| **Total** | **116** |
+| Routes a city deliberately does not ship | 33 |
+| Absences the product states on the page | 20 |
+| **Total** | **130** |
 
 **1 of these have no recorded rationale.** They are real, deliberate omissions whose original reason was never written down. They are marked rather than back-filled with a guess, because an invented justification reads as authoritative and is worse than an admitted blank. Each is a TODO: record the real reason, or ship the thing.
 
@@ -23,7 +23,9 @@ This exists because a platform that treats data gaps as first-class has to be ab
 
 A city skipping a derived staleness check. This is the only kind that suppresses a CI failure, which is why the map is owned by `scripts/lib/exemptions.ts` rather than by the checker. **Empty is the correct steady state.** Every entry should carry the condition that would retire it.
 
-_None._
+| Scope | Subject | Reason |
+|---|---|---|
+| gurugram | rainfall-recent | No IMD gridded base series exists for Gurugram yet, and rainfall-recent is the provisional fill on top of one. Retire this by generating imd-rainfall-monthly-gurugram.json and wiring the city into fetch_recent_rainfall.py. |
 
 ## Artifacts with no registered upstream
 
@@ -121,6 +123,17 @@ Derived by diffing each city against the union of every route any city ships, so
 | delhi | climate-risk | Not built for this city. |
 | delhi | shoreline | Landlocked. |
 | delhi | tanker | Not built for this city. |
+| gurugram | allocations | No published entitlement instrument has been located. Gurugram's canal share of Yamuna water is governed by inter-state arrangements that GMDA does not publish, and the ledger's primitive is entitled-vs-received against a named instrument - without the paper there is no row to write. |
+| gurugram | cascades | Not a cascade geography. Aravalli johads and village ponds are a real water heritage, but no chained-surplus system was engineered here the way it was in the Tamil kanmoi districts or the Bengaluru kere chains, so the cascade story must not be told about this city. Catchment delineation itself is buildable - GMDA publishes a 10-polygon watershed layer and a natural-flow-direction layer - and is a separate question from the cascade narrative. |
+| gurugram | climate-risk | Chennai's sub-basin climate risk comes from HydroBASINS level 12, a global product that would transfer here. Genuinely buildable and simply not built, so this is backlog rather than refusal. |
+| gurugram | commitments | Buildable and not built. The dated commitments exist and are citable (the NGT's February 2026 orders on illegal extraction and rainwater harvesting, GMDA's Chandu Budhera fifth-unit target), but each needs primary-source verification before it goes in the register, and none has had it yet. |
+| gurugram | facts | Needs a facts-gurugram.json, which needs the supply and demand numbers that are the very ones still unverified - every figure in circulation for this city is press-sourced, and GMDA's own GIS already contradicts two of them. Ships when the numbers do. |
+| gurugram | flood-risk | Gurugram floods by waterlogging on a paved catchment, not by river. The inputs exist on GMDA OneMap (117 GMUC waterlogging sites, the master storm-water network, natural flow direction) and only the drain legs are harvested so far, so this is a backlog item with a known path rather than a refusal. |
+| gurugram | groundwater | The signature issue is the thinnest data, which is why this is off rather than empty. Gurugram has been a CGWA dark zone since 2008, but the India-WRIS level record is 37 stations that stop in June 2020 and the Haryana telemetry network does not cover this district at all - 95 MB of the state export contains zero Gurugram rows. 37 stations across 36 wards would not carry honest per-ward interpolation even if they were current. Closes on IN-GRES block assessment plus the HSPCB 2016-2024 quality series, both identified and neither wired up. |
+| gurugram | lake-restoration | Needs a restoration-priority-gurugram.json, which needs a scorer. The water-body register is harvested and carries ownership, area and GMDA's own cross-survey flags, so the inputs are present and the ranking is simply not built. |
+| gurugram | origins | Not built for this city yet. The spine is identified - GMDA OneMap publishes the MCG limit at 1985, 1996, 2008, 2010, 2015 and 2020, which is the city eating its own catchment in six dated steps - but the narrative is unwritten. |
+| gurugram | rivers | Gurugram has no river. Its NWMP monitoring stations are all lakes and borewells, and its surface water leaves the city as drain flow into the Najafgarh jheel and then Delhi's Najafgarh drain. There is nothing to put on a rivers page that would not be an invention. |
+| gurugram | shoreline | Landlocked. |
 | hyderabad | climate-risk | Not built for this city. |
 | hyderabad | my-ward | The 300-ward delimitation gazetted 25 Dec 2025 has no public geometry, and with the corporations under a Special Officer there are no sitting councillors to attach to a ward either. Returns with the ward build, following the Mumbai precedent. |
 | hyderabad | shoreline | Landlocked. |
@@ -150,6 +163,8 @@ Gaps the UI itself renders rather than hiding: the reason below is the copy a re
 | delhi | water source: Tehri (Delhi share) | THDC publishes Tehri's 300-cusec allocation to Delhi but no daily release against it; the CWC weekly bulletin that carried Tehri storage stopped in May 2025. |
 | delhi | water source: Upper Ganga Canal | No public daily release on the Upper Ganga Canal leg; the channel also closes for UP's annual canal maintenance with no Delhi-visible schedule. |
 | delhi | water source: Yamuna at Wazirabad | No public daily gauge for the Wazirabad pond. Levels surface only in crisis reporting and Supreme Court filings. |
+| gurugram | storage history chart | Gurugram impounds no water of its own. It has no reservoir and no dam, so no storage series exists to chart - here or anywhere else. Its supply is canal water from the Yamuna, groundwater from municipal tubewells, and tankers. |
+| gurugram | UI language: hi | Advertised as coming soon and rendered as a disabled chip. The hi dictionary is not populated, and must be translated by a native speaker rather than machine-generated, so the UI falls back to English by contract until it is. |
 | hyderabad | UI language: te | Advertised as coming soon and rendered as a disabled chip. The te dictionary is not populated, and must be translated by a native speaker rather than machine-generated, so the UI falls back to English by contract until it is. |
 | hyderabad | water source: Nagarjuna Sagar | HMWSSB publishes this level daily, but Nagarjuna Sagar is a parent Krishna storage reported for context, not a city source: it records a city draw of 0 MLD. Its level is the real constraint on Akkampally, which is why it is listed here. |
 | hyderabad | water source: Srisailam | HMWSSB publishes this level daily, but Srisailam is a parent Krishna storage reported for context, not a city source: it records a city draw of 0 MLD. Its level is the real constraint on Akkampally, which is why it is listed here. |

--- a/neer-vazhvu-api/scripts/fetch_recent_rainfall.py
+++ b/neer-vazhvu-api/scripts/fetch_recent_rainfall.py
@@ -51,6 +51,15 @@ CITIES = {
     # Matches the IMD gridded point in generate_imd_rainfall.py, not the city
     # centre: the provisional months must continue the same series they fill.
     "kolkata": (22.5000, 88.2500),
+    # Gurugram is NOT here yet, deliberately. Its grid point is (28.4360,
+    # 77.0560), the centroid of MCG's 36-ward extent, but this fetcher only
+    # fills provisional months AFTER an IMD authoritative base series, and
+    # imd-rainfall-monthly-gurugram.json does not exist. Adding the city
+    # before that base is generated would fail `--all` - and `--all` is what
+    # the daily rainfall-recent-refresh workflow runs, so the whole job would
+    # go red every day for every city. Add it in the same change as the IMD
+    # backfill, not before. Tracked by the freshness exemption
+    # "gurugram:rainfall-recent".
 }
 
 API = (

--- a/scripts/lib/exemptions.ts
+++ b/scripts/lib/exemptions.ts
@@ -46,7 +46,25 @@ import { UNWATCHED } from "./headwaters-coverage";
  * here rather than deleted silently because "an exemption we retired" is the
  * evidence that the removal conditions are real.
  */
-export const FRESHNESS_EXEMPTIONS: Record<string, string> = {};
+export const FRESHNESS_EXEMPTIONS: Record<string, string> = {
+  // TEMPORARY, and the same exemption Kolkata carried for the same reason
+  // (see the note above, which records its retirement). rainfall-recent is a
+  // PROVISIONAL fill layered on top of an IMD authoritative base, so it cannot
+  // exist before imd-rainfall-monthly-gurugram.json does, and generating that
+  // base is a multi-decade gridded download that belongs in its own change
+  // rather than bolted onto the city scaffold.
+  //
+  // Gurugram is deliberately absent from CITIES in fetch_recent_rainfall.py
+  // meanwhile: the daily workflow runs `--all`, which exits non-zero if any
+  // one city fails, so adding the grid point early would turn the whole job
+  // red every day for every city.
+  //
+  // REMOVAL CONDITION: run generate_imd_rainfall.py for the Gurugram grid
+  // point (28.4360, 77.0560), add "gurugram" to CITIES in
+  // fetch_recent_rainfall.py, and delete this entry in the same change.
+  "gurugram:rainfall-recent":
+    "No IMD gridded base series exists for Gurugram yet, and rainfall-recent is the provisional fill on top of one. Retire this by generating imd-rainfall-monthly-gurugram.json and wiring the city into fetch_recent_rainfall.py.",
+};
 
 /* ── 2. Reported: declared absences owned by their consumers ────────────── */
 
@@ -114,6 +132,31 @@ const ROUTE_OFF_REASONS: Record<string, string> = {
     "KMC runs a municipal tanker service and publishes per-trip rates, but no volumes, trips or coverage - so there is nothing to chart that would not be invented.",
   "kolkata:climate-risk":
     "Chennai's sub-basin climate risk comes from HydroBASINS level 12, a global product that would transfer here. It is genuinely buildable and simply not built yet, so this is a backlog item rather than a refusal.",
+
+  // Gurugram - preview-gated, city nine. The set is deliberately small: only
+  // the surfaces with data behind them are on, and the two most conspicuous
+  // absences are properties of the city rather than backlog.
+  "gurugram:rivers":
+    "Gurugram has no river. Its NWMP monitoring stations are all lakes and borewells, and its surface water leaves the city as drain flow into the Najafgarh jheel and then Delhi's Najafgarh drain. There is nothing to put on a rivers page that would not be an invention.",
+  "gurugram:groundwater":
+    "The signature issue is the thinnest data, which is why this is off rather than empty. Gurugram has been a CGWA dark zone since 2008, but the India-WRIS level record is 37 stations that stop in June 2020 and the Haryana telemetry network does not cover this district at all - 95 MB of the state export contains zero Gurugram rows. 37 stations across 36 wards would not carry honest per-ward interpolation even if they were current. Closes on IN-GRES block assessment plus the HSPCB 2016-2024 quality series, both identified and neither wired up.",
+  "gurugram:flood-risk":
+    "Gurugram floods by waterlogging on a paved catchment, not by river. The inputs exist on GMDA OneMap (117 GMUC waterlogging sites, the master storm-water network, natural flow direction) and only the drain legs are harvested so far, so this is a backlog item with a known path rather than a refusal.",
+  "gurugram:shoreline": "Landlocked.",
+  "gurugram:lake-restoration":
+    "Needs a restoration-priority-gurugram.json, which needs a scorer. The water-body register is harvested and carries ownership, area and GMDA's own cross-survey flags, so the inputs are present and the ranking is simply not built.",
+  "gurugram:origins":
+    "Not built for this city yet. The spine is identified - GMDA OneMap publishes the MCG limit at 1985, 1996, 2008, 2010, 2015 and 2020, which is the city eating its own catchment in six dated steps - but the narrative is unwritten.",
+  "gurugram:cascades":
+    "Not a cascade geography. Aravalli johads and village ponds are a real water heritage, but no chained-surplus system was engineered here the way it was in the Tamil kanmoi districts or the Bengaluru kere chains, so the cascade story must not be told about this city. Catchment delineation itself is buildable - GMDA publishes a 10-polygon watershed layer and a natural-flow-direction layer - and is a separate question from the cascade narrative.",
+  "gurugram:allocations":
+    "No published entitlement instrument has been located. Gurugram's canal share of Yamuna water is governed by inter-state arrangements that GMDA does not publish, and the ledger's primitive is entitled-vs-received against a named instrument - without the paper there is no row to write.",
+  "gurugram:commitments":
+    "Buildable and not built. The dated commitments exist and are citable (the NGT's February 2026 orders on illegal extraction and rainwater harvesting, GMDA's Chandu Budhera fifth-unit target), but each needs primary-source verification before it goes in the register, and none has had it yet.",
+  "gurugram:facts":
+    "Needs a facts-gurugram.json, which needs the supply and demand numbers that are the very ones still unverified - every figure in circulation for this city is press-sourced, and GMDA's own GIS already contradicts two of them. Ships when the numbers do.",
+  "gurugram:climate-risk":
+    "Chennai's sub-basin climate risk comes from HydroBASINS level 12, a global product that would transfer here. Genuinely buildable and simply not built, so this is backlog rather than refusal.",
 
   // Hyderabad
   "hyderabad:my-ward":

--- a/src/app/[cityId]/rivers/page.tsx
+++ b/src/app/[cityId]/rivers/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import fs from "node:fs";
 import path from "node:path";
 import { tryGetPlaceConfig } from "@/lib/cities";
+import { isFeatureSupportedForCity } from "@/lib/cities/routing";
 import { basinsForCity, tryGetBasinManifest, type BasinInventory } from "@/lib/basins";
 import { FeatureNotYetAvailable } from "@/components/layout/feature-not-yet-available";
 import { riversVariant } from "@/lib/cities/data-paths";
@@ -550,6 +551,17 @@ export default async function CityRiversPage({ params }: PageProps) {
   const { cityId } = await params;
   const config = tryGetPlaceConfig(cityId);
   if (!config) notFound();
+
+  // Cities whose FEATURE_AVAILABILITY set omits "rivers" 404 here, the same
+  // gate my-ward uses. Without it this page fell through to the generic
+  // not-yet-available state, which tells the reader the page "hasn't shipped
+  // yet" and lists what is needed to ship it - true for a city awaiting a
+  // data layer, FALSE for one that has no river at all. Gurugram is the
+  // first: its NWMP stations are all lakes and borewells, and its surface
+  // water leaves as drain flow into the Najafgarh jheel. Promising a page
+  // that can never exist is the same defect as Delhi's storage chart
+  // promising to "fill in automatically" for a city that impounds nothing.
+  if (!isFeatureSupportedForCity("/rivers", cityId)) notFound();
 
   // Renderer is selected by declared data-layout variant, not a city-id
   // branch in render code (see multi-city-component-discipline.md rule 3).

--- a/src/app/[cityId]/tanker/page.tsx
+++ b/src/app/[cityId]/tanker/page.tsx
@@ -13,9 +13,11 @@ import {
 import { IIScStressWardsMap } from "@/components/dashboard/iisc-stress-wards-map";
 import { TankerPageHeader, TankerPageFooter } from "@/components/dashboard/tanker-page-chrome";
 import { TankerLedgerPanel } from "@/components/dashboard/tanker-ledger-panel";
+import { TankerSalesPanel } from "@/components/dashboard/tanker-sales-panel";
 import { BillingLedgerPanel } from "@/components/dashboard/billing-ledger-panel";
 import type { BillingLedger } from "@/components/dashboard/billing-ledger-panel";
 import type { TankerLedger } from "@/components/dashboard/tanker-ledger-panel";
+import type { TankerSales } from "@/components/dashboard/tanker-sales-panel";
 
 interface PageProps {
   params: Promise<{ cityId: string }>;
@@ -46,14 +48,46 @@ export default async function CityTankerPage({ params }: PageProps) {
   // (Hyderabad) has no household survey and never will, so gating on the
   // survey alone 404'd a page that was already in the nav.
   const kind = config.tankerDataKind ?? "household-survey";
-  const dataPath = join(
-    process.cwd(),
-    "public",
-    "data",
-    kind === "utility-ledger" ? `${cityId}-tankers.json` : `${cityId}-tanker-survey.json`,
-  );
+  const FILE_FOR_KIND: Record<string, string> = {
+    "household-survey": `${cityId}-tanker-survey.json`,
+    "utility-ledger": `${cityId}-tankers.json`,
+    "utility-sales-ledger": `${cityId}-tanker-sales.json`,
+  };
+  const dataPath = join(process.cwd(), "public", "data", FILE_FOR_KIND[kind]);
   if (!existsSync(dataPath)) {
     notFound();
+  }
+
+  if (kind === "utility-sales-ledger") {
+    const sales = JSON.parse(await readFile(dataPath, "utf-8")) as TankerSales;
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <nav className="text-xs text-slate-500 dark:text-slate-400">
+          <Link
+            href={`/${cityId}`}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            ← {config.displayName} dashboard
+          </Link>
+        </nav>
+
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {config.displayName} bulk water sales
+          </h1>
+          <p className="text-sm text-slate-600 dark:text-slate-400 max-w-3xl leading-relaxed">
+            {config.displayName} is the rare city where the authority sells
+            bulk water by the tanker load and publishes the transaction record.
+            GMDA logged every load it dispensed for three years - the point it
+            came from, the grade of water, the buyer, and the price - so this
+            page shows what a dark-zone city actually sold, rather than a
+            surveyed household price.
+          </p>
+        </header>
+
+        <TankerSalesPanel sales={sales} cityDisplayName={config.displayName} />
+      </div>
+    );
   }
 
   if (kind === "utility-ledger") {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,13 @@ const CITY_HOOKS: Record<string, string> = {
     "The Musi and its tank cascade, a 2,978-lake gazetted register, the utility's own tanker ledger, and a daily statement that publishes the draw as well as the storage.",
   kolkata:
     "Victorian sewers rated for 6 mm of rain an hour, KMC's own weekly waterlogging register, the wetlands that treat two-thirds of the city's sewage, and the Adi Ganga at zero dissolved oxygen.",
+  // Added with the city itself, NOT after cutover. buildCityBoard() maps over
+  // listAllPlaces(), so a registered-but-disabled city already renders a card
+  // here - a missing hook shows as an Onboarding badge above an empty line.
+  // That is exactly how Hyderabad and Mumbai both shipped a blank card, and
+  // this map is not derived from the registry, so nothing catches it for you.
+  gurugram:
+    "No river, no reservoir, and a dark zone since 2008 - plus GMDA's own ledger of every tanker load it sold, naming who bought it and at what price.",
 };
 
 type CityStatus = "live" | "onboarding" | "upnext";

--- a/src/components/dashboard/tanker-sales-panel.tsx
+++ b/src/components/dashboard/tanker-sales-panel.tsx
@@ -1,0 +1,383 @@
+/**
+ * Tanker page, "utility-sales-ledger" variant.
+ *
+ * The third kind, and the one with prices AND a census. Bengaluru's survey
+ * panel answers "what do households PAY?" because that market is private and
+ * RTI-gated. Hyderabad's ledger panel answers "who ASKS, and when?" because
+ * HMWSSB runs the fleet but records no tariff. Gurugram is neither: GMDA sells
+ * bulk water by the tanker load from six named points, at a published tariff
+ * that differs by water grade, to buyers it names - so this panel answers
+ * "what did the utility SELL, to whom, and at what price?"
+ *
+ * Deliberate editorial choice, and it is the whole design of this page:
+ * VOLUME IS NOT THE HEADLINE. Bookings fall 12,337 to 7,208 across 2019-2021,
+ * which reads as falling tanker dependence and is not safe to read that way -
+ * this is a construction-driven market and 2020-21 are COVID years. The
+ * finding that survives the confound is compositional, because it is a ratio
+ * measured inside the same disrupted period: non-potable share rises 29.7% ->
+ * 42.2% -> 51.2% against tariffs stable to the decimal. So the composition
+ * shift leads, the volume series is shown with its caveat attached, and the
+ * caveat is rendered rather than buried in About.
+ */
+
+import type { ReactNode } from "react";
+
+export type TankerSales = {
+  _source: string;
+  _source_url: string;
+  _licence: string;
+  _fetched: string;
+  _note: string;
+  _coverage_gap: string;
+  _caveats: string[];
+  totals: {
+    bookings: number;
+    litres: number;
+    amount_inr: number;
+    years: number;
+    months: number;
+    buyers: number;
+    delivery_sites: number;
+    stations: number;
+    first_booking: string;
+    last_booking: string;
+    non_potable_pct_first_year: number | null;
+    non_potable_pct_last_year: number | null;
+  };
+  by_year: {
+    year: number;
+    bookings: number;
+    litres: number;
+    amount_inr: number;
+    buyers: number;
+    non_potable_litres: number;
+    non_potable_pct: number | null;
+    rows_rejected: number;
+  }[];
+  water_types: {
+    water_type: string;
+    potable: boolean;
+    bookings: number;
+    litres: number;
+    amount_inr: number;
+    rate_inr_per_kl: number | null;
+    by_year: { year: number; litres: number; rate_inr_per_kl: number | null }[];
+  }[];
+  stations: {
+    station: string;
+    bookings: number;
+    litres: number;
+    water_types: string[];
+    years: number[];
+    active_all_years: boolean;
+  }[];
+  top_buyers: {
+    buyer: string;
+    bookings: number;
+    litres: number;
+    share_pct: number | null;
+    potable_pct: number | null;
+  }[];
+};
+
+const nf = new Intl.NumberFormat("en-IN");
+
+/** Litres are the natural unit upstream but unreadable at 10^9. */
+function ml(litres: number): string {
+  return `${nf.format(Math.round(litres / 1_000_000))} ML`;
+}
+
+function crore(rupees: number): string {
+  return `Rs ${(rupees / 10_000_000).toFixed(2)} Cr`;
+}
+
+function Card({ label, value, sub }: { label: string; value: string; sub: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">
+      <div className="text-xs text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="text-2xl font-bold text-slate-900 dark:text-slate-100 mt-1">{value}</div>
+      <div className="text-[11px] text-slate-500 dark:text-slate-400 mt-1 leading-snug">{sub}</div>
+    </div>
+  );
+}
+
+export function TankerSalesPanel({
+  sales,
+  cityDisplayName,
+}: {
+  sales: TankerSales;
+  cityDisplayName: string;
+}) {
+  const { totals, by_year, water_types, stations, top_buyers } = sales;
+
+  const first = by_year[0];
+  const last = by_year[by_year.length - 1];
+  const potable = water_types.find((t) => t.potable);
+  const treated = water_types
+    .filter((t) => !t.potable)
+    .sort((a, b) => (a.rate_inr_per_kl ?? 0) - (b.rate_inr_per_kl ?? 0))[0];
+  const priceRatio =
+    potable?.rate_inr_per_kl && treated?.rate_inr_per_kl
+      ? potable.rate_inr_per_kl / treated.rate_inr_per_kl
+      : null;
+
+  const maxYearLitres = Math.max(...by_year.map((y) => y.litres));
+  const top3 = top_buyers.slice(0, 3).reduce((s, b) => s + b.litres, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Headline counters. Composition first, volume second - see the file
+          docstring for why the volume trend is not the headline. */}
+      <section className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <Card
+          label="Non-potable share of sales"
+          value={`${first?.non_potable_pct ?? "-"}% → ${last?.non_potable_pct ?? "-"}%`}
+          sub={`${first?.year} to ${last?.year}, by volume`}
+        />
+        <Card
+          label="Water sold by tanker"
+          value={ml(totals.litres)}
+          sub={`${nf.format(totals.bookings)} loads over ${totals.months} months`}
+        />
+        <Card
+          label="Revenue"
+          value={crore(totals.amount_inr)}
+          sub={`across ${nf.format(totals.buyers)} buyers and ${totals.stations} dispensing points`}
+        />
+        <Card
+          label="Potable vs treated price"
+          value={priceRatio ? `${priceRatio.toFixed(1)}x` : "-"}
+          sub={
+            potable && treated
+              ? `Rs ${potable.rate_inr_per_kl}/kL against Rs ${treated.rate_inr_per_kl}/kL for ${treated.water_type.toLowerCase()}`
+              : "tariffs unavailable"
+          }
+        />
+      </section>
+
+      {/* The finding. */}
+      <section className="rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          What {cityDisplayName} sold, and how that changed
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">
+          {cityDisplayName} sits on a Central Ground Water Authority dark zone,
+          declared in 2008. Across these three years the share of bulk tanker
+          water that was <em>not</em> drinking water rose from{" "}
+          {first?.non_potable_pct}% to {last?.non_potable_pct}% - potable volume
+          fell {first && last ? Math.round((1 - (last.litres - last.non_potable_litres) / (first.litres - first.non_potable_litres)) * 100) : "-"}%
+          while treated and recycled volume held roughly flat. The tariffs did
+          not move over the same period, so this is a change in what was sold
+          rather than a change in what it cost.
+        </p>
+
+        <div className="mt-4 space-y-3">
+          {by_year.map((y) => {
+            const potableLitres = y.litres - y.non_potable_litres;
+            return (
+              <div key={y.year} className="space-y-1">
+                <div className="flex items-baseline justify-between text-[11px]">
+                  <span className="font-medium text-slate-700 dark:text-slate-300 tabular-nums">
+                    {y.year}
+                  </span>
+                  <span className="text-slate-500 dark:text-slate-400 tabular-nums">
+                    {ml(y.litres)} · {y.non_potable_pct}% non-potable
+                  </span>
+                </div>
+                <div
+                  className="flex h-5 rounded-sm overflow-hidden bg-slate-100 dark:bg-slate-800"
+                  style={{ width: `${(y.litres / maxYearLitres) * 100}%` }}
+                >
+                  <div
+                    className="bg-blue-600/80 h-full"
+                    style={{ width: `${(potableLitres / y.litres) * 100}%` }}
+                    title={`Potable ${ml(potableLitres)}`}
+                  />
+                  <div
+                    className="bg-emerald-600/80 h-full"
+                    style={{ width: `${(y.non_potable_litres / y.litres) * 100}%` }}
+                    title={`Treated + recycled ${ml(y.non_potable_litres)}`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex gap-4 text-[11px] text-slate-500 dark:text-slate-400">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm bg-blue-600/80" /> Potable
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm bg-emerald-600/80" /> Treated + recycled
+          </span>
+        </div>
+      </section>
+
+      {/* The caveat that must travel with the volume series, rendered rather
+          than buried in About. */}
+      <section className="rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50/50 dark:bg-amber-950/20 p-4 text-xs text-slate-700 dark:text-slate-300 leading-relaxed">
+        <strong className="font-semibold">Read the falling volume carefully.</strong>{" "}
+        Total loads drop from {nf.format(by_year[0]?.bookings ?? 0)} in{" "}
+        {by_year[0]?.year} to {nf.format(last?.bookings ?? 0)} in {last?.year}, but
+        that is not evidence of falling tanker dependence. This is a
+        construction-driven market and {by_year[1]?.year}-{last?.year} are COVID
+        years, when building stopped. The composition shift above is the
+        finding that survives, because it is a ratio measured inside the same
+        disrupted period.
+      </section>
+
+      {/* Tariff by grade. */}
+      <section className="rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          What each grade costs
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          GMDA&apos;s own tariff, unchanged to the decimal across all three years.
+        </p>
+        <table className="w-full text-xs mt-3">
+          <thead>
+            <tr className="text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+              <th className="text-left font-medium py-1">Water grade</th>
+              <th className="text-right font-medium py-1">Rs / kL</th>
+              <th className="text-right font-medium py-1">Volume</th>
+              <th className="text-right font-medium py-1">Loads</th>
+            </tr>
+          </thead>
+          <tbody>
+            {water_types.map((t) => (
+              <tr
+                key={t.water_type}
+                className="border-b border-slate-100 dark:border-slate-800"
+              >
+                <td className="py-1 text-slate-700 dark:text-slate-300">
+                  {t.water_type}
+                  {t.potable && (
+                    <span className="ml-2 text-[10px] uppercase tracking-wide text-blue-600 dark:text-blue-400">
+                      drinking
+                    </span>
+                  )}
+                </td>
+                <td className="py-1 text-right text-slate-700 dark:text-slate-300 tabular-nums">
+                  {t.rate_inr_per_kl ?? "-"}
+                </td>
+                <td className="py-1 text-right text-slate-500 tabular-nums">{ml(t.litres)}</td>
+                <td className="py-1 text-right text-slate-500 tabular-nums">
+                  {nf.format(t.bookings)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* Who buys it. */}
+      <section className="rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          Who buys it
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          The three largest buyers alone took{" "}
+          {((top3 / totals.litres) * 100).toFixed(1)}% of everything sold. This
+          is a bulk market of developers, contractors and industry, not a
+          household one - GMDA sells tanker water to construction sites and
+          factories, and the publisher names them.
+        </p>
+        <table className="w-full text-xs mt-3">
+          <thead>
+            <tr className="text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+              <th className="text-left font-medium py-1">Buyer</th>
+              <th className="text-right font-medium py-1">Volume</th>
+              <th className="text-right font-medium py-1">Share</th>
+              <th className="text-right font-medium py-1">Potable</th>
+            </tr>
+          </thead>
+          <tbody>
+            {top_buyers.map((b) => (
+              <tr key={b.buyer} className="border-b border-slate-100 dark:border-slate-800">
+                <td className="py-1 text-slate-700 dark:text-slate-300">{b.buyer}</td>
+                <td className="py-1 text-right text-slate-700 dark:text-slate-300 tabular-nums">
+                  {ml(b.litres)}
+                </td>
+                <td className="py-1 text-right text-slate-500 tabular-nums">
+                  {b.share_pct ?? "-"}%
+                </td>
+                <td className="py-1 text-right text-slate-500 tabular-nums">
+                  {b.potable_pct ?? "-"}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* Dispensing points. */}
+      <section className="rounded-lg border border-slate-200 dark:border-slate-700 p-4">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200">
+          Where it is dispensed
+        </h2>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          Two of these are water works and boosting stations; the rest are
+          sewage and effluent treatment plants selling their output. Points
+          that stopped reporting are marked, rather than smoothed away.
+        </p>
+        <table className="w-full text-xs mt-3">
+          <thead>
+            <tr className="text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+              <th className="text-left font-medium py-1">Dispensing point</th>
+              <th className="text-right font-medium py-1">Volume</th>
+              <th className="text-right font-medium py-1">Years active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stations.map((s) => (
+              <tr key={s.station} className="border-b border-slate-100 dark:border-slate-800">
+                <td className="py-1 text-slate-700 dark:text-slate-300">
+                  {s.station}
+                  {!s.active_all_years && (
+                    <span className="ml-2 text-[10px] text-amber-700 dark:text-amber-500">
+                      stopped reporting
+                    </span>
+                  )}
+                </td>
+                <td className="py-1 text-right text-slate-700 dark:text-slate-300 tabular-nums">
+                  {ml(s.litres)}
+                </td>
+                <td className="py-1 text-right text-slate-500 tabular-nums">
+                  {s.years.join(", ")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* Honest gaps. */}
+      <section className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50/40 dark:bg-slate-900/40 p-4 space-y-2 text-xs text-slate-600 dark:text-slate-400 leading-relaxed">
+        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+          What this data does not tell you
+        </h2>
+        <p>{sales._coverage_gap}</p>
+        {sales._caveats.map((c) => (
+          <p key={c.slice(0, 40)}>{c}</p>
+        ))}
+        <p>
+          It also covers only what GMDA itself sold. Gurugram has a private
+          tanker market alongside this one, and no public record of it exists -
+          so this is the floor on tanker dependence, not the total.
+        </p>
+        <p className="pt-1 text-[11px]">
+          Source:{" "}
+          <a
+            href={sales._source_url}
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {sales._source}
+          </a>{" "}
+          · fetched {sales._fetched} · aggregated on build, not republished
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/layout/feature-not-yet-available.tsx
+++ b/src/components/layout/feature-not-yet-available.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { PlaceConfig } from "@/lib/cities";
+import { isFeatureSupportedForCity } from "@/lib/cities/routing";
 
 export type FeatureScope =
   | "city-admin"
@@ -47,6 +48,22 @@ export function FeatureNotYetAvailable({
   parityVerdict,
   relatedLinks,
 }: FeatureNotYetAvailableProps) {
+  // Callers hardcode their cross-links, and for most cities every target is
+  // live so nothing showed. Gurugram is the first city where they are not:
+  // its flood-risk page offered a "Groundwater stress map" and its
+  // climate-risk page offered "Flood risk", both of which are themselves
+  // not-yet-available pages. A heading that says "What's live now" must not
+  // link to something that is not.
+  //
+  // Filtered here rather than in the six callers so no future caller has to
+  // remember. The city home is always kept - it is live by definition for any
+  // registered city.
+  const liveLinks = (relatedLinks ?? []).filter((link) => {
+    const feature = link.href.replace(`/${config.cityId}`, "");
+    if (!feature || feature === "/") return true;
+    return isFeatureSupportedForCity(feature, config.cityId);
+  });
+
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
       <div className="flex flex-wrap items-center gap-2 mb-4">
@@ -89,13 +106,13 @@ export function FeatureNotYetAvailable({
         </Card>
       )}
 
-      {relatedLinks && relatedLinks.length > 0 && (
+      {liveLinks.length > 0 && (
         <div>
           <div className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400 font-semibold mb-2">
             What&apos;s live now for {config.displayName}
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {relatedLinks.map((link) => (
+            {liveLinks.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -46,6 +46,16 @@ const CITY_FOOTER_SOURCES: Record<
     { label: "IN-GRES", href: "https://ingres.iith.ac.in/" },
     { label: "OpenCity", href: "https://data.opencity.in/" },
   ],
+  kolkata: [
+    { label: "KMC", href: "https://www.kmcgov.in/" },
+    { label: "WBPCB EMIS", href: "https://emis.wbpcb.gov.in/" },
+    { label: "IN-GRES", href: "https://ingres.iith.ac.in/" },
+  ],
+  gurugram: [
+    { label: "GMDA", href: "https://www.gmda.gov.in/" },
+    { label: "GMDA OneMap", href: "https://onemapdepts.gmda.gov.in/" },
+    { label: "HSPCB", href: "https://hspcb.gov.in/" },
+  ],
 };
 
 export function Footer() {
@@ -59,7 +69,12 @@ export function Footer() {
   }
 
   const { cityId } = parsePath(pathname);
-  const sources = CITY_FOOTER_SOURCES[cityId] ?? CITY_FOOTER_SOURCES.chennai;
+  // Fall back to NOTHING, not to Chennai. The old `?? CITY_FOOTER_SOURCES.chennai`
+  // meant any city missing from the map above told its readers that CMWSSB -
+  // Chennai's utility - was one of their core live sources. Kolkata shipped
+  // live that way, and Gurugram would have. A city with no entry now renders
+  // no source list, which is merely incomplete rather than false.
+  const sources = CITY_FOOTER_SOURCES[cityId] ?? [];
   const aboutHref = cityId === "chennai" ? "/about#data-sources" : `/${cityId}/about#data-sources`;
 
   return (
@@ -67,7 +82,9 @@ export function Footer() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-500 dark:text-slate-400">
           <div>
-            {t("footer.data_sources")}{" "}
+            {/* Label only when there is a list to label - an empty city would
+                otherwise render "Core live sources:" followed by nothing. */}
+            {sources.length > 0 && <>{t("footer.data_sources")}{" "}</>}
             {sources.map((s, i) => (
               <span key={s.label}>
                 {i > 0 && " - "}
@@ -81,7 +98,7 @@ export function Footer() {
                 </a>
               </span>
             ))}
-            {" - "}
+            {sources.length > 0 && " - "}
             <a
               href={aboutHref}
               className="text-blue-600 dark:text-blue-400 hover:underline"

--- a/src/lib/cities/gurugram.ts
+++ b/src/lib/cities/gurugram.ts
@@ -1,0 +1,141 @@
+import type { CityConfig } from './types';
+
+// Gurugram, city nine. PREVIEW-GATED: `enabled: false` keeps it out of
+// listEnabledPlaces(), the [cityId] route guard, the switcher and the nav
+// until the surfaces below are actually worth reading. Reach it with
+// NEXT_PUBLIC_PREVIEW_CITIES=gurugram.
+//
+// Plan and source verification: docs/specs/gurugram-onboarding.md (local).
+// Data acquisition landed in neer-vazhvu#264; this file is the config that
+// points the shared surfaces at it.
+//
+// WHAT KIND OF CITY THIS IS, because it drives every value below. Gurugram
+// has no river, no reservoir and no storage of its own. Water arrives by
+// canal from the Yamuna, by borewell (GMDA maps 524 municipal tubewells),
+// and by tanker. The Central Ground Water Authority declared it a dark zone
+// in 2008 and extraction has continued since. So the reservoir machinery
+// that anchors Chennai, Mumbai and Hyderabad has nothing to render here, and
+// saying that plainly is better than a hero with no numbers behind it.
+//
+// AUTHORITY SPLIT. GMDA is the metropolitan authority that runs bulk supply,
+// the WTPs and the tanker fleet; MCG is the municipal corporation with the
+// 36 wards. primaryAuthority is therefore GMDA and localGovernment is MCG -
+// the same shape as Hyderabad's HMWSSB-over-GHMC, and NOT the MMR region
+// model: there is one water utility here, not nine competing ones.
+//
+// HERO: 'none', deliberately, and this is the honest call rather than a
+// placeholder. 'cauvery-pumping' is the right eventual mode - its own
+// docstring describes "pumped from a long way away + local groundwater +
+// tankers", which is a literal description of Gurugram - but it renders
+// engineering-document numbers from a <cityId>-supply-overview.json that
+// does not exist yet. Every supply and demand figure in circulation for
+// this city (570 MLD supplied, 675-700 MLD peak demand, extraction at 195%
+// of recharge) is press-sourced, and the one primary contradiction found so
+// far cuts against them: GMDA's own GIS publishes Chandu Budhera at 300 MLD
+// and Basai at 272, against the widely-quoted 400 and 270. Shipping a hero
+// on unverified numbers would be worse than shipping none.
+export const GURUGRAM: CityConfig = {
+  cityId: 'gurugram',
+  displayName: 'Gurugram',
+  displayNameLocalized: { hi: 'गुरुग्राम' },
+  stateCode: 'HR',
+  timezone: 'Asia/Kolkata',
+  // Centre and bbox are COMPUTED from the harvested MCG ward geometry
+  // (public/geojson/gurugram-wards-2026.geojson), not looked up: the wards
+  // span 76.9351-77.1762 E, 28.3306-28.5415 N. Padded west and south to
+  // cover the GMDA metropolitan area, because the water-body register
+  // legitimately reaches to 76.66 E / 28.21 N - out past Farrukhnagar and
+  // Sohna, well beyond the corporation. The map should show the water
+  // system, not the municipal boundary.
+  center: { lat: 28.436, lng: 77.056 },
+  bbox: { south: 28.2, north: 28.56, west: 76.64, east: 77.25 },
+  primaryAuthority: {
+    code: 'gmda',
+    name: 'Gurugram Metropolitan Development Authority',
+    acronym: 'GMDA',
+  },
+  localGovernment: {
+    code: 'mcg',
+    name: 'Municipal Corporation of Gurugram',
+    acronym: 'MCG',
+    // 36, counted from GMDA OneMap's own MCG_Wards_Boundary layer rather
+    // than taken from a news figure. The layer carries ward_no 1-36 and a
+    // zone code, and publishes no ward NAME - so ward surfaces here can
+    // label by number and zone only.
+    wardCount: 36,
+  },
+  // Hindi, already in LanguageCode from Delhi - so unlike Surat's Gujarati
+  // this city adds no new-language cost. Shipping English-first with hi
+  // advertised as upcoming, the same posture as Kannada and Marathi.
+  availableLanguages: ['en'],
+  upcomingLanguages: ['hi'],
+  // No reservoirs, no storage, nothing to impound. The empty array is the
+  // point rather than an omission.
+  waterSources: [],
+  sourceNameAliases: {},
+  defaultConsumptionMld: null,
+  defaultDesalinationMld: null,
+  heroMode: 'none',
+  // Says WHY there is no storage history instead of promising one will
+  // appear. Gurugram impounds nothing: there is no dam to publish a level
+  // for, so this is a permanent property of the city, not a backfill gap.
+  reservoirHistoryAbsentNote:
+    'Gurugram impounds no water of its own. It has no reservoir and no dam, so no storage series exists to chart - here or anywhere else. Its supply is canal water from the Yamuna, groundwater from municipal tubewells, and tankers.',
+  // The tanker page. THIRD kind: not Bengaluru's household price survey and
+  // not Hyderabad's booking/delivery ledger. See tankerDataKind in types.ts
+  // for why the three cannot share a renderer.
+  tankerDataKind: 'utility-sales-ledger',
+  tankerSummary:
+    "GMDA's own bulk-water sales ledger - every tanker load it sold, to whom, and at what price.",
+  waterBodies: {
+    // OFF: needs the Supabase water_bodies_census table, which is a
+    // different dataset from GMDA's register.
+    censusSource: false,
+    // OFF: no restoration-priority-gurugram.json yet.
+    rankingTab: false,
+    // OFF: needs gurugram-ward-profiles.json. The ward GEOMETRY exists (36
+    // polygons) but nothing is joined to it yet.
+    wardSearch: false,
+    // OFF, and this one needs stating carefully rather than being read as a
+    // backfill gap. GMDA's register carries its own cross-survey flags per
+    // waterbody (ror/soi/wv_12/drone/ge), so 283 of 824 bodies match a 1956
+    // revenue-record plot and 29 of those are absent from WorldView 2012.
+    // That is a genuine lost-bodies signal AND it is the publisher's own
+    // attribution rather than a spatial join of ours. It stays off only
+    // until it is rendered as a derived layer; what must never ship is the
+    // raw count series 640 (1956) -> 519 (1976) -> 824 (2012), which RISES
+    // at the end because three survey methods have three inclusion criteria.
+    lostBodies: false,
+  },
+  groundwaterViews: {
+    // ALL OFF at preview, and the reason is the uncomfortable one: the
+    // signature issue is the thinnest data. Gurugram's WRIS groundwater
+    // LEVEL record is 37 stations that stop in June 2020, and the city has
+    // no WRIS telemetry at all - the Haryana telemetry exports cover 14
+    // districts and Gurugram is not one of them. 37 stations over 36 wards
+    // would not carry honest per-ward interpolation even if they were
+    // current.
+    exploitation: false,
+    depth: false,
+    risk: false,
+    cgwbStations: false,
+    gapNote:
+      'Gurugram is a Central Ground Water Authority dark zone, declared in 2008, and it is also the city on this platform with the weakest published groundwater record. The India-WRIS level series covers 37 stations and stops in June 2020; the Haryana telemetry network does not include this district at all. The current picture has to come from IN-GRES block assessment and the state pollution board’s 2016-2024 water-quality series instead, and neither is wired up yet.',
+  },
+  // OFF because the pipeline has not run here, NOT because Gurugram cannot
+  // support it - GMDA's own GIS carries a 10-polygon Watershed_Gurugram layer
+  // and a natural-flow-direction layer, and the Aravalli gives real relief to
+  // delineate against. So no catchmentsGapNote: that field is for cities where
+  // the view is impossible (Kolkata's 11 m of relief across 40 km of delta),
+  // and claiming a reason here would be inventing one.
+  //
+  // Worth recording for whoever builds it: Aravalli johads and village ponds
+  // are a real water heritage but they are NOT a tank cascade. No
+  // chained-surplus system was engineered here the way it was in the Tamil
+  // kanmoi districts or the Bengaluru kere chains, so the cascade narrative
+  // must not be told about this city even once the catchment layer exists.
+  hasCascadeOverlay: false,
+  // Landlocked.
+  hasShoreline: false,
+  enabled: false,
+};

--- a/src/lib/cities/index.ts
+++ b/src/lib/cities/index.ts
@@ -1,6 +1,7 @@
 import { BANGALORE } from './bangalore';
 import { CHENNAI } from './chennai';
 import { DELHI } from './delhi';
+import { GURUGRAM } from './gurugram';
 import { HYDERABAD } from './hyderabad';
 import { KOLKATA } from './kolkata';
 import { MADURAI } from './madurai';
@@ -8,7 +9,7 @@ import { MUMBAI } from './mumbai';
 import type { PlaceConfig } from './types';
 
 export * from './types';
-export { BANGALORE, CHENNAI, DELHI, HYDERABAD, KOLKATA, MADURAI, MUMBAI };
+export { BANGALORE, CHENNAI, DELHI, GURUGRAM, HYDERABAD, KOLKATA, MADURAI, MUMBAI };
 
 // Registry contains every known city, enabled or not. Disabled cities
 // (config.enabled === false) are usable internally for scaffolding but
@@ -23,6 +24,7 @@ const REGISTRY: Record<string, PlaceConfig> = {
   [DELHI.cityId]: DELHI,
   [HYDERABAD.cityId]: HYDERABAD,
   [KOLKATA.cityId]: KOLKATA,
+  [GURUGRAM.cityId]: GURUGRAM,
 };
 
 export const DEFAULT_CITY_ID = CHENNAI.cityId;

--- a/src/lib/cities/routing.ts
+++ b/src/lib/cities/routing.ts
@@ -150,6 +150,21 @@ export const FEATURE_AVAILABILITY: Record<string, Set<string>> = {
     "allocations",
     "commitments",
   ]),
+  // Gurugram preview set, deliberately small. Only the surfaces with data
+  // behind them are listed: the tanker sales ledger, the water-body register
+  // and the ward map. No `groundwater` - the signature issue is the thinnest
+  // data (37 WRIS stations ending June 2020, no telemetry) and an empty
+  // groundwater page on a dark-zone city would read as a bug rather than as
+  // the gap it is. No `rivers`, because Gurugram has no river. Features fill
+  // in as their artifacts land; this set drives nav while the city is
+  // preview-gated (NEXT_PUBLIC_PREVIEW_CITIES=gurugram).
+  gurugram: new Set([
+    "",
+    "about",
+    "water-bodies",
+    "my-ward",
+    "tanker",
+  ]),
 };
 
 /**

--- a/src/lib/cities/types.ts
+++ b/src/lib/cities/types.ts
@@ -382,15 +382,27 @@ export interface BasePlaceConfig {
    *  the river stations downstream. Reads `<cityId>-stps.json`. Omit -> hidden. */
   hasTreatmentDischarge?: boolean;
 
-  /** Which KIND of tanker data this city has. The two are not
-   *  interchangeable and must not share a renderer:
+  /** Which KIND of tanker data this city has. The three are not
+   *  interchangeable and must not share a renderer - they answer different
+   *  questions off different evidence:
    *  - `household-survey` (default, Bengaluru): longitudinal price surveys of
-   *    what households pay a private market. Reads
+   *    what households pay a private market. Sampled, demand-side. Reads
    *    `<cityId>-tanker-survey.json`.
    *  - `utility-ledger` (Hyderabad): the utility's own booking/delivery
    *    record, because HMWSSB runs the fleet itself. No prices exist in it.
-   *    Reads `<cityId>-tankers.json`. */
-  tankerDataKind?: 'household-survey' | 'utility-ledger';
+   *    Reads `<cityId>-tankers.json`.
+   *  - `utility-sales-ledger` (Gurugram): the utility's own SALES record -
+   *    every tanker load GMDA sold, from which dispensing point, of which
+   *    water grade, to which named buyer, at which tariff. A census of
+   *    priced transactions. There is no delivery confirmation to measure
+   *    because a booking here IS a collection, and no ward or section unit
+   *    because the analytical dimensions are station, water type and buyer.
+   *    Reads `<cityId>-tanker-sales.json`.
+   *
+   *  Adding a fourth kind is cheaper than bending one of these: forcing a
+   *  city through the wrong panel means making its required fields optional
+   *  and gutting its copy, which damages the city the panel was written for. */
+  tankerDataKind?: 'household-survey' | 'utility-ledger' | 'utility-sales-ledger';
 
   /** One-line description of what this city's tanker page actually shows.
    *  The shape of tanker data differs fundamentally by city - Bangalore has


### PR DESCRIPTION
Now based on **main** (#264 merged as `c6ed90be`). Registers Gurugram as city nine, points the shared surfaces at the artifacts #264 acquired, and fixes three rendering defects the UI sweep turned up — **one of which is live on main right now**.

Preview-gated (`enabled: false`); nothing is user-visible without `NEXT_PUBLIC_PREVIEW_CITIES=gurugram`.

## Part 1 — the city

`about`, `water-bodies`, `my-ward`, `tanker` turn on. Every route that stays off carries a recorded reason in `scripts/lib/exemptions.ts`, and the two most conspicuous absences are properties of the city rather than backlog: **Gurugram has no river**, and its **groundwater record is the thinnest on the platform** despite groundwater being its signature issue (37 WRIS stations ending June 2020; the Haryana telemetry network does not cover the district at all).

`heroMode: 'none'` is the honest call, not a placeholder. `cauvery-pumping` is the right eventual mode, but it renders numbers from a `supply-overview` artifact that does not exist, and every supply figure in circulation for Gurugram is press-sourced — GMDA's own GIS already contradicts two of them (Chandu Budhera 300 MLD and Basai 272, against the quoted 400/270).

**Tanker is a third `tankerDataKind`**, not a variant. The contract already says the kinds must not share a renderer, and `utility-ledger` says plainly "No prices exist in it". Gurugram has prices, no delivery confirmation (a booking IS a collection), and stations rather than sections. The route, page shell and `FEATURE_AVAILABILITY` slot are reused unchanged; only the panel is new, and it leads on the composition shift (29.7% → 42.2% → 51.2% non-potable) rather than volume, because the volume trend is confounded by COVID in a construction-driven market.

Rainfall is exempted with its removal condition written in, and Gurugram is deliberately kept OUT of `CITIES` in `fetch_recent_rainfall.py` — the daily workflow runs `--all`, which exits non-zero if any one city fails, so adding the grid point before the IMD base exists would turn that job red every day for every city.

## Part 2 — three defects the sweep found

Swept all live routes across Gurugram plus Hyderabad and Bangalore as controls, per the route-matrix method: probe every city × route pair rather than following nav links, poll until `innerText` stops growing, and require a control that would fail if the working case broke.

**1. The footer advertised Chennai's utility to other cities.** `CITY_FOOTER_SOURCES` fell back to `?? CITY_FOOTER_SOURCES.chennai`, so any city missing from the map told its readers CMWSSB was one of their core live sources. **Kolkata is live and shipped this way.** Added entries for Kolkata and Gurugram, and changed the fallback to render nothing — incomplete rather than false. Controls: Hyderabad still HMWSSB, Bangalore BWSSB, Chennai CMWSSB.

**2. The rivers page promised a page Gurugram can never have.** It fell through to the generic not-yet-available state, which says the page "hasn't shipped yet" and lists what's needed to ship it. Gated on `FEATURE_AVAILABILITY`, the same gate `my-ward` uses. Same class as Delhi's storage chart promising to "fill in automatically" for a city that impounds nothing. Controls: rivers still 200 on Chennai, Hyderabad, Bangalore, Kolkata.

**3. "What's live now" linked to pages that were not live.** Callers hardcode cross-links and every earlier city's targets happened to be live. Gurugram's flood-risk page offered a "Groundwater stress map" and climate-risk offered "Flood risk", both themselves empty states. Filtered inside the shared component, so no future caller has to remember. Control: Gurugram's lake-restoration page still offers "Water bodies map", which IS live, and both control cities are unchanged.

All three are one failure mode — **a per-city map not derived from the registry, silently falling back to Chennai** — which is the same shape as the `CITY_HOOKS` bug the Hyderabad cutover surfaced. `CITY_HOOKS` itself was also missing Gurugram and is fixed here.

**If you'd rather the Kolkata footer fix landed independently of Gurugram, say so and I'll split it into its own PR against main.**

## Verification

Post-fix sweep: 40 live routes, Gurugram down from 12 to 11 (rivers now correctly 404s), controls unchanged at 14 and 15, zero real findings. Three false findings were caught by the controls before being reported — a broken local install that made every page look empty, the word "null" in prose on Hyderabad's tanker page, and a page-wide grep that flagged an already-correct control.

Gates: eslint 0 errors, tsc 0, 83 frontend tests, `npm run data:check` including the freshness and exemption registers, `ruff check`, `ruff format --check`, 152 API tests.
