### PR TITLE
Kabini matrix: the stretch grew, the matrix did not

### DIFF
--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -2377,7 +2377,7 @@
    "family": "basins",
    "scope": "cauvery-ka",
    "dataset": "accountability-C2",
-   "bytes": 9800,
+   "bytes": 19300,
    "schema": {
     "kind": "object",
     "keys": [
@@ -3825,7 +3825,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "accountability",
-   "bytes": 10869,
+   "bytes": 20369,
    "schema": {
     "kind": "object",
     "keys": [
@@ -23996,7 +23996,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 78455,
+   "bytes": 87955,
    "schema_variants": 2,
    "registered": true,
    "has_consumer": true
@@ -24044,7 +24044,7 @@
    "scopes": [
     "cauvery-ka"
    ],
-   "bytes": 9800,
+   "bytes": 19300,
    "schema_variants": 1,
    "registered": false,
    "has_consumer": true

--- a/public/data/basins/cauvery-ka/accountability-C2.json
+++ b/public/data/basins/cauvery-ka/accountability-C2.json
@@ -1,6 +1,6 @@
 {
   "question": "Do the Action Plan and the MPRs address all potential pollution contributors on the Kabini stretch?",
-  "intro": "The Kabini's CPCB polluted stretch runs Nanjangud to Hejjige (Priority IV). This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
+  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the 9 km below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
   "baseline": {
     "primary": {
       "label": "NMCG Monthly Progress Report (Karnataka, Kabini stretch)",
@@ -15,7 +15,8 @@
     "otherSources": [
       "CPCB Polluted River Stretches report (October 2025)",
       "KSPCB NWMP monthly classification 2025-26",
-      "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative"
+      "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative",
+      "Revised District Environmental Plan of Mysuru District (May 2022) - the only source that reports Sargur and T. Narasipura, the two towns the October-2025 redraw added to the stretch"
     ]
   },
   "legalLibrary": {
@@ -51,6 +52,113 @@
     ]
   },
   "regions": [
+    {
+      "kind": "ulb",
+      "key": "sargur",
+      "name": "Sargur (TP)",
+      "inBasinNote": "Town Panchayat at the head of the 2025 stretch. CPCB's first monitoring point on the reach, 'Kabini at Saragur village D/S', already reads BOD 4 mg/L.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "The Action Plan names Nanjangud as the only local body on the river - 'CMC Nanjangudu is the only local body located on the bank of the river Kabini' (p.3), written when the stretch was the 9 km below the town.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not itemised in any edition through August 2025 - the Kabini stretch section covered Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Revised District Environmental Plan of Mysuru District (May 2022) puts the town's sewage at 1.2339 MLD with no sewerage network, no treatment, and no facility marked as planned in its STP-requirement table. It is the only source that reports the town at all.",
+            "Sargur has sat at the head of the polluted stretch since CPCB redrew it in October 2025, and has never appeared in a progress report."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for Sargur appears in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "The district plan reports 4.57 TPD generated across 12 wards, 10 of them at 100% source segregation (pp.8-9); waste destinations are not reported.",
+            "Solid waste for Sargur appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Biomedical waste does not appear in the Kabini Action Plan.",
+            "cite": "Kabini Action Plan (full text, zero mentions)"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No biomedical-waste reporting for Sargur in any edition through August 2025; the stretch section's figure covers Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "No known public biomedical-waste figure for this town."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Faecal sludge and septage do not appear in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "With no sewerage network at all, the whole of the town's sewage takes an unreported septage or surface route to the river, at the head of the polluted stretch."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Not mentioned.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No private STP reporting for Sargur in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [],
+          "legalRef": "public-stps"
+        }
+      ]
+    },
     {
       "kind": "ulb",
       "key": "nanjangud",
@@ -159,6 +267,113 @@
       ]
     },
     {
+      "kind": "ulb",
+      "key": "tn-pura",
+      "name": "T. Narasipura (TMC)",
+      "inBasinNote": "Town Municipal Council at the foot of the 2025 stretch. The reach ends at this town's water-supply intake, the worst monitored point on the river - BOD 6 mg/L in both the 2022-23 and 2024 CPCB rounds.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "The Action Plan names Nanjangud as the only local body on the river - 'CMC Nanjangudu is the only local body located on the bank of the river Kabini' (p.3), written when the stretch was the 9 km below the town.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not itemised in any edition through August 2025, though the stretch now ends at this town's water-supply intake.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Revised District Environmental Plan of Mysuru District (May 2022) puts the town's sewage at 3.401784 MLD with UGD covering half its area, and contradicts itself on treatment: an existing 5.5 MLD STP on pp.57 and 60, but 0 MLD in the capacity table on p.59. Treated volume is not reported in any edition.",
+            "The stretch's worst BOD is measured at this town's water-supply intake, and no progress report has ever covered the town."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for T. Narasipura appears in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "The district plan reports 13 TPD across 23 wards, 22 of them at 100% source segregation (pp.8-9); waste destinations and any bank-side dumping are not reported.",
+            "Solid waste for T. Narasipura appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Biomedical waste does not appear in the Kabini Action Plan.",
+            "cite": "Kabini Action Plan (full text, zero mentions)"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No biomedical-waste reporting for T. Narasipura in any edition through August 2025; the stretch section's figure covers Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "No known public biomedical-waste figure for this town."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Faecal sludge and septage do not appear in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Half the town sits outside the UGD; that share's septage route is unreported, in the town where the stretch's worst BOD is measured."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Not mentioned.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No private STP reporting for T. Narasipura in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [],
+          "legalRef": "public-stps"
+        }
+      ]
+    },
+    {
       "kind": "ia",
       "key": "nanjangud-ia",
       "name": "Nanjangud industrial areas (KIADB, Thandya / Adakanahalli)",
@@ -190,7 +405,7 @@
       "kind": "gp",
       "key": "gps",
       "name": "Gram Panchayats (Kabini stretch)",
-      "inBasinNote": "The rural reach between Nanjangud and Hejjige.",
+      "inBasinNote": "The rural reach between the three towns on the 2025 stretch.",
       "silentNote": "No MPR edition and no Action Plan item reports anything at gram-panchayat level for this stretch - the rural reach is unreported in the official accountability trail.",
       "categories": []
     }

--- a/public/data/basins/kabini/accountability.json
+++ b/public/data/basins/kabini/accountability.json
@@ -25,11 +25,11 @@
       }
     ],
     "method": "manual",
