### PR TITLE
Kabini PRS: Arkavathi's fields, not a second vocabulary

### DIFF
--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -4824,7 +4824,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "prs",
-   "bytes": 37319,
+   "bytes": 37082,
    "schema": {
     "kind": "object",
     "keys": [
@@ -24356,7 +24356,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 131570,
+   "bytes": 131333,
    "schema_variants": 4,
    "registered": true,
    "has_consumer": true

--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -4824,7 +4824,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "prs",
-   "bytes": 31622,
+   "bytes": 37319,
    "schema": {
     "kind": "object",
     "keys": [
@@ -4832,6 +4832,7 @@
      "citeSource",
      "dataset",
      "epochs",
+     "evidence",
      "governance",
      "grievance",
      "growthNote",
@@ -24355,7 +24356,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 125873,
+   "bytes": 131570,
    "schema_variants": 4,
    "registered": true,
    "has_consumer": true

--- a/public/data/basins/kabini/prs.json
+++ b/public/data/basins/kabini/prs.json
@@ -107,9 +107,8 @@
   "tabs": [
     {
       "key": "sewage",
-      "label": "Sewage from the towns on the stretch",
+      "label": "Sewage",
       "status": "built",
-      "scope": "stretch",
       "subtabKind": "units",
       "unitLabel": "MLD",
       "treatedVerb": "treated",
@@ -143,7 +142,8 @@
           ],
           "capacity": "None. No sewerage network, and no facility marked as planned in the plan's STP-requirement table.",
           "gapValue": 1.2339,
-          "gapNote": "the whole of it, on the plan's own arithmetic"
+          "gapNote": "the whole of it, on the plan's own arithmetic",
+          "dashboard": "No public dashboard reported"
         },
         {
           "key": "nanjangud",
@@ -187,8 +187,14 @@
               "label": "8 MLD SBT upgrade at Goluru",
               "status": "Consent to establish 31/07/2025; operational and complying, April 2026 annexure",
               "tone": "good"
+            },
+            {
+              "label": "Rs 80 crore restoration cost (action plan, section 6 and Table-3)",
+              "status": "Rs 2.5 crore per MLD of capital cost for primary, secondary and tertiary treatment, asked for as Rs 80 crore of budgetary provision: Rs 1.18 crore a year of O&M for the existing 7 MLD STP plus Rs 78.82 crore for UGD to the 60% of the town still uncovered and house connections for the whole of it. Every rupee is Nanjangud - Sargur and T. Narasipura, both on the 2025 stretch, are not costed - and the table is headed 'Cost Component involved in the Rejuvenation of Polluted Stretch of Bhadra', another river's name left in the Kabini plan.",
+              "tone": "bad"
             }
-          ]
+          ],
+          "dashboard": "No public dashboard reported"
         },
         {
           "key": "tn-pura",
@@ -207,54 +213,8 @@
           ],
           "generationNote": "The plan's own figure for the town; UGD covers 50% of its area.",
           "treated": [],
-          "capacity": "5.5 MLD per pp.57 and 60; 0 MLD per the p.59 table."
-        }
-      ]
-    },
-    {
-      "key": "water-quality",
-      "label": "Water quality along the stretch",
-      "status": "built",
-      "scope": "stretch",
-      "subtabKind": "categories",
-      "source": "CPCB, Polluted River Stretches for Restoration of Water Quality 2025 (October 2025), pp.48, 77 and 144; KSPCB Action Plan for Rejuvenation of River Kabini, Table-2",
-      "intro": "Five CPCB stations sit on the 2025 stretch. Their BOD readings are what set the Priority band - and they place the worst reading at the downstream end, where T. Narasipura draws its water.",
-      "summaryBadge": "worst at intake",
-      "summaryLine": "BOD rises down the stretch to 6 mg/L at the T. Narasipura water-supply intake, in both rounds",
-      "summaryTone": "bad",
-      "categories": [
-        {
-          "key": "stations-2024",
-          "label": "The five stations, 2022-23 and 2024",
-          "level": "monitoring station",
-          "layerRef": "monitoring-points",
-          "body": "Maximum BOD observed, in mg/L. The 3 mg/L line is the Primary Water Quality Criteria for Bathing Water; every station on the stretch is above it in both rounds.",
-          "points": [
-            "Kabini at Saragur village D/S - 4.0 (2022-23), 4.0 (2024)",
-            "Kabini at causeway, Sattur - 4.0 (2022-23), 3.5 (2024)",
-            "Kabini u/s intake point to Nanjangud & Gundlupet at Debur - 3.5 (2022-23), 3.8 (2024)",
-            "Kabini at bathing ghat, Nanjangud - 4.5 (2022-23), 5.0 (2024)",
-            "Kabini at water-supply intake point to T. Narasipura - 6.0 (2022-23), 6.0 (2024)"
-          ]
-        },
-        {
-          "key": "classes-2017-18",
-          "label": "What the board recorded before the stretch was redrawn",
-          "level": "monitoring station",
-          "body": "The action plan's own Table-2 covers just two stations for 2017 and 2018, and reads the pollution as coming from Nanjangud town.",
-          "points": [
-            "Bathing ghat, Nanjangud: Class D in 2017 (BOD 2.4-6.5, faecal coliform 320-790 MPN/100ml), Class E in 2018.",
-            "Water-supply intake, T. Narasipura: Class C in both 2017 and 2018 (BOD 1.2-3.0, then 1.04-2.0).",
-            "The plan's reading: 'The results indicate that the water is polluted due to sewage from Nanjungud Town.'",
-            "By CPCB's 2022-23 and 2024 rounds the intake is the worst point on the stretch, not the best."
-          ]
-        },
-        {
-          "key": "parameters",
-          "label": "What is not measured",
-          "level": "stretch",
-          "body": "The classification runs on BOD alone. No public monitoring we hold reports heavy metals, pesticides or pharmaceutical residues on this river - which matters upstream of a belt that includes distilleries, pulp and paper, and pharmaceutical units.",
-          "noData": true
+          "capacity": "5.5 MLD per pp.57 and 60; 0 MLD per the p.59 table.",
+          "dashboard": "No public dashboard reported"
         }
       ]
     },
