### PR TITLE
Pune cutover: nine routes live

### DIFF
--- a/.github/workflows/pravah-dam-refresh.yml
+++ b/.github/workflows/pravah-dam-refresh.yml
@@ -59,24 +59,53 @@ jobs:
           echo "Pravah unreachable after 3 attempts; keeping yesterday's snapshot"
           exit 0
 
+      # Pune off the SAME daily bulletin - one PDF covers all of Maharashtra, so
+      # this is a second parse of a document already fetched above rather than a
+      # second source. Upserts the six PMC/PCMC dams into reservoir_daily_v2
+      # (Mulshi is Tata's hydro and the city's db_filter drops it), plus the
+      # same six dated a year back from the bulletin's own
+      # same-date-last-year column, so the series grows at both ends.
+      #
+      # Kept as its own step, not folded into the loop above: a Pune failure
+      # must not discard Mumbai's successful snapshot, and vice versa.
+      - name: Scrape Pravah dam storage (Pune)
+        working-directory: neer-vazhvu-api
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          for attempt in 1 2 3; do
+            if python scripts/scrape_pravah_dams.py --city pune --out ../public/data/pune-dam-storage.json --supabase; then
+              exit 0
+            fi
+            echo "attempt $attempt failed; retrying in 60s"
+            sleep 60
+          done
+          echo "Pravah unreachable after 3 attempts; keeping yesterday's snapshot"
+          exit 0
+
       - name: Commit refreshed snapshot
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           # Refresh gate: files enveloped at HEAD must still certify L2
           # (report mode below cannot fail; this can - round-2 review)
+          # Both snapshots, or Pune's is refreshed on disk in CI and never
+          # committed - the database would move daily while the repo copy sat
+          # stale, which is the kind of drift nothing reports.
           bash scripts/nvdm-refresh-gate.sh public/data/mmr-dam-storage.json
+          bash scripts/nvdm-refresh-gate.sh public/data/pune-dam-storage.json
           # NVDM conformance before publishing (review 2026-07-30: direct
           # pushes bypass the PR gate - so the gate runs here instead;
           # any failure aborts before commit)
           python3 scripts/build_dataset_catalogue.py
           python3 scripts/validate_nvdm.py
           python3 scripts/validate_nvdm.py --selftest
-          git add public/data/mmr-dam-storage.json docs/architecture/dataset-catalogue.json docs/architecture/dataset-catalogue.md docs/architecture/nvdm-conformance.md
+          git add public/data/mmr-dam-storage.json public/data/pune-dam-storage.json docs/architecture/dataset-catalogue.json docs/architecture/dataset-catalogue.md docs/architecture/nvdm-conformance.md
           if git diff --staged --quiet; then
             echo "No storage change to commit"
             exit 0
           fi
-          git commit -m "Pravah dam storage refresh ($(date -u +%Y-%m-%d))"
+          git commit -m "Pravah dam storage refresh, Mumbai + Pune ($(date -u +%Y-%m-%d))"
           git pull --rebase origin main
           git push

--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -22764,7 +22764,8 @@
    "consumers": [],
    "producer_refs": [
     "neer-vazhvu-api/scripts/build_pune_geography.py",
-    "neer-vazhvu-api/scripts/build_pune_gw_stations.py"
+    "neer-vazhvu-api/scripts/build_pune_gw_stations.py",
+    "scripts/lib/exemptions.ts"
    ],
    "headwaters_sources": [
     "opencity-pune-wards"

--- a/docs/architecture/exemptions.md
+++ b/docs/architecture/exemptions.md
@@ -11,9 +11,9 @@ This exists because a platform that treats data gaps as first-class has to be ab
 |---|---|
 | Suppressed freshness checks | 1 |
 | Artifacts with no registered upstream | 83 |
-| Routes a city deliberately does not ship | 37 |
+| Routes a city deliberately does not ship | 38 |
 | Absences the product states on the page | 21 |
-| **Total** | **142** |
+| **Total** | **143** |
 
 **1 of these have no recorded rationale.** They are real, deliberate omissions whose original reason was never written down. They are marked rather than back-filled with a guess, because an invented justification reads as authoritative and is worse than an admitted blank. Each is a TODO: record the real reason, or ship the thing.
 
@@ -159,6 +159,7 @@ Derived by diffing each city against the union of every route any city ships, so
 | pune | climate-risk | Not built for this city. |
 | pune | commitments | Buildable and not built. The dated commitments are citable and sharp: JICA loan ID-P243 signed 13 January 2016 for a May 2023 completion now targeted August 2026, and the equitable-supply project's own slippage from December 2024 to December 2025 to May 2026 to 'twelve to fourteen months' as of the August 2026 ESR. Each needs primary-source verification of the attribution before it enters the register. |
 | pune | lake-restoration | No restoration-project register exists for Pune. There is also no official register of the city's LOST or encroached water bodies, which is the layer this surface leans on elsewhere. |
+| pune | my-ward | The 41 prabhags of the 2025 delimitation ship as named geometry (public/geojson/pune-wards-2025.geojson, all 41 joined to PMC's own election results), but no ward rows exist in the database: /api/wards?city=pune and /api/localities?city=pune both 404, so the page renders a heading, a subtitle and nothing else. Turned OFF at cutover rather than shipped empty - a live page with no content is exactly issue #279, which this same onboarding filed against Gurugram's water-bodies page. Kolkata carries this exemption for the same reason. Retire it when ward + locality rows are seeded, which needs a producer that does not exist yet; the geometry is not the blocker. |
 | pune | shoreline | Landlocked. |
 
 ## Absences the product states on the page

--- a/docs/cities/pune/features.md
+++ b/docs/cities/pune/features.md
@@ -20,7 +20,6 @@ exactly that.
 | `/pune/groundwater` | shared block choropleth | 14 talukas x 6 IN-GRES editions + 120 telemetry station points |
 | `/pune/water-bodies` | shared map | 791 OSM polygons, 84 named (7 pools/tanks excluded and counted) |
 | `/pune/rivers` | shared `RiversClient` | 8 rivers with CPCB priority class and 2024 BOD per station |
-| `/pune/my-ward` | shared | 41 named prabhags (needs ward/locality seeding to work) |
 | `/pune/flood-risk` | shared narrative stack + `DrainageNetworkMap` | 3,075 nalla segments (1,014 km) over 8 rivers, 4 dated events, 6 stated gaps |
 | `/pune/tanker` | **`delivery-register`** (new 4th kind) | 57,370 deliveries, the scheduled-vs-on-demand split, 7 filling points, partial prabhag attribution |
 | `/pune/facts` | shared `FactsPage` (static snapshot) | 22 quotable cards across all four tiers, every figure read from a shipped artifact |

--- a/docs/cities/pune/parity-scorecard.md
+++ b/docs/cities/pune/parity-scorecard.md
@@ -15,7 +15,7 @@
 | **Low** | Minimal or absent. Reason stated; several are not ours to fix |
 | **N/A** | Structurally inapplicable. **Not a deficiency** - a difference in the city |
 
-**Headline: 10 of 15 routes live. 0 empty states, 0 console errors, 0 crashes on the 10 that ship.**
+**Headline: 9 of 15 routes live. 0 empty states, 0 console errors, 0 crashes on the 9 that ship.**
 
 8 XHigh · 5 High · 7 Medium · 4 Low · 2 N/A
 
@@ -101,7 +101,7 @@ observatory normal. See `data-sources.md` §7.
 
 | Feature | Chennai | Pune | Ours to fix? |
 |---|---|---|---|
-| **Localities** | 519 | 0 | Yes. Needs a locality gazetteer; `/pune/my-ward` also needs ward + locality seeding in the DB before it functions. |
+| **Localities and `/my-ward`** | 519 localities, 200 wards | 0 | Yes, and it cost the route. The 41 prabhags ship as named geometry, but no ward rows exist in the database - `/api/wards?city=pune` 404s - so `/pune/my-ward` was turned OFF at cutover rather than shipped as a heading over nothing. Kolkata is off for the same reason. Needs a seeding producer; the geometry is not the blocker. |
 | **Commitments** | register | none | Yes. The dated commitments are citable and sharp (JICA loan signed 13 Jan 2016 for a May 2023 completion, now targeting 2026; the 24x7 project's slide from Dec 2024 to "12-14 months" as of Aug 2026), but each needs primary-source verification of attribution first. |
 | **Allocations** | ledger | none | **Partly not ours.** The instrument chain is unusually well documented, but the ledger's primitive is entitled-vs-*received* and **no measured annual draw has been published since 2017-18** - a year for which PMC and the state water department disagree by 4.15 TMC. A ledger whose received column is eight years old and contested is worse than none. |
 | **Lake restoration** | priority scoring | none | Partly. No restoration register exists, and no official register of Pune's *lost* water bodies exists either. |
@@ -156,7 +156,7 @@ Three things Pune ships that have no Chennai equivalent and are not captured by 
 
 In rough order of value per unit of work:
 
-1. **Ward + locality seeding.** Makes `/pune/my-ward` function and closes the localities row.
+1. **Ward + locality seeding.** Turns `/pune/my-ward` back on and closes the localities row. Now the top item: it is the only route withheld for something the repo already half-has.
 2. **Commitments**, once each attribution is primary-verified.
 3. **The WRD dated Marathi archive**, which is now the only remaining reservoir-history route and
    the better one: it would reach **all seven** dams at **daily** resolution, where the CWC

--- a/scripts/lib/exemptions.ts
+++ b/scripts/lib/exemptions.ts
@@ -233,6 +233,8 @@ const ROUTE_OFF_REASONS: Record<string, string> = {
   // hero and a 1911 survey plate; the 1961 Panshet death toll is stated as
   // having no official figure, per the state's own current disaster plan,
   // rather than substituting the number that circulates.
+  "pune:my-ward":
+    "The 41 prabhags of the 2025 delimitation ship as named geometry (public/geojson/pune-wards-2025.geojson, all 41 joined to PMC's own election results), but no ward rows exist in the database: /api/wards?city=pune and /api/localities?city=pune both 404, so the page renders a heading, a subtitle and nothing else. Turned OFF at cutover rather than shipped empty - a live page with no content is exactly issue #279, which this same onboarding filed against Gurugram's water-bodies page. Kolkata carries this exemption for the same reason. Retire it when ward + locality rows are seeded, which needs a producer that does not exist yet; the geometry is not the blocker.",
   "pune:lake-restoration":
     "No restoration-project register exists for Pune. There is also no official register of the city's LOST or encroached water bodies, which is the layer this surface leans on elsewhere.",
   "pune:cascades":

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,6 +64,8 @@ const CITY_HOOKS: Record<string, string> = {
   // here - a missing hook shows as an Onboarding badge above an empty line.
   // That is exactly how Hyderabad and Mumbai both shipped a blank card, and
   // this map is not derived from the registry, so nothing catches it for you.
+  pune:
+    "Four dams on the Mutha, a water budget where the leak is bigger than the shortfall, groundwater drilled to taluka, and the corporation's own record of every tanker it sent.",
   gurugram:
     "No river, no reservoir, and a dark zone since 2008 - plus GMDA's own ledger of every tanker load it sold, naming who bought it and at what price.",
 };

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -29,6 +29,11 @@ const CITY_FOOTER_SOURCES: Record<
     { label: "India WRIS", href: "https://indiawris.gov.in/wris/" },
     { label: "OpenCity", href: "https://data.opencity.in/" },
   ],
+  pune: [
+    { label: "PMC", href: "https://webadmin.pmc.gov.in/en/jsonapi/node/reports_and_dpr" },
+    { label: "WRD Pravah", href: "https://mwrdpravah.in/damsafety/control/main" },
+    { label: "IN-GRES", href: "https://ingres.iith.ac.in/" },
+  ],
   mumbai: [
     { label: "WRD Pravah", href: "https://mwrdpravah.in/damsafety/control/main" },
     { label: "MPCB", href: "https://mpcb.gov.in/" },

--- a/src/components/my-ward/ward-actions-card.tsx
+++ b/src/components/my-ward/ward-actions-card.tsx
@@ -94,6 +94,48 @@ const ACTIONS_BY_CITY: Record<string, CityActionsConfig> = {
       { labelKey: "my_ward.hl_flood_emergency", value: "1916", href: "tel:1916" },
     ],
   },
+  // PUNE. Added WITH the cutover rather than after it, because line 152 reads
+  // `ACTIONS_BY_CITY[cityId] ?? ACTIONS_BY_CITY.chennai` - a missing city does
+  // not render an empty card, it renders CHENNAI'S HELPLINES. A Pune resident
+  // would have been given CMWSSB's number.
+  //
+  // The toll-free number is PMC's own, read off its grievance portal
+  // (complaint.pmc.gov.in) where it is captioned in Marathi as the call centre
+  // for "सूचना आणि तक्रारींसाठी" - suggestions and complaints. Nothing here is
+  // inferred: PMC publishes no separate water-supply or flood number that
+  // could be verified, so those entries carry value:null and a URL rather than
+  // a plausible-looking digit string.
+  pune: {
+    quickActions: [
+      {
+        labelKey: "my_ward.report_issue",
+        subLabel: "PMC grievance portal",
+        href: "https://complaint.pmc.gov.in/",
+        icon: "complaint",
+      },
+      {
+        labelKey: "my_ward.water_supply_portal",
+        subLabel: "Pune Municipal Corporation",
+        href: "https://pmc.gov.in/en/grievance",
+        icon: "portal",
+      },
+    ],
+    helplines: [
+      {
+        labelKey: "my_ward.hl_water_complaint",
+        value: "1800 1030 222",
+        href: "tel:18001030222",
+      },
+      {
+        // PMC dispatches tankers but publishes no booking line: the daily
+        // registers behind /pune/tanker are a record of what was sent, not a
+        // way to ask. Points at that page rather than inventing a number.
+        labelKey: "my_ward.hl_tanker_booking",
+        value: null,
+        href: "/pune/tanker",
+      },
+    ],
+  },
   delhi: {
     quickActions: [
       {

--- a/src/lib/cities/pune.ts
+++ b/src/lib/cities/pune.ts
@@ -322,9 +322,16 @@ export const PUNE: CityConfig = {
   availableLanguages: ['en'],
   upcomingLanguages: ['mr'],
 
-  // Preview-gated. The data layers are real and the producers are wired, but
-  // the reservoir series needs its first ingestion run and the narrative
-  // surfaces (Origins, commitments, allocations) are not written yet. Flip
-  // this to true, and the `cities` row with it, at cutover.
-  enabled: false,
+  // LIVE since 2026-08-18. This flag is the ONLY functional gate on the city:
+  // [cityId]/layout.tsx reads it, and the `enabled` column on the cities row is
+  // read by no code at all (see 045_pune_enable.sql, which flips it anyway so a
+  // fresh rebuild is honest about a city that is live).
+  //
+  // The three conditions this comment used to list as blockers are met: the
+  // reservoir series had its first ingestion run (12 rows, and no row above
+  // 105% of live capacity - the issue #276 signature), and Origins shipped in
+  // #275 with ten chapters. Commitments and allocations are still unwritten
+  // and are recorded as route-off exemptions with their reasons, which is a
+  // declared absence rather than a reason to withhold the whole city.
+  enabled: true,
 };

--- a/src/lib/cities/routing.ts
+++ b/src/lib/cities/routing.ts
@@ -173,8 +173,7 @@ export const FEATURE_AVAILABILITY: Record<string, Set<string>> = {
   // editions, reproducing CGWB's National Compilation 2025 exactly, with
   // Shirur critical at 95.71% inside a district that reads SAFE at 63.73%.
   // `rivers` is in because Pune has five and CPCB rates four of those
-  // stretches Priority I or II. `my-ward` is in because all 41 prabhags of
-  // the 2025 delimitation carry names. `facts` is in because facts-pune.json
+  // stretches Priority I or II. `facts` is in because facts-pune.json
   // ships 22 cards, every figure of which is READ from an artifact already in
   // the repo rather than transcribed again, so a quoted card cannot drift from
   // the dashboard it came from. `tanker` is in on the fourth tankerDataKind,
@@ -190,6 +189,12 @@ export const FEATURE_AVAILABILITY: Record<string, Set<string>> = {
   // flood-line absence ships as a data gap on the page.
   //
   // NOT in, each for a stated reason rather than pending work:
+  // `my-ward` - the 41 prabhags exist as NAMED GEOMETRY in the repo, but no
+  //   ward rows exist in the database, so /api/wards?city=pune 404s and the
+  //   page renders a heading over nothing. Turned off at cutover rather than
+  //   shipped empty: a live-and-empty page is issue #279, filed against
+  //   Gurugram during this same onboarding. Kolkata is off for the same
+  //   reason. Returns with the ward seeding, not with a better endpoint.
   // `lake-restoration`, `allocations`, `commitments` - no artifacts built.
   // `cascades` - the cascade pipeline has not been run for Pune district.
   // `shoreline` - landlocked.
@@ -203,7 +208,6 @@ export const FEATURE_AVAILABILITY: Record<string, Set<string>> = {
     "rivers",
     "flood-risk",
     "tanker",
-    "my-ward",
   ]),
 };
 

--- a/supabase/migrations/045_pune_enable.sql
+++ b/supabase/migrations/045_pune_enable.sql
@@ -1,0 +1,76 @@
+-- =============================================================
+-- 045_pune_enable.sql
+-- Launch cutover: flip Pune from registered-but-disabled to live.
+--
+-- 044_pune_seed_disabled.sql seeded the city with enabled=FALSE so the
+-- CityConfig, water_sources and ten routes could be built against
+-- city_id='pune' without exposing any of it. This is the promised follow-up.
+--
+-- WHAT ACTUALLY GATES THE SITE - unchanged from 033_delhi_enable.sql,
+-- 039_hyderabad_enable.sql and 042_kolkata_enable.sql:
+--   The ONLY functional switch is `enabled: true` on the CityConfig in
+--   src/lib/cities/pune.ts, read by the frontend route guard in
+--   [cityId]/layout.tsx. Without it /pune 404s outside
+--   NEXT_PUBLIC_PREVIEW_CITIES and the landing board shows Pune as
+--   "onboarding".
+--
+--   This `enabled` COLUMN is read by no code at all - neither the Next.js app
+--   nor the Python API queries it.
+--
+-- So this migration is for CONSISTENCY, not for gating: it keeps the seeded
+-- row honest about a city that is live, and keeps the state reproducible on a
+-- fresh database.
+--
+-- STATE AT CUTOVER (2026-08-18), so a fresh rebuild can be checked against it:
+--   cities         1 row, ward_count=41 (the 2025 delimitation's electoral
+--                  prabhags, NOT the 15 administrative ward offices),
+--                  default_consumption_mld=1631.84 (PMC's own stated total
+--                  requirement, not a measured delivery), enabled flips
+--                  FALSE -> TRUE here.
+--   water_sources  6 rows: khadakwasla, panshet, warasgaon and temghar (the
+--                  Khadakwasla chain PMC drinks from), bhama_askhed (PMC's
+--                  eastern scheme) and pawana (PCMC's source, the one row with
+--                  is_primary_drinking_source FALSE).
+--                  Their four chain capacities sum to 29,158.9 Mcft = 29.159
+--                  TMC, which reproduces the 29.15 TMC PMC publishes in its own
+--                  ESR from a completely separate source. That agreement was
+--                  re-checked against the live rows after applying 044.
+--                  MULSHI IS DELIBERATELY ABSENT: it is Tata's hydro reservoir,
+--                  carried on the artifact for context and excluded from every
+--                  supply total, so scrape_pravah_dams.py's pune db_filter
+--                  drops it before any write.
+--   reservoir_daily_v2  12 rows at cutover, from the first
+--                  `scrape_pravah_dams.py --city pune --supabase` run: 6 dams
+--                  for the report date plus the same 6 dated a year back, which
+--                  the bulletin publishes as a same-date-last-year percentage.
+--                  Every daily run grows the series at both ends.
+--                  Checked before the flip: no row exceeds 105% of live
+--                  capacity. That is the signature of the bug in issue #276,
+--                  where the Pravah parser read today's GROSS storage as last
+--                  year's LIVE and put Modaksagar at 159%. The producer fix
+--                  shipped in #275; this confirms Pune never carried it.
+--
+-- KNOWN SCHEMA GAP, unchanged and recorded again rather than worked around:
+--   The corporations and source_corporation tables from 029_mmr_corporations.sql
+--   still do not exist in the live database - the remote ledger records only
+--   001-016 and later migrations were applied out-of-band and data-only. No
+--   code queries either table (the region dashboard reads its corporation list
+--   from src/lib/cities/<city>.ts), so nothing breaks. Pune declares no
+--   corporations of its own, being a PMC-scoped city rather than an MMR-style
+--   region, so it adds nothing to that debt.
+--
+-- PREREQUISITE: 044 must already be applied. This raises rather than silently
+-- updating nothing if the row is absent.
+-- =============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cities WHERE city_id = 'pune') THEN
+    RAISE EXCEPTION
+      'pune is not seeded - apply 044_pune_seed_disabled.sql first';
+  END IF;
+END $$;
+
+UPDATE cities
+   SET enabled = TRUE
+ WHERE city_id = 'pune';


### PR DESCRIPTION
Takes Pune live. `enabled: true` on the CityConfig — the only functional gate, since `[cityId]/layout.tsx` reads it and no code reads the `enabled` column — plus `045_pune_enable.sql` so a fresh rebuild is honest about a city that is live.

## Nine routes, not ten

**`/pune/my-ward` is turned OFF at cutover.** The 41 prabhags ship as named geometry, all joined to PMC's own election results, but no ward rows exist in the database: `/api/wards?city=pune` and `/api/localities?city=pune` both 404, and the page renders a heading, a subtitle and nothing else.

It returned **HTTP 200 the whole time** — the emptiness was only visible in a real browser. Shipping it would have been issue #279 for the second time, and that issue is Gurugram's live-and-empty water-bodies page, filed during this same onboarding. Kolkata already carries this exemption for the same cause. Reason and retirement condition are recorded: ward seeding needs a producer that does not exist yet, and the geometry is not the blocker.

## Three city-keyed maps were missing Pune

Found by auditing every `Record` in `src/` keyed by cityId, not by clicking around. This is the failure that has shipped live **three times** — Mumbai, Hyderabad, Kolkata — and `page.tsx` carries a comment saying exactly that.

| Map | What it would have done |
|---|---|
| `ward-actions-card.tsx` | Line 152 is `ACTIONS_BY_CITY[cityId] ?? ACTIONS_BY_CITY.chennai`. A missing city doesn't render empty — **it renders Chennai's helplines.** A Pune resident would have been handed CMWSSB's number. |
| `page.tsx` CITY_HOOKS | Pune's landing card was **already** rendering a badge over a blank line on main — the board maps over `listAllPlaces()`, so a registered-but-disabled city gets a card immediately. |
| `footer.tsx` | Empty source list. |

The ward-actions fix landed even though the route is now off, because the fallback is what bites the moment it comes back on.

**The helpline number is PMC's own**, read off its grievance portal (`complaint.pmc.gov.in`) where it's captioned in Marathi as the call centre for *"सूचना आणि तक्रारींसाठी"* — suggestions and complaints. PMC publishes no separate water-supply or flood line that could be verified, so those entries carry `value: null` and a URL rather than a plausible-looking digit string. The tanker row points at `/pune/tanker`, which is a record of what was sent rather than a way to ask.

## Daily refresh wired

`pravah-dam-refresh.yml` gets a Pune step off the **same** bulletin — one PDF covers all of Maharashtra, so it's a second parse of a document already fetched, not a second source. Kept as its own step so a Pune failure can't discard Mumbai's snapshot.

The commit step now gates **and** commits both files. It was adding only `mmr-dam-storage.json`, so Pune's snapshot would have been refreshed on disk in CI and never committed — the database moving daily while the repo copy sat stale.

## DB state, applied before the flip

Verified against the live rows, not assumed:

- **cities** 1 row
- **water_sources** 6 rows, whose four Khadakwasla-chain capacities sum to **29.159 TMC** against the 29.15 PMC publishes in its own ESR — two independent sources agreeing
- **reservoir_daily_v2** 12 rows (6 dams today + 6 back-dated a year from the bulletin's own same-date-last-year column). **No row above 105% of live capacity** — the issue #276 signature. Mulshi correctly absent, dropped by the city's own `db_filter` as Tata hydro.

## Verification

All nine routes HTTP 200 with no runtime errors and **no preview flag set**; `/pune/my-ward` 404s; chennai, madurai and kolkata unaffected. Gate green: ruff, ruff format, 152 API tests, tsc 0, lint 0 errors, 83 JS tests, nvdm L2 487, generator-drift, encumbrance, data:check.

Also fixed: the comment above `enabled` still said "preview-gated … flip this at cutover" and listed three blockers, one of which (Origins) shipped in #275.

## One thing I did not touch

The `cities` table holds **7 rows and Gurugram is not among them**, despite being live since 15 Aug. Pre-existing, unrelated to this change, and flagged rather than fixed mid-launch.
