### PR TITLE
Restoration Priority: a crash, an empty table, and a second crash behind it

### DIFF
--- a/src/components/lake-restoration/restoration-ranking-table.tsx
+++ b/src/components/lake-restoration/restoration-ranking-table.tsx
@@ -50,7 +50,7 @@ export function RestorationRankingTable({ data, onSelect }: RestorationRankingTa
         arr.sort((a, b) => b.priority_score - a.priority_score);
         break;
       case "area":
-        arr.sort((a, b) => b.area_ha - a.area_ha);
+        arr.sort((a, b) => (b.area_ha ?? -1) - (a.area_ha ?? -1));
         break;
       case "name":
         arr.sort((a, b) => {
@@ -63,10 +63,18 @@ export function RestorationRankingTable({ data, onSelect }: RestorationRankingTa
     return arr;
   }, [data, sortBy, language]);
 
-  // Show only critical + high by default
-  const displayed = showAll
-    ? sorted
-    : sorted.filter((wb) => wb.priority_level === "critical" || wb.priority_level === "high");
+  // Show only critical + high by default, because in most cities that is the
+  // actionable shortlist and the full register is long.
+  //
+  // But fall back to the whole list when that shortlist is EMPTY. Hyderabad
+  // scores nothing critical or high - its worst body, Mir Alam Tank, sits at
+  // 52 - so the default filter rendered an empty table reading "0 / 14
+  // scored", which looks broken rather than like a city doing comparatively
+  // well. A table that knows it has 14 rows must never show zero.
+  const urgent = sorted.filter(
+    (wb) => wb.priority_level === "critical" || wb.priority_level === "high",
+  );
+  const displayed = showAll || urgent.length === 0 ? sorted : urgent;
 
   const getName = (wb: ScoredWaterBody) => {
     if (language === "ta") {
@@ -124,7 +132,7 @@ export function RestorationRankingTable({ data, onSelect }: RestorationRankingTa
                     {wb.water_type}
                   </td>
                   <td className="px-4 py-2 text-sm text-slate-600 dark:text-slate-300 text-right font-mono tabular-nums">
-                    {wb.area_ha.toLocaleString()}
+                    {wb.area_ha != null ? wb.area_ha.toLocaleString() : "-"}
                   </td>
                   <td className="px-4 py-2 text-sm text-right font-bold font-mono tabular-nums" style={{ color }}>
                     {wb.priority_score}
@@ -159,7 +167,7 @@ export function RestorationRankingTable({ data, onSelect }: RestorationRankingTa
                       </span>
                     </div>
                     <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                      {wb.water_type} - {wb.area_ha.toLocaleString()} ha
+                      {wb.water_type}{wb.area_ha != null ? ` - ${wb.area_ha.toLocaleString()} ha` : ""}
                     </div>
                   </div>
                   <div className="flex items-center gap-2">

--- a/src/components/water-bodies/unified-map.tsx
+++ b/src/components/water-bodies/unified-map.tsx
@@ -145,8 +145,23 @@ export function UnifiedMap({
   // on the map if we draw an explicit Circle for each. Render in a
   // dedicated high-z pane so they sit above polygons and stay
   // clickable.
+  // A scored body needs a CENTROID to be drawn as a Circle: Leaflet resolves
+  // `center` through L.latLng(), which throws "Cannot read properties of null
+  // (reading 'lng')" on a null and takes the whole Restoration Priority view
+  // down with it. Hyderabad is the first city to carry any - Ramanthapur and
+  // Nacharam Pedda Cheruvu are scored off the HMDA register but never matched
+  // to a polygon, so the producer left the centroid null rather than inventing
+  // one. Every other city has zero.
+  //
+  // These are DROPPED FROM THE MAP ONLY. They keep their score and stay in the
+  // ranking table, which reads restorationData directly - a body we cannot
+  // place is still a body we ranked, and silently deleting it would be worse
+  // than not drawing it.
   const orphanScored = useMemo(
-    () => scoredData.filter((wb) => wb.osm_id == null && wb.census_id == null),
+    () =>
+      scoredData.filter(
+        (wb) => wb.osm_id == null && wb.census_id == null && wb.centroid != null,
+      ),
     [scoredData],
   );
 


### PR DESCRIPTION
One report, three defects, each hidden by the one in front of it. Found by clicking, which is how it should have been found the first time.

## 1. The crash

`unified-map` draws a `Circle` for every scored body that has no polygon. Leaflet resolves `center` through `L.latLng()`, which throws on a null:

```
Cannot read properties of null (reading 'lng')
```

Hyderabad is the first city to carry a null centroid. Ramanthapur Pedda Cheruvu and Nacharam Pedda Cheruvu are scored off the HMDA register but were never matched to a polygon, so the producer left the coordinate null rather than inventing one. Every other city has zero.

They are now dropped from **the map only**. They keep their score and their row in the table, because a body we cannot place is still a body we ranked, and silently deleting it would be worse than not drawing it.

## 2. The empty table

With the crash gone, the ranking table read **"0 / 14 scored"**.

It defaults to critical + high, which is the right shortlist for most cities. Hyderabad has neither: its worst body, Mir Alam Tank, scores 52. So the default filter matched nothing and the table looked broken rather than like a city doing comparatively well.

An empty shortlist now falls back to the full list. A table that knows it holds 14 rows must never render zero.

## 3. The second crash

Rendering those previously-hidden rows immediately hit `area_ha.toLocaleString()` on a null. Guarded, along with the area sort, where nulls were producing `NaN` comparisons and scattering rows unpredictably.

**This third one is not Hyderabad-specific and is the reason I would merge this even without the report.** Bangalore has six null-area bodies and five of them are critical or high, so they render by default. It is invisible today only because Bangalore does not set `waterBodies.rankingTab`. Turning that flag on would have crashed the page. Chennai, the only other city with the tab enabled, has no nulls at all, which is why nobody has hit this yet.

## Verified

Clicked every view mode on all five cities carrying restoration data, in a real browser:

| city | Restoration Priority | Ranking Table | Lake register | Catchments |
|---|---|---|---|---|
| Hyderabad | clean | clean | clean | - |
| Chennai | clean | clean | - | - |
| Bangalore | clean | - | - | clean |
| Mumbai | clean | - | - | clean |
| Madurai | clean | - | - | clean |

All 14 Hyderabad bodies now list, including the two without coordinates. Build, lint (0 errors), 83 frontend tests, API ruff and 152 pytest all pass.

## The pattern worth naming

This is the third bug in a week where a shared component assumed a data shape that held for the first five cities and broke on the sixth. Ranges instead of point values, a lying type, and now nulls where there had never been nulls. Onboarding a city is as much a test of the components as of the data, and the only reliable way to run that test is to click every surface.