### PR TITLE
fix(basins): the flow-duration curve went blank on rivers that run dry

### DIFF
--- a/src/components/basin/station-readings-panel.tsx
+++ b/src/components/basin/station-readings-panel.tsx
@@ -170,12 +170,24 @@ function SeriesChart({ s, isDark }: { s: ReadingsSeries; isDark: boolean }) {
 
     case "flow-duration": {
       const data = (s.exceedance ?? []).map(([pct, v]) => ({ pct, v }));
+      // A log axis cannot hold a zero, and recharts does not degrade: given a
+      // domain containing 0 it draws no ticks and no line, so the chart comes
+      // out blank under a caption still claiming N values. Rivers that run dry
+      // are exactly the ones worth plotting - T. Narasipur reads 0 cumec at the
+      // 95th and 99th percentile - so fall back to a linear axis whenever the
+      // series touches zero, and keep log for the perennial stations where it
+      // earns its keep across three orders of magnitude.
+      const positive = data.every((d) => Number.isFinite(d.v) && d.v > 0);
       return (
         <ResponsiveContainer width="100%" height={150}>
           <LineChart data={data} margin={{ top: 6, right: 6, bottom: 0, left: -18 }}>
             <CartesianGrid strokeDasharray="3 3" stroke={grid} />
             <XAxis dataKey="pct" tick={tickStyle} unit="%" type="number" domain={[0, 100]} />
-            <YAxis tick={tickStyle} width={54} scale="log" domain={["auto", "auto"]} allowDataOverflow />
+            {positive ? (
+              <YAxis tick={tickStyle} width={54} scale="log" domain={["auto", "auto"]} allowDataOverflow />
+            ) : (
+              <YAxis tick={tickStyle} width={54} />
+            )}
             <Tooltip contentStyle={tooltipStyle} labelFormatter={(v) => `exceeded ${v}% of days`} />
             <Line type="monotone" dataKey="v" stroke="#0d9488" strokeWidth={1.5} dot={false} name={s.unit ?? ""} />
           </LineChart>


### PR DESCRIPTION
Found while click-testing the Kabini atlas on production after #255 went live.

Clicking T. Narasipur gives five charts and one empty box. The flow-duration curve draws no line and no y-axis, under a caption still reading "Exceedance of 2990 daily values, 2015-2026" - the chart asserts a record it is not showing.

## Cause

The y-axis was `scale="log"`, and T. Narasipur reads **0 cumec at the 95th and 99th percentile**. A log axis cannot hold a zero, and recharts does not degrade: given a domain containing one it renders no ticks and no line, and reports no error.

That is why nothing caught it. Hommaragalli's minimum is 2.94, so its curve drew fine throughout - the failure needs a river that actually stops flowing, and only one of the two gauges does. No test, no lint rule and no CI job looks at whether a chart drew anything.

## Fix

Fall back to a linear axis when the series touches zero; keep log for perennial stations where three orders of magnitude earn it. The zero is the point - a Kabini reading no flow 5% of the year is the finding, not a rendering edge case to paper over, so the linear axis shows it rather than clamping it to some epsilon.

## Verification

Driven in a real browser against the real readings pack, counting rendered SVG rather than eyeballing it:

| station | exceedance min | chart 4 before | chart 4 after |
|---|---|---|---|
| T. Narasipur | 0.0 (95th, 99th pct) | 0 lines, 0 y-ticks | 1 line, 5 y-ticks |
| Hommaragalli | 2.94 | 1 line, 6 y-ticks | unchanged |

Gate: lint 0 errors, tsc clean, 83/83 tests, build, data:check, and the three generated docs regenerate with no drift.

It is the only `scale="log"` axis in the codebase, so nothing else carries this hazard today.