### PR TITLE
Pin the corpus at the 50 m densification release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -14,10 +14,11 @@
     "Arkavathi 2025 stretch rebuilt from the canonical PRS layer at 109.1 km, the",
     "earlier epoch relabelled 2018 at 64.6 km, and the September 2025 MPR read so",
     "asOf values move forward a month. Seven files edited, none added or removed,",
-    "so expected_files is unchanged at 497/114."
+    "so expected_files is unchanged at 497/114.",
+    "2026-08-20: the 50 m measurement grid (data#26, squash 3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44). Modification-only: 12 waterway artifacts re-synced from neer-vazhvu#296, no files added or removed, so expected_files stays 497/114 and this bump moves only the sha. Both waterway pages' transects and condition strips move to 50 m; methods sections ship per waterway in reaches.json."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "0d70b0771ee6cc57f5f164fad7beff5a2c1aff46",
+  "sha": "3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44",
   "expected_files": {
     "data": 497,
     "geojson": 114


### PR DESCRIPTION
Sha-only bump to data#26's squash (3dcf72a4): the 50 m measurement grid for both waterways, 12 artifacts modified, none added or removed, expected_files unchanged at 497/114. Fetch-corpus verified against the new pin in a throwaway worktree: 497/114 synced, the served Cooum reads 62.9 km with 1,049 of 1,258 transects and its 6 methods sections. After this merges the data repo's toolchain re-pins to main and the chain is closed.