-    "produced_at": "2026-08-14",
+    "produced_at": "2026-08-17",
     "produced_by": "Authored on the cauvery-ka overview (accountability-C2.json) and carried verbatim by scripts/build_kabini_sources.py."
   },
   "question": "Do the Action Plan and the MPRs address all potential pollution contributors on the Kabini stretch?",
-  "intro": "The Kabini's CPCB polluted stretch runs Nanjangud to Hejjige (Priority IV). This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
+  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the 9 km below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
   "baseline": {
     "primary": {
       "label": "NMCG Monthly Progress Report (Karnataka, Kabini stretch)",
@@ -44,7 +44,8 @@
     "otherSources": [
       "CPCB Polluted River Stretches report (October 2025)",
       "KSPCB NWMP monthly classification 2025-26",
-      "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative"
+      "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative",
+      "Revised District Environmental Plan of Mysuru District (May 2022) - the only source that reports Sargur and T. Narasipura, the two towns the October-2025 redraw added to the stretch"
     ]
   },
   "legalLibrary": {
@@ -80,6 +81,113 @@
     ]
   },
   "regions": [
+    {
+      "kind": "ulb",
+      "key": "sargur",
+      "name": "Sargur (TP)",
+      "inBasinNote": "Town Panchayat at the head of the 2025 stretch. CPCB's first monitoring point on the reach, 'Kabini at Saragur village D/S', already reads BOD 4 mg/L.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "The Action Plan names Nanjangud as the only local body on the river - 'CMC Nanjangudu is the only local body located on the bank of the river Kabini' (p.3), written when the stretch was the 9 km below the town.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not itemised in any edition through August 2025 - the Kabini stretch section covered Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Revised District Environmental Plan of Mysuru District (May 2022) puts the town's sewage at 1.2339 MLD with no sewerage network, no treatment, and no facility marked as planned in its STP-requirement table. It is the only source that reports the town at all.",
+            "Sargur has sat at the head of the polluted stretch since CPCB redrew it in October 2025, and has never appeared in a progress report."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for Sargur appears in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "The district plan reports 4.57 TPD generated across 12 wards, 10 of them at 100% source segregation (pp.8-9); waste destinations are not reported.",
+            "Solid waste for Sargur appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Biomedical waste does not appear in the Kabini Action Plan.",
+            "cite": "Kabini Action Plan (full text, zero mentions)"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No biomedical-waste reporting for Sargur in any edition through August 2025; the stretch section's figure covers Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "No known public biomedical-waste figure for this town."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Faecal sludge and septage do not appear in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "With no sewerage network at all, the whole of the town's sewage takes an unreported septage or surface route to the river, at the head of the polluted stretch."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Not mentioned.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No private STP reporting for Sargur in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [],
+          "legalRef": "public-stps"
+        }
+      ]
+    },
     {
       "kind": "ulb",
       "key": "nanjangud",
@@ -188,6 +296,113 @@
       ]
     },
     {
+      "kind": "ulb",
+      "key": "tn-pura",
+      "name": "T. Narasipura (TMC)",
+      "inBasinNote": "Town Municipal Council at the foot of the 2025 stretch. The reach ends at this town's water-supply intake, the worst monitored point on the river - BOD 6 mg/L in both the 2022-23 and 2024 CPCB rounds.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "The Action Plan names Nanjangud as the only local body on the river - 'CMC Nanjangudu is the only local body located on the bank of the river Kabini' (p.3), written when the stretch was the 9 km below the town.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not itemised in any edition through August 2025, though the stretch now ends at this town's water-supply intake.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Revised District Environmental Plan of Mysuru District (May 2022) puts the town's sewage at 3.401784 MLD with UGD covering half its area, and contradicts itself on treatment: an existing 5.5 MLD STP on pp.57 and 60, but 0 MLD in the capacity table on p.59. Treated volume is not reported in any edition.",
+            "The stretch's worst BOD is measured at this town's water-supply intake, and no progress report has ever covered the town."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for T. Narasipura appears in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "The district plan reports 13 TPD across 23 wards, 22 of them at 100% source segregation (pp.8-9); waste destinations and any bank-side dumping are not reported.",
+            "Solid waste for T. Narasipura appears in neither the Action Plan nor the MPRs - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Biomedical waste does not appear in the Kabini Action Plan.",
+            "cite": "Kabini Action Plan (full text, zero mentions)"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No biomedical-waste reporting for T. Narasipura in any edition through August 2025; the stretch section's figure covers Nanjangud only.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "No known public biomedical-waste figure for this town."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Faecal sludge and septage do not appear in the Action Plan.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [
+            "Half the town sits outside the UGD; that share's septage route is unreported, in the town where the stretch's worst BOD is measured."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "Not mentioned.",
+            "cite": "Kabini Action Plan"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No private STP reporting for T. Narasipura in any edition through August 2025.",
+            "asOf": "August 2025"
+          },
+          "gaps": [],
+          "legalRef": "public-stps"
+        }
+      ]
+    },
+    {
       "kind": "ia",
       "key": "nanjangud-ia",
       "name": "Nanjangud industrial areas (KIADB, Thandya / Adakanahalli)",
@@ -219,7 +434,7 @@
       "kind": "gp",
       "key": "gps",
       "name": "Gram Panchayats (Kabini stretch)",
-      "inBasinNote": "The rural reach between Nanjangud and Hejjige.",
+      "inBasinNote": "The rural reach between the three towns on the 2025 stretch.",
       "silentNote": "No MPR edition and no Action Plan item reports anything at gram-panchayat level for this stretch - the rural reach is unreported in the official accountability trail.",
       "categories": []
     }