@@ -262,7 +222,6 @@
       "key": "industrial",
       "label": "Industrial effluent",
       "status": "built",
-      "scope": "stretch",
       "subtabKind": "categories",
       "source": "KSPCB Action Plan for Rejuvenation of River Kabini, section 2.5; NMCG Monthly Progress Report, August 2025",
       "intro": "The Nanjangud industrial belt sits at the head of the original polluted reach. Both the action plan and the progress reports report it as discharging nothing to the river.",
@@ -288,50 +247,181 @@
           "label": "What would let anyone check it",
           "level": "stretch",
           "body": "The zero-discharge position is the board's own assertion. For a sugar, distillery, pulp-and-paper and pharmaceutical cluster upstream of a polluted stretch, no published effluent data exists to test it: there is no public OCEMS-style feed for these units, and the compliance table reports a count, not a measurement.",
+          "noData": true,
+          "sourceTier": "other",
+          "link": {
+            "url": "https://cems.cpcb.gov.in/public/#/l/realtime-connectivity-status-dashboard",
+            "label": "Open CPCB's live connectivity dashboard"
+          }
+        }
+      ]
+    },
+    {
+      "key": "solid",
+      "label": "Solid waste",
+      "status": "built",
+      "subtabKind": "units",
+      "unitLabel": "TPD",
+      "treatedVerb": "processed",
+      "source": "KSPCB Action Plan for Rejuvenation of River Kabini, section 2.2; NMCG Monthly Progress Report, August 2025; Revised District Environmental Plan of Mysuru District (May 2022)",
+      "intro": "Municipal solid waste generated vs processed (tonnes/day) and the processing and landfill infrastructure, for the towns along the stretch. Bank dumping is one of the few pollution sources the action plan names outright. It is also the one with no closure status in any report since.",
+      "summaryBadge": "unclosed",
+      "summaryLine": "Plan records dumping on the banks; no edition since says it stopped",
+      "summaryTone": "warn",
+      "units": [
+        {
+          "key": "sargur",
+          "name": "Sargur (TP)",
+          "level": "ULB (Town Panchayat) - one DEP snapshot",
+          "sourceTier": "other",
+          "gapUnit": "mysuru",
+          "mprNote": "Not itemised in any MPR edition - the Kabini stretch section covered Nanjangud only.",
+          "sourceNote": "Revised District Environmental Plan of Mysuru District, May 2022, pp.8-9.",
+          "caveat": "Neither this town's waste destinations nor bank-side dumping are reported anywhere we hold.",
+          "generation": [
+            {
+              "year": 2022,
+              "value": 4.57
+            }
+          ],
+          "generationNote": "The plan's own figure for the town.",
+          "treated": [],
+          "infrastructure": [
+            {
+              "label": "Source segregation",
+              "status": "10 of 12 wards at 100% source segregation (DEP 2022)",
+              "tone": "neutral"
+            }
+          ],
+          "dashboard": "No public dashboard reported"
+        },
+        {
+          "key": "nanjangud",
+          "name": "Nanjangud (CMC)",
+          "level": "ULB (City Municipal Council) - yearly (MPR)",
+          "sourceTier": "mpr",
+          "gapUnit": "mysuru",
+          "generation": [
+            {
+              "year": 2025,
+              "value": 26
+            }
+          ],
+          "generationNote": "26 TPD in the August 2025 MPR. The action plan records about 20 TPD and that the waste is not being segregated.",
+          "treated": [
+            {
+              "year": 2025,
+              "value": 6
+            }
+          ],
+          "gapValue": 20,
+          "gapNote": "26 generated, about 6 composted (NMCG August 2025); the report's own figures are a composting gap of 4.66 TPD and a landfill gap of 6.24 TPD.",
+          "capacity": "No functional sanitary landfill; a Rs 5.16 crore DPR is approved and construction reported 'in progress'.",
+          "infrastructure": [
+            {
+              "label": "Dumping on the river banks",
+              "status": "The action plan records that 'apart from dumping the solid wastes in the MSW site, some quantity is also dumped on banks of the river' (section 2.2); its remedy is disposal only at MSW sites. No edition since reports whether it stopped.",
+              "tone": "bad"
+            },
+            {
+              "label": "Sanitary landfill",
+              "status": "Rs 5.16 crore DPR approved, construction 'in progress'; the proposed-facility timeline is still printed as 31.03.2021.",
+              "tone": "bad"
+            },
+            {
+              "label": "Collection and segregation",
+              "status": "Door-to-door collection in all 31 wards; source segregation in 24 of them, against the DEP's count of 31 of 31.",
+              "tone": "neutral"
+            }
+          ],
+          "dashboard": "No public dashboard reported",
+          "otherStreams": [
+            {
+              "label": "Biomedical",
+              "value": "0.217 kg/day across 35 bedded and 50 non-bedded health-care facilities, disposal via CBMWTF (NMCG, unchanged through August 2025) - implausibly low as stated, likely a units error in the report itself"
+            }
+          ]
+        },
+        {
+          "key": "tn-pura",
+          "name": "T. Narasipura (TMC)",
+          "level": "ULB (Town Municipal Council) - one DEP snapshot",
+          "sourceTier": "other",
+          "gapUnit": "mysuru",
+          "mprNote": "Not itemised in any MPR edition, though the stretch now ends at this town's water-supply intake.",
+          "sourceNote": "Revised District Environmental Plan of Mysuru District, May 2022, pp.8-9.",
+          "caveat": "Neither this town's waste destinations nor bank-side dumping are reported anywhere we hold.",
+          "generation": [
+            {
+              "year": 2022,
+              "value": 13
+            }
+          ],
+          "generationNote": "The plan's own figure for the town.",
+          "treated": [],
+          "infrastructure": [
+            {
+              "label": "Source segregation",
+              "status": "22 of 23 wards at 100% source segregation (DEP 2022)",
+              "tone": "neutral"
+            }
+          ],
+          "dashboard": "No public dashboard reported"
+        }
+      ]
+    },
+    {
+      "key": "hazardous",
+      "label": "Hazardous waste",
+      "status": "built",
+      "subtabKind": "categories",
+      "source": "NMCG Monthly Progress Reports (Karnataka, Kabini stretch, to August 2025); Revised District Environmental Plan of Mysuru District (May 2022)",
+      "summaryBadge": "not reported",
+      "summaryLine": "No hazardous-waste figure reported for the stretch in any edition held",
+      "summaryTone": "neutral",
+      "categories": [
+        {
+          "key": "hazardous",
+          "label": "Hazardous waste",
+          "level": "stretch / district",
+          "body": "Hazardous waste is not reported for this stretch.",
+          "points": [
+            "No hazardous-waste generation, treatment or TSDF figure appears in any NMCG progress report edition for the Kabini stretch through August 2025.",
+            "The Mysuru District Environment Plan (May 2022) inventories solid waste, domestic sewage, industrial wastewater, air, mining and noise; no known public hazardous-waste inventory covers the district's Kabini-side towns.",
+            "Biomedical waste is the one special stream reported here, and only for Nanjangud - see Solid waste."
+          ],
           "noData": true
         }
       ]
     },
     {
-      "key": "solid-waste",
-      "label": "Solid waste on the river banks",
+      "key": "fstp",
+      "label": "FSTP",
       "status": "built",
-      "scope": "stretch",
       "subtabKind": "categories",
-      "source": "KSPCB Action Plan for Rejuvenation of River Kabini, section 2.2; NMCG Monthly Progress Report, August 2025; Revised District Environmental Plan of Mysuru District (May 2022)",
-      "intro": "Bank dumping is one of the few pollution sources the action plan names outright. It is also the one with no closure status in any report since.",
-      "summaryBadge": "unclosed",
-      "summaryLine": "Plan records dumping on the banks; no edition since says it stopped",
+      "source": "KSPCB Action Plan for Rejuvenation of River Kabini; NMCG Monthly Progress Reports (to August 2025); Revised District Environmental Plan of Mysuru District (May 2022)",
+      "summaryBadge": "not reported",
+      "summaryLine": "No faecal-sludge plant on the stretch; the unsewered share's septage route is unreported",
       "summaryTone": "warn",
       "categories": [
         {
-          "key": "banks",
-          "label": "Dumping on the banks",
-          "level": "ULB",
-          "body": "The action plan records about 20 TPD generated at Nanjangud, that waste is not being segregated, and that 'apart from dumping the solid wastes in the MSW site, some quantity is also dumped on banks of the river' (section 2.2). Its remedy is that municipal waste, including poultry and slaughterhouse waste, shall be disposed of only at MSW sites.",
+          "key": "fstp",
+          "label": "FSTP",
+          "level": "ULB / district",
+          "body": "Faecal-sludge treatment for the unsewered load:",
           "points": [
-            "August 2025 MPR: 26 TPD generated, about 6 TPD composted - a composting gap of 4.66 TPD and a landfill gap of 6.24 TPD.",
-            "A Rs 5.16 crore sanitary-landfill DPR is approved and construction reported 'in progress'; the proposed-facility timeline is still printed as 31.03.2021.",
-            "Door-to-door collection in all 31 wards; source segregation in 24 of them, against the DEP's count of 31 of 31.",
-            "No edition since the plan reports whether the bank dumping it acknowledged has stopped."
-          ]
-        },
-        {
-          "key": "other-towns",
-          "label": "The other towns on the stretch",
-          "level": "ULB",
-          "body": "T. Narasipura generates 13 TPD across 23 wards and Sargur 4.57 TPD across 12; both fall outside the MPR's stretch reporting entirely. Their figures come from the district plan (pp.8-9).",
-          "points": [
-            "T. Narasipura: 13 TPD, 22 of 23 wards at 100% source segregation.",
-            "Sargur: 4.57 TPD, 10 of 12 wards at 100% source segregation.",
-            "Neither town's waste destinations or bank-side dumping are reported anywhere we hold."
-          ]
+            "Faecal sludge and septage do not appear in the KSPCB Kabini action plan.",
+            "With 40% of Nanjangud's households unconnected to the UGD, their septage route is not reported in any edition through August 2025 - the unsewered share's septage is the unaccounted flow between the town and the river.",
+            "Sargur has no sewerage network and no facility marked as planned; T. Narasipura's UGD covers half the town. No faecal-sludge plant is reported for either.",
+            "The Mysuru District Environment Plan lists an FSTP approved for HD Kote, a Kabini-side town off the 2025 stretch; no plant is reported operational anywhere on the stretch itself."
+          ],
+          "noData": true
         }
       ]
     },
     {
       "key": "eflow",
-      "label": "Environmental flow (E-flow)",
+      "label": "E-flow",
       "status": "built",
       "scope": "stretch",
       "subtabKind": "categories",
@@ -361,51 +451,56 @@
             "Water-year mean discharge swings from 8.7 cumec in 2014-15 and 51.9 in 2023-24 to 1,072 in 2018-19, against a long-term average of 199.3 cumec.",
             "Priority bands are set on BOD from grab samples, so a dry year and a wet year of the same effluent load do not read the same.",
             "Discharge is published in arrears; the telemetric level feed has been frozen at source since 04 June 2026."
-          ]
+          ],
+          "sourceTier": "other"
         }
       ]
     },
     {
-      "key": "cost",
-      "label": "What restoration was costed at",
+      "key": "reuse",
+      "label": "Treated-water reuse",
       "status": "built",
-      "scope": "stretch",
       "subtabKind": "categories",
-      "source": "KSPCB Action Plan for Rejuvenation of River Kabini, section 6 and Table-3",
-      "intro": "The plan puts a number on restoring the stretch. It is a sewerage number, for one town.",
-      "summaryBadge": "Rs 80 crore",
-      "summaryLine": "Costed entirely as Nanjangud sewerage; the table is headed with another river's name",
-      "summaryTone": "warn",
-      "categories": [
-        {
-          "key": "table",
-          "label": "The Rs 80 crore",
-          "level": "stretch",
-          "body": "Section 6 estimates Rs 2.5 crore of capital cost per MLD for primary, secondary and tertiary treatment, and asks for Rs 80 crore of budgetary provision for the towns along the Kabini.",
-          "points": [
-            "Table-3 splits it as Rs 1.18 crore a year of O&M for the existing 7 MLD STP, and Rs 78.82 crore for UGD to the 60% of Nanjangud still uncovered plus house connections for the whole town.",
-            "Every rupee of it is Nanjangud. Sargur and T. Narasipura, both on the 2025 stretch, are not costed.",
-            "The table is headed 'Cost Component involved in the Rejuvenation of Polluted Stretch of Bhadra' - another river's name, left in the Kabini plan; its only column is Nanjangud."
-          ]
-        }
-      ]
-    },
-    {
-      "key": "evidence",
-      "label": "Independent evidence",
-      "status": "built",
-      "scope": "stretch",
-      "subtabKind": "categories",
-      "intro": "On the Arkavathi, independent lab work and citizen documentation sit alongside the official record. On the Kabini there is no such body of evidence in what we hold.",
-      "summaryBadge": "none held",
-      "summaryLine": "No independent study, citizen record or lab analysis for this stretch in our sources",
+      "source": "KSPCB Action Plan for Rejuvenation of River Kabini, section 2.5; NMCG Monthly Progress Reports (to August 2025; STP annexure April 2026)",
+      "summaryBadge": "not reported",
+      "summaryLine": "Industrial on-land gardening is the only reuse reported; no municipal reuse in any edition",
       "summaryTone": "neutral",
+      "scope": "stretch",
       "categories": [
         {
-          "key": "none",
-          "label": "No independent record held",
+          "key": "reuse",
+          "label": "Treated-water reuse",
+          "level": "taluk / ULB",
+          "body": "Reuse of treated water as reported for this stretch:",
+          "points": [
+            "The action plan reports that industries in Nanjangud taluk use their treated water on land for gardening inside their premises (section 2.5). No volume is given, and the statement covers the taluk rather than named units.",
+            "No municipal treated-water reuse is reported for Nanjangud, Sargur or T. Narasipura in any edition through August 2025. Nanjangud's 7 MLD plant is reported at 2 MLD utilised in August 2025 and 3.5 MLD in April 2026, but where the treated water goes is not reported."
+          ],
+          "noData": true
+        }
+      ]
+    },
+    {
+      "key": "floodplain",
+      "label": "Flood plain",
+      "status": "built",
+      "subtabKind": "categories",
+      "source": "KSPCB Action Plan for Rejuvenation of River Kabini; NMCG Monthly Progress Reports (Karnataka, Kabini stretch, to August 2025)",
+      "summaryBadge": "not reported",
+      "summaryLine": "No flood-plain-zone commitment in the plan or in any progress report edition held",
+      "summaryTone": "neutral",
+      "scope": "stretch",
+      "categories": [
+        {
+          "key": "floodplain",
+          "label": "Flood plain",
           "level": "stretch",
-          "body": "Everything on this page comes from CPCB, KSPCB, NMCG and the district administration - the bodies being held to account. We hold no independent sampling, no citizen-collected record and no academic study for this stretch. That absence is itself worth stating: on this river, the official record has no second opinion.",
+          "body": "The flood plain does not appear as an obligation in this stretch's record.",
+          "points": [
+            "No flood-plain-zone commitment - notification, encroachment check, plantation, or a prohibition on dumping in the zone - appears in the KSPCB Kabini action plan or in any MPR edition through August 2025 in what we hold.",
+            "The plan's named executing agencies cover sewerage and solid waste (CMC Nanjangud), monitoring and consent (KSPCB), and the bathing ghat and offerings in the river (the temple authority at Nanjangud). The river's banks appear only as the place solid waste is dumped (section 2.2).",
+            "The 2025 stretch runs 104 km past three towns and a largely rural reach; no encroachment count, demarcation or plantation figure exists for any of it in the documents here."
+          ],
           "noData": true
         }
       ]
@@ -528,5 +623,16 @@
     "Town-level sewage and solid-waste figures for Sargur and T. Narasipura: Revised District Environmental Plan of Mysuru District, May 2022.",
     "Flow: India-WRIS Dataset API, CWC hydrological observations at T. Narasipur.",
     "Towns on the stretch: computed from the KGIS urban local body boundaries in Paani Earth's Admin GeoPackage against the mapped 2025 stretch."
-  ]
+  ],
+  "evidence": {
+    "headline": "The worst reading on the stretch sits at the point a town draws its drinking water - and the official record has no second opinion.",
+    "points": [
+      "CPCB monitoring, maximum BOD in mg/L (2022-23, then 2024): Kabini at Saragur village D/S 4.0, 4.0; at the causeway, Sattur 4.0, 3.5; u/s the intake to Nanjangud & Gundlupet at Debur 3.5, 3.8; at the bathing ghat, Nanjangud 4.5, 5.0; at the water-supply intake to T. Narasipura 6.0, 6.0. Every station is above 3 mg/L, the Primary Water Quality Criteria for Bathing Water, in both rounds.",
+      "The action plan's own Table-2 covers two stations for 2017 and 2018: the bathing ghat at Nanjangud reads Class D in 2017 (BOD 2.4-6.5, faecal coliform 320-790 MPN/100ml) and Class E in 2018; the water-supply intake at T. Narasipura reads Class C in both years (BOD 1.2-3.0, then 1.04-2.0). By CPCB's 2022-23 and 2024 rounds the intake is the worst point on the stretch, not the best.",
+      "The plan's own reading of that table: 'The results indicate that the water is polluted due to sewage from Nanjungud Town.'",
+      "The classification runs on BOD alone. No known public monitoring reports heavy metals, pesticides or pharmaceutical residues on this river - which matters upstream of a belt that includes distilleries, pulp and paper, and pharmaceutical units.",
+      "Everything on this page comes from CPCB, KSPCB, NMCG and the district administration - the bodies being held to account. We hold no independent sampling, no citizen-collected record and no academic study for this stretch. That absence is itself worth stating: on this river, the official record has no second opinion."
+    ],
+    "layerRef": "monitoring-points"
+  }
 }

