### PR TITLE
Pin the corpus at the estimates + locator release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -16,10 +16,11 @@
     "asOf values move forward a month. Seven files edited, none added or removed,",
     "so expected_files is unchanged at 497/114.",
     "2026-08-20: the 50 m measurement grid (data#26, squash 3dcf72a4e07eca7a8016e2ab3340afb6e21a1f44). Modification-only: 12 waterway artifacts re-synced from neer-vazhvu#296, no files added or removed, so expected_files stays 497/114 and this bump moves only the sha. Both waterway pages' transects and condition strips move to 50 m; methods sections ship per waterway in reaches.json.",
-    "2026-08-20: the opener-title release (data#28, squash 6412b0bee3c3cafeda8cbc03bfc5d3e59e8667f3). Two chapters.json artifacts re-synced from neer-vazhvu#298; counts stay 497/114 - a sha-only bump. The canal's first line becomes 'From Ennore to Mahabalipuram, fifty metres at a time', the Cooum's 'From Satharai to the sea, fifty metres at a time'."
+    "2026-08-20: the opener-title release (data#28, squash 6412b0bee3c3cafeda8cbc03bfc5d3e59e8667f3). Two chapters.json artifacts re-synced from neer-vazhvu#298; counts stay 497/114 - a sha-only bump. The canal's first line becomes 'From Ennore to Mahabalipuram, fifty metres at a time', the Cooum's 'From Satharai to the sea, fifty metres at a time'.",
+    "2026-08-20: the locator-anchors + labelled-estimates release (data#30, squash 15d251bae82af2a850c59e4c3a0d0b07ad6f9657). Four waterway artifacts re-synced from neer-vazhvu#300 and #301; counts stay 497/114 - a sha-only bump. The canal strips carry 50 OFFSET + 241 calibration-gated spectral estimates; the Cooum ships none by the quality gate, stated in its methods."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "6412b0bee3c3cafeda8cbc03bfc5d3e59e8667f3",
+  "sha": "15d251bae82af2a850c59e4c3a0d0b07ad6f9657",
   "expected_files": {
     "data": 497,
     "geojson": 114


### PR DESCRIPTION
Sha-only bump to data#30's squash: locator anchors and the labelled width estimates go live on both pages. Counts unchanged at 497/114; fetch verified against the pin in a throwaway worktree (canal 241 spectral transects + 5 anchors, cooum 0 spectral + 5 anchors, exactly as gated). Toolchain re-pin follows the merge.