### PR TITLE
Pin the corpus at the opener-title release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -15,10 +15,11 @@
     "earlier epoch relabelled 2018 at 64.6 km, and the September 2025 MPR read so",
     "asOf values move forward a month. Seven files edited, none added or removed,",
     "so expected_files is unchanged at 497/114.",
-    "2026-08-20: the 50 m measurement grid (data#26, squash 3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44). Modification-only: 12 waterway artifacts re-synced from neer-vazhvu#296, no files added or removed, so expected_files stays 497/114 and this bump moves only the sha. Both waterway pages' transects and condition strips move to 50 m; methods sections ship per waterway in reaches.json."
+    "2026-08-20: the 50 m measurement grid (data#26, squash 3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44). Modification-only: 12 waterway artifacts re-synced from neer-vazhvu#296, no files added or removed, so expected_files stays 497/114 and this bump moves only the sha. Both waterway pages' transects and condition strips move to 50 m; methods sections ship per waterway in reaches.json.",
+    "2026-08-20: the opener-title release (data#28, squash 6412b0bee3c3cafeda8cbc03bfc5d3e59e8667f3). Two chapters.json artifacts re-synced from neer-vazhvu#298; counts stay 497/114 - a sha-only bump. The canal's first line becomes 'From Ennore to Mahabalipuram, fifty metres at a time', the Cooum's 'From Satharai to the sea, fifty metres at a time'."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44",
+  "sha": "6412b0bee3c3cafeda8cbc03bfc5d3e59e8667f3",
   "expected_files": {
     "data": 497,
     "geojson": 114


### PR DESCRIPTION
Sha-only bump to data#28's squash: two retitled chapters.json artifacts, counts unchanged at 497/114. Fetch verified against the pin in a throwaway worktree - both new first lines confirmed in the fetched tree.