### PR DESCRIPTION
Follow-up to #282, which left this open deliberately.

CPCB redrew the Kabini stretch in October 2025, from the ~9 km below Nanjangud to 104.3 km running Saragur down to the T. Narasipura water-supply intake. #255 updated the PRS panel for the redraw and left the accountability matrix on the old reach. Its intro still described "Nanjangud to Hejjige (Priority IV)", its rural region was "the rural reach between Nanjangud and Hejjige", and two of the three towns now on the stretch had no region at all.

That mattered more after #282, which restored the Arkavathi's tab scoping. Scoping only the stretch-level obligations is correct **if** the matrix carries the per-town record, which is how the Arkavathi works across its 16 regions. Kabini's carried one town.

## What changes

`Sargur (TP)` and `T. Narasipura (TMC)` join as **all-silent regions** - the shape the Arkavathi already uses for seven of its own (Magadi, Nelamangala, Doddaballapura, Bidadi, Harohalli, Dabaspet, Doddaballapura-IA). Every verdict is `silent` because both towns are genuinely absent from both sides of the comparison:

- **Action Plan**: says outright that "CMC Nanjangudu is the only local body located on the bank of the river Kabini" (p.3), written when the stretch was 9 km.
- **MPRs**: neither town is itemised in any edition through August 2025.

Two towns on a polluted stretch with nothing to compare on either side is the finding, not a blank - which is what the matrix is for.

Figures in the `gaps` lines are the Mysuru District Environment Plan's own, the only source that reports either town, and the same ones already charting in the PRS panel:

| | sewage | solid waste |
|---|---|---|
| Sargur | 1.2339 MLD, no network, no plant planned | 4.57 TPD across 12 wards, 10 at 100% segregation |
| T. Narasipura | 3.401784 MLD, UGD over half the town, STP at 5.5 MLD on pp.57/60 and 0 MLD on p.59 | 13 TPD across 23 wards, 22 at 100% segregation |

The intro is rewritten for the 2025 reach, the rural region's note follows it, the ULBs are ordered head to foot as they sit on the river, and the DEP joins `otherSources`.

## Where it is authored

In `cauvery-ka/accountability-C2.json`, which is where that file's own comment says the matrix lives ("the overview file stays the single place the matrix is authored; re-run this script after editing it"), then carried to the deep dive by step 10 of `build_kabini_sources.py`. The rest of that script needs the Paani GeoPackages and would restage every layer, so only step 10 was re-run, using the same `merge_envelope` import - envelope preserved, drift gate green.

Worth knowing: `accountability-C2.json` is live on the cauvery-ka C2 sub-basin card too, so both surfaces move together. That is right here, since C2 is the Kabini sub-basin and all three towns sit inside it, but the C2 card is worth a look.

## Checks

Browser-checked with the Arkavathi as control: the ULBs tab now offers three region chips where it offered none, Sargur and T. Narasipura each render five rows badged "not in plan or MPR", and Magadi renders identically alongside.

NVDM L2 OK on both written artifacts, generator-drift OK, encumbrance selftest 0 failures, `data:check` clean, 83/83 tests, catalogue regenerated. `accountability-C2.json` reports L0 (no envelope), which is pre-existing on main and unchanged by this PR - verified by re-running the check against a clean tree.