--- a/public/data/basins/kabini/prs.json
+++ b/public/data/basins/kabini/prs.json
@@ -60,15 +60,12 @@
     {
       "year": 2018,
       "length_km": 9,
-      "priority": "IV",
-      "note": "KSPCB's own action plan puts this stretch at about 9 km, from the Nanjangud water-supply intake to Hejjige village (p.3). Paani Earth's mapping of the 2018 edition covers about 3 km of that, and her separately-labelled 2020 lines are geometrically identical to it - so the reach is reported here from the documents rather than drawn short.",
-      "notMapped": true
+      "priority": "IV"
     },
     {
       "year": 2025,
       "length_km": 104.3,
-      "priority": "V",
-      "note": "CPCB redrew the stretch as 'River Kabini from Saragur village D/S to water supply intake point to Narasipura town' (Polluted River Stretches 2025, p.15). The length is Paani Earth's mapping of that reach."
+      "priority": "V"
     }
   ],
   "statusLine": "The polluted reach went from about 9 km below Nanjangud to 104 km - close to the river's entire Karnataka course - and CPCB files the change under the annexure titled 'PRS wherein improvement was observed'.",
@@ -98,7 +95,7 @@
       "value": "Reduce BOD below 3 mg/L to meet the Primary Water Quality Criteria for Bathing Water (organised outdoor bathing)"
     }
   ],
