### PR TITLE
Pin the corpus at the Kabini PRS release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -10,14 +10,13 @@
     "fetch script refuses to sync a corpus that does not match them, so a",
     "missing or truncated root can never wipe the destination and report",
     "success.",
-    "2026-08-17: the Kabini release, corpus-2026-08-17-kabini. Neither side of",
-    "the main merge was right on its own - main pinned the Gurugram release",
-    "(no Kabini), this branch pinned the Kabini release (cut before Kolkata and",
-    "Gurugram, so it would have rolled two live cities back out). This is the",
-    "union: 474 under data/ (410 + 18 city + 46 Kabini), 108 under geojson/."
+    "2026-08-17: corpus-2026-08-17-kabini-prs. The Kabini PRS panel moved onto",
+    "the Arkavathi field vocabulary (#282) and its accountability matrix gained",
+    "Sargur and T. Narasipura for CPCB's October-2025 reach (#283). Three files",
+    "edited, none added or removed, so expected_files is unchanged at 474/108."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "9e558abb5046d2ca2ad3a59081ff83d8f708bf77",
+  "sha": "cb50bb8bcbd11d4fb84e1aa11eb1189eca798694",
   "expected_files": {
     "data": 474,
     "geojson": 108


### PR DESCRIPTION
Third and last step of the Kabini PRS release. #282 and #283 both merged green and neither reached the site.

The build is `bash scripts/fetch-corpus.sh && next build`, so every deploy replaces `public/data` wholesale from the data repo at this pin. A green public merge is not a shipped change for anything under `public/data`. Checked against production rather than assumed - it was still returning the pre-#282 tab keys and a three-region matrix.

Moves the pin to `corpus-2026-08-17-kabini-prs` (data-repo `cb50bb8b`, merged as neer-vazhvu-data#18), which carries the three edited files byte-identical to main `3e12e334`.

**Only the sha moves.** Three files edited, none added or removed, so `expected_files` stays 474 / 108. No new source ids or licence strings either, so the data repo's `toolchain.lock` stays at `c9ac424e` - none of the circular-dependency dance Hyderabad and Kabini needed.

## Verified, not assumed

`CORPUS_SOURCE=remote CORPUS_USE_GIT_AUTH=1 bash scripts/fetch-corpus.sh` against this pin, in a throwaway worktree:

```
fetch-corpus: public/data <- data/ (474 files)
fetch-corpus: public/geojson <- geojson/ (108 files)
exit 0
```

and the fetched `public/data` carries what it should:

| | fetched corpus |
|---|---|
| tab keys | `sewage, industrial, solid, hazardous, fstp, eflow, reuse, floodplain` |
| `evidence` block | present |
| epoch fields | `year, length_km, priority` |
| matrix regions | `sargur, nanjangud, tn-pura, nanjangud-ia, gps` |

## Note on the data-repo CI

neer-vazhvu-data#18 shows a red check. It is the billing block, not a failure: the job ended 5 seconds after starting with no steps and no log blob, and the annotation reads "The job was not started because recent account payments have failed or your spending limit needs to be increased." Every recent run on that repo has the same signature, including five of Pune's. The substance was reproduced locally instead - `check-corpus.py` OK at 582 artifacts, and `build_dataset_catalogue.py`, `validate_nvdm.py` and `nvdm-encumbrance-report.py` all exit 0 at the pinned toolchain with that corpus mounted.
