### PR TITLE
my-ward: stop serving one city's emergency numbers to another city

### DIFF
--- a/src/components/my-ward/ward-actions-card.tsx
+++ b/src/components/my-ward/ward-actions-card.tsx
@@ -136,6 +136,55 @@ const ACTIONS_BY_CITY: Record<string, CityActionsConfig> = {
       },
     ],
   },
+  // GURUGRAM. The city this bug was actually live for: /gurugram/my-ward
+  // serves in production and gurugram was missing from this map, so it was
+  // rendering Chennai's helplines.
+  //
+  // Numbers are GMDA's own, read off gmda.gov.in, which publishes them as one
+  // line: "For any query, suggestion and complaint about Grievance Redressal
+  // Portal (GRAP) pls. contact through following means: Toll free number and
+  // PRI Number ( 18001801817, 01242653908) WEB portal ( services.gmda.gov.in )".
+  // Nothing here is inferred. MCG's own site serves a 1 KB shell with no
+  // contact details at all, so the municipal corporation contributes no
+  // verifiable number and none is invented for it.
+  gurugram: {
+    quickActions: [
+      {
+        labelKey: "my_ward.report_issue",
+        subLabel: "GMDA grievance redressal (GRAP)",
+        href: "https://services.gmda.gov.in/",
+        icon: "complaint",
+      },
+      {
+        labelKey: "my_ward.water_supply_portal",
+        subLabel: "Gurugram Metropolitan Development Authority",
+        href: "https://www.gmda.gov.in/",
+        icon: "portal",
+      },
+    ],
+    helplines: [
+      {
+        labelKey: "my_ward.hl_water_complaint",
+        value: "1800 180 1817",
+        href: "tel:18001801817",
+      },
+      {
+        // GMDA publishes this PRI line beside the toll-free one for the same
+        // grievance portal; carried because a toll-free number is not always
+        // reachable from every network.
+        labelKey: "my_ward.hl_mmc_helpline",
+        value: "0124 265 3908",
+        href: "tel:01242653908",
+      },
+      {
+        // Gurugram's tanker supply IS a published sales ledger rather than a
+        // booking line - point at it instead of inventing a number.
+        labelKey: "my_ward.hl_tanker_booking",
+        value: null,
+        href: "/gurugram/tanker",
+      },
+    ],
+  },
   delhi: {
     quickActions: [
       {
@@ -188,10 +237,21 @@ export function WardActionsCard({ wardNumber }: Props) {
   const { t } = useLanguage();
   const { cityId } = useMyWardCity();
   const [helpOpen, setHelpOpen] = useState(false);
-  // Fall back to Chennai when no per-city config is registered, so a new
-  // city onboarded without an entry here at least renders something
-  // sensible until its config lands.
-  const actionsConfig = ACTIONS_BY_CITY[cityId] ?? ACTIONS_BY_CITY.chennai;
+  // NO FALLBACK. This used to read `?? ACTIONS_BY_CITY.chennai`, on the
+  // reasoning that a city onboarded without an entry would "at least render
+  // something sensible". What it actually rendered was ANOTHER CITY'S
+  // EMERGENCY NUMBERS: a Gurugram resident opening this card was shown
+  // CMWSSB's complaint line, Chennai's water utility, 1,900 km away. That is
+  // not a degraded experience, it is wrong information presented with the same
+  // confidence as right information - the one failure mode a card full of
+  // helplines must not have.
+  //
+  // Rendering nothing is the honest degradation: the ward page keeps its other
+  // sections, and a missing city is VISIBLY missing rather than silently
+  // wearing Chennai's. Adding a city here is a launch step, and now it fails
+  // loudly enough to notice. See issue #286.
+  const actionsConfig = ACTIONS_BY_CITY[cityId];
+  if (!actionsConfig) return null;
 
   return (
     <Card>

--- a/src/components/my-ward/ward-actions-coverage.test.ts
+++ b/src/components/my-ward/ward-actions-coverage.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Every city whose /my-ward route ships must have an entry in
+ * ACTIONS_BY_CITY.
+ *
+ * This exists because of issue #286. The card used to read
+ * `ACTIONS_BY_CITY[cityId] ?? ACTIONS_BY_CITY.chennai`, so a city missing from
+ * that map did not render an empty card - it rendered CHENNAI'S EMERGENCY
+ * NUMBERS. Gurugram shipped /my-ward for weeks showing CMWSSB's complaint line
+ * to residents 1,900 km away, and nothing caught it because the page looked
+ * complete and returned HTTP 200.
+ *
+ * The fallback is gone, so the failure mode is now a missing card rather than
+ * wrong information. This test closes the other half: it fails the build if a
+ * city turns its route on without adding real contact details, instead of
+ * letting the card silently vanish.
+ *
+ * Deliberately NOT asserting the reverse: mumbai and pune carry entries while
+ * their routes are off, which is correct - the config is ready for whenever
+ * they turn on.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const routing = readFileSync(join(root, "src/lib/cities/routing.ts"), "utf-8");
+const card = readFileSync(join(root, "src/components/my-ward/ward-actions-card.tsx"), "utf-8");
+
+function citiesShippingMyWard(): string[] {
+  const block = routing.slice(
+    routing.indexOf("FEATURE_AVAILABILITY"),
+    routing.indexOf("\n};", routing.indexOf("FEATURE_AVAILABILITY")),
+  );
+  const out: string[] = [];
+  for (const m of block.matchAll(/^ {2}([a-z]+): new Set\(\[([\s\S]*?)\]\)/gm)) {
+    if (m[2].includes('"my-ward"')) out.push(m[1]);
+  }
+  return out;
+}
+
+function citiesWithActions(): Set<string> {
+  const block = card.slice(
+    card.indexOf("const ACTIONS_BY_CITY"),
+    card.indexOf("\n};", card.indexOf("const ACTIONS_BY_CITY")),
+  );
+  return new Set([...block.matchAll(/^ {2}([a-z]+): \{$/gm)].map((m) => m[1]));
+}
+
+test("every city shipping /my-ward has ward-actions contact details", () => {
+  const ships = citiesShippingMyWard();
+  const configured = citiesWithActions();
+  assert.ok(ships.length > 0, "no city ships /my-ward - the parser is broken, not the config");
+  const missing = ships.filter((c) => !configured.has(c));
+  assert.deepEqual(
+    missing,
+    [],
+    `${missing.join(", ")} ship /my-ward with no entry in ACTIONS_BY_CITY. ` +
+      "Since issue #286 removed the Chennai fallback, the actions card will not " +
+      "render at all for these cities. Add each city's OWN agency numbers and " +
+      "portal URLs, primary-sourced - never another city's, and never a " +
+      "plausible-looking number.",
+  );
+});
+
+/** Strip comments so the check reads CODE, not prose.
+ *
+ *  The first version of the test below failed on its own documentation: the
+ *  comment in ward-actions-card.tsx quotes the old expression verbatim to
+ *  explain what was wrong with it, and a raw-text scan cannot tell an
+ *  explanation from a reintroduction. */
+function codeOnly(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^\s*\/\/.*$/gm, " ");
+}
+
+test("the Chennai fallback has not come back", () => {
+  const code = codeOnly(card);
+  assert.ok(
+    !/ACTIONS_BY_CITY\[[^\]]+\]\s*\?\?/.test(code),
+    "ward-actions-card falls back to another city's config again. That is issue " +
+      "#286: it renders one city's emergency numbers to another city's residents. " +
+      "A missing city must render no card, not somebody else's helplines.",
+  );
+  assert.ok(
+    /const actionsConfig = ACTIONS_BY_CITY\[cityId\];/.test(code),
+    "expected the plain lookup with no fallback - if this line moved, update the test",
+  );
+});


### PR DESCRIPTION
Fixes #286.

`ward-actions-card.tsx` read:

```ts
const actionsConfig = ACTIONS_BY_CITY[cityId] ?? ACTIONS_BY_CITY.chennai;
```

with the stated intent that a city onboarded without an entry would "at least render something sensible". What it rendered was **another city's emergency numbers** — not a degraded experience, but wrong information carrying exactly the same confidence as right information. That's the one failure a card full of helplines must not have.

**Gurugram was live with it.** `/gurugram/my-ward` serves in production and `gurugram` was missing from the map, so residents were being shown CMWSSB's complaint line — a water utility 1,900 km away in Chennai.

## I had this backwards when I filed the issue

#286 says Hyderabad ships `/my-ward` and is exposed, with Gurugram and Kolkata latent. Checked against production:

| City | `/my-ward` |
|---|---|
| hyderabad | **404** |
| kolkata | **404** |
| **gurugram** | **200** ← the affected one |

Exactly one city was affected and it wasn't the one I named. Corrected on the issue.

## Two changes

**The fallback is gone.** A city with no entry renders no card, keeping the rest of the ward page. A missing city is now *visibly* missing rather than silently wearing Chennai's identity.

**Gurugram gets a real entry.** Numbers are GMDA's own, read off `gmda.gov.in`, which publishes them in one line:

> For any query, suggestion and complaint about Grievance Redressal Portal (GRAP) pls. contact through following means: Toll free number and PRI Number ( 18001801817, 01242653908) WEB portal ( services.gmda.gov.in )

Both numbers carried, since a toll-free line isn't reachable from every network. **MCG's own site serves a 1 KB shell with no contact details at all**, so the municipal corporation contributes nothing verifiable and nothing is invented for it. Tanker points at `/gurugram/tanker` — that city publishes a sales ledger, not a booking line.

**Hyderabad and Kolkata stay absent on purpose.** Neither ships `/my-ward`, and I won't guess at helplines for cities whose routes are off. The fallback removal is what protects them if either is turned on — they now fail visible rather than fail Chennai.

## A test closes the other half

Removing the fallback turns a wrong card into a missing one, which is also worth catching. The test asserts every city shipping `/my-ward` has an entry, and that the fallback hasn't returned. Both confirmed to fail when broken deliberately — reinstating the `??` drops the suite to 84 pass / 1 fail.

The second assertion needed hardening first: it failed on its own documentation, because the comment explaining the old expression quotes it verbatim and a raw-text scan can't tell an explanation from a reintroduction. It strips comments now.

## Verification

85 tests pass, tsc 0, lint 0 errors, `data:check` clean. Coverage checked across the registry — bangalore, chennai, delhi, gurugram, madurai ship `/my-ward` and all five have entries, so no live card disappears; mumbai and pune carry entries with routes off, which is correct.