-  "growthNote": "CPCB's earlier lists did not carry the Kabini at all: the 1993-94 and 2011 stretch sets in the same partner package are Cauvery, Bhavani, Lakshmanthirtha and Tamil Nadu reaches, with nothing on this river. It first appears in 2018 as the short reach below Nanjangud, unchanged in the 2020 mapping, and is redrawn in 2025 to run from Saragur - up near where the river leaves the Kabini reservoir - all the way down to the T. Narasipura intake. The stretch grew upstream and downstream at once, and picked up two more towns doing so.",
+  "growthNote": "CPCB's earlier lists did not carry the Kabini at all: the 1993-94 and 2011 stretch sets in the same partner package are Cauvery, Bhavani, Lakshmanthirtha and Tamil Nadu reaches, with nothing on this river. It first appears in 2018 as the short reach below Nanjangud, unchanged in the 2020 mapping, and is redrawn in 2025 to run from Saragur - up near where the river leaves the Kabini reservoir - all the way down to the T. Narasipura intake. The stretch grew upstream and downstream at once, and picked up two more towns doing so. Only the 2025 reach is drawn on the map. The 2018 length shown is KSPCB's own, about 9 km from the Nanjangud water-supply intake to Hejjige village (action plan, p.3); Paani Earth's mapping of the 2018 edition covers about 3 km of that and her separately-labelled 2020 lines are geometrically identical to it, so drawing one would understate the reach by two thirds.",
   "priorityNote": "Priority is CPCB's BOD-based band, set by the worst monitoring point on the stretch: I is above 30 mg/L, V is 3-6. On that scale the Kabini moved from IV to V, which is why it sits in CPCB's list of stretches where improvement was observed against 2018 (Annexure X, p.108) - even though the reach CPCB now names is more than ten times longer. The documents do not sit easily together either: the KSPCB action plan heads the stretch 'Priority: IV (BOD 6-10 mg/L)' while giving its own BOD range as 3.6-6.5 mg/L, which is mostly the Priority V band (p.3).",
   "bodCaveat": "What Priority V means here: the worst of the five monitored points read 6 mg/L, the top of the 3-6 band. It is the mildest CPCB category - and every station on the stretch is still above 3 mg/L, the bathing-water criterion, including the one at Saragur at the very head of it. Priority is set from BOD alone, on grab samples, so a reading reflects dilution as much as load: the CWC gauge at T. Narasipur on this map records a water-year mean of 51.9 cumec in 2023-24 against a 199.3 cumec long-term average, and the same effluent in a year like that reads worse. BOD also says nothing about metals or pesticides, which no public monitoring we hold reports on this river.",
   "mprOverview": "Tracked under NGT order OA 673/2018 through monthly NMCG progress reports. Through the August 2025 edition those reports carried a stretch-wise section for the Kabini, and it named one town: Nanjangud. From October 2025 the per-stretch narrative disappears, and by April 2026 the report is state-wide annexure tables only - station classes and STP lists.",


