### PR TITLE
Cooum cutover: corpus re-pin (497/114) + enabled

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -35,12 +35,13 @@
     "'buckingham-canal', kind 'waterway'), the first non-city, non-basin",
     "family in the corpus. Imagery for the canal page lives in the public",
     "repo under public/images/waterways/ - the corpus stays json/geojson.",
-    "The page goes LIVE with neer-vazhvu#287, which carries this bump."
+    "The page goes LIVE with neer-vazhvu#287, which carries this bump.",
+    "2026-08-19 (evening): the Cooum release plus the corrected Buckingham Canal set (data#23, squash 09a1c15f). 497 under data/ and 114 under geojson/, up from 490 / 114 - the Cooum's 7 waterway-scope artifacts, and 5 canal artifacts re-synced with the 20 Aug freshness corrections (sanction record, works-on-hold status, UCF hedge, plain language). This bump ships in the same PR as the cooum manifest flip to enabled:true - merging it launches the page and updates the live canal page in one deploy. Cooum imagery lives under public/images/waterways/ in this repo, per the canal precedent."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "da321e63963640a3c7047c177c8bc032f575ee3e",
+  "sha": "09a1c15f1ef1ab010b33401884358e3689242f9f",
   "expected_files": {
-    "data": 490,
+    "data": 497,
     "geojson": 114
   }
 }

--- a/src/lib/waterways/cooum.ts
+++ b/src/lib/waterways/cooum.ts
@@ -7,8 +7,10 @@ import type { WaterwayManifest } from "./types";
  * docs/waterways/cooum/waterway-curation.json; decisions:
  * docs/waterways/cooum/DECISIONS.md (C1-C7).
  *
- * Ships preview-gated (enabled: false); surfaces on preview builds via
- * NEXT_PUBLIC_PREVIEW_WATERWAYS=cooum.
+ * Enabled for production 19 Aug 2026, same-day as the preview review:
+ * facts-only voice (DECISIONS C8), two freshness rounds folded (C9),
+ * corpus release data#23. Joins nav registry-driven: with two Chennai
+ * waterways the Explore entry now lands on the /waterways index.
  */
 export const COOUM: WaterwayManifest = {
   waterwayId: "cooum",
@@ -26,5 +28,5 @@ export const COOUM: WaterwayManifest = {
     "Chainage runs west to east: km 0 at the origin junction near " +
     "Satharai, km 62.8 at the Bay of Bengal mouth.",
   cityIds: ["chennai"],
-  enabled: false,
+  enabled: true,
 };


### PR DESCRIPTION
The launch PR. corpus.lock moves to data#23's squash (09a1c15f): the Cooum's seven artifacts plus the five corrected Buckingham Canal artifacts, counts 490/114 -> 497/114, verified by running fetch-corpus against the new pin in a throwaway worktree (497/114 synced; cooum files byte-identical; the canal corrections present in the fetched tree). The cooum manifest flips to enabled: true - the preview badge self-retires, and Chennai's Explore entry lands on the /waterways index now that the city has two waterways, all registry-driven with no nav code changes.

Merging this launches the Cooum page publicly and ships the canal's freshness corrections to the live site in the same deploy. After it merges I re-pin the data repo's toolchain to main and the release chain is closed.