### PR DESCRIPTION
The Arkavathi is the only other basin shipping a `prs.json`, so its field set is the template. The Kabini panel had drifted from it, and the two surfaces told the same story in two shapes.

## What diverged

| | before | after |
|---|---|---|
| tab keys | 7, incl. invented `water-quality`, `cost`, `solid-waste` | Arkavathi's 8, in Arkavathi's order |
| `scope: "stretch"` | all 7 | `eflow`, `reuse`, `floodplain` |
| top-level `evidence` | absent (was a tab) | present |
| `units[].dashboard` | 0/3 | 6/6 |
| `units[].otherStreams` | 0 | 1 |
| `categories[].sourceTier` | 0/11 | 2/8 |
| `categories[].link` | 0/11 | 1/8 |
| `epochs[]` fields | `year, length_km, priority, note, notMapped` | `year, length_km, priority` |

Kabini also carried two fields the Arkavathi does not have, `epochs[].note` and `epochs[].notMapped`, which painted a grey caption under each Current Status bar. Both the panel and the PDF gate that whole caption on `note`, so dropping it takes the "Not drawn on the map." prefix with it and the two surfaces go quiet together. Most of what those captions said was already on the page: the 2025 one restated the stretch name and length, both `statusFacts` rows, and cited CPCB p.15, the first line of Sources. The one thing worth keeping - why the 2018 bar reads 9 km when no 2018 line is drawn - moved into `growthNote`, a tap deep in the methodology disclosure. Current Status is now bars, kilometres and priority chips only, matching the Arkavathi.

Every Arkavathi field is now populated or deliberately empty. The only one left unset is `evidence.link`, the Paani x ICCW report: the Kabini has no independent study, which is itself the last evidence point.

## Where the content went

Nothing sourced is dropped. The five CPCB stations and the 2017-18 KSPCB classes move into the `evidence` block, which is where the Arkavathi keeps its own CPCB monitoring line, `layerRef` and all. The Rs 80 crore becomes an `infrastructure` row on the Nanjangud sewage unit, next to the Rs 36.86 crore UGD DPR it sits beside in the plan. Solid waste converts to the units shape: the per-town TPD figures were already in the prose, so Sargur 4.57, Nanjangud 26 and T. Narasipura 13 now chart as bars, and the biomedical line moves to `otherStreams`.

The four missing tabs come from the Kabini's own record: `hazardous` and `fstp` from the accountability matrix's `biomedical` and `fecal-sludge` rows plus the Mysuru DEP, `reuse` from the action plan's on-land gardening line, `floodplain` from its absence. All four carry `noData`.

## Two things worth a look

**`scope` is load-bearing.** Only `scope: "stretch"` tabs are reachable, and the Kabini had marked all seven, listing seven obligations where the Arkavathi lists three. It now matches. That leaves the sewage, solid and industrial detail authored but unreachable, and the Kabini matrix does not catch it the way the Arkavathi's does.

The reason is worth naming: the matrix is one stretch-definition behind. Its own intro reads "The Kabini's CPCB polluted stretch runs Nanjangud to Hejjige (Priority IV)" and its `gps` region is "the rural reach between Nanjangud and Hejjige" - the ~9 km 2018 reach, one town on it. `build_kabini_sources.py:316-320` copies it verbatim from `cauvery-ka/accountability-C2.json`. When CPCB redrew the stretch to Saragur - T. Narasipura at 104.3 km, #255 updated the PRS panel and left the matrix on the old definition, so Sargur (TP) and T. Narasipura (TMC) are absent because they were not on the stretch when it was written, not because of anything about their ULB status.

Checked in the browser: the Arkavathi's ULBs tab reveals 8 region chips, the Kabini's reveals none - one region, auto-selected, Nanjangud. The stale sentence is not visible to a reader, because `AccountabilityMatrix` renders `question` and never `intro`. Refreshing the matrix for the 2025 reach is the fix, and it is not this change.

**One addition is not from the Kabini's own text.** The CPCB live connectivity dashboard link on the industrial `check` category, copied from the Arkavathi's `monitoring` category. That category argues no public effluent feed exists for the 140 units; the link is how a reader confirms the absence. Easy to drop.

## Checks

Browser-checked against the Arkavathi as control, not just the gates: three obligations each, evidence block with five points each, four epoch bars, six statusFacts and two governance rows each. The new `sourceTier` actually splits the E-flow pane into MPR and Other sources, and the `noData` tabs paint their no-known-public-data badge. `notMapped` renders too: 2018 draws a stub bar captioned "Not drawn on the map", 2025 the full 104.3 km bar at Priority V. Console clean apart from the two by-design optional 404s the Arkavathi also has.

NVDM L2 OK, generator-drift OK, encumbrance selftest 0 failures, `validate_basin.py` PASS, `data:check` clean, 83/83 tests. `dataset-catalogue.json` regenerated against current main: a byte count and the new `evidence` key.

Not exercised: the PDF export, which filters `scope` the same way at `basin-pdf-report.tsx:563`, so the Kabini PDF now carries three tabs instead of seven.

