### PR TITLE
Surat cutover: nine routes live

### DIFF
--- a/docs/cities/surat/features.md
+++ b/docs/cities/surat/features.md
@@ -4,8 +4,9 @@ What ships for Surat, and what each surface is doing differently from the Chenna
 and their traps live alongside in [data-sources.md](data-sources.md); measured parity is in
 [parity-scorecard.md](parity-scorecard.md).
 
-Surat is registered `enabled: false` and reachable only behind
-`NEXT_PUBLIC_PREVIEW_CITIES=surat` until cutover.
+**Surat went live on 2026-08-20** as city nine, on corpus-2026-08-20-surat-r2. Nine routes;
+`/surat/my-ward` is off, along with six other routes, each with a recorded reason in the
+exemption register.
 
 ## The shape of the city, and what follows from it
 

--- a/src/app/[cityId]/city-dashboard.tsx
+++ b/src/app/[cityId]/city-dashboard.tsx
@@ -644,13 +644,33 @@ export async function CityDashboard({ cityId }: { cityId: string }) {
         </Link>
       </div>
 
-      {/* Footer methodology */}
+      {/* Footer methodology.
+
+          BOTH CLAUSES ARE CONDITIONAL, and neither used to be. This paragraph
+          asserted "Reservoir levels for <city> from <acronym>" for every city,
+          including the run-of-river ones that impound nothing - Kolkata and
+          Gurugram both shipped live saying it - and it printed the consumption
+          figure as "~- MLD demand" wherever defaultConsumptionMld is null,
+          then promised sliders to adjust a number that is not there.
+
+          `impounds` is the same signal ReservoirCards uses a few dozen lines
+          up, for the same reason: a city's water_sources say whether it
+          actually stores water or just takes it from a river. */}
       <div className="text-xs text-slate-500 dark:text-slate-400 pt-4 border-t border-slate-200 dark:border-slate-700 space-y-2">
         <p>
-          <span className="font-semibold">Methodology:</span> Reservoir
-          levels for {config.displayName} from {config.primaryAuthority.acronym}.
-          Daily consumption assumptions (~{config.defaultConsumptionMld ?? "-"} MLD demand) are starting
-          points; the sliders above let you substitute your own. See the
+          <span className="font-semibold">Methodology:</span>{" "}
+          {config.waterSources.some((s) => s.type === "reservoir")
+            ? "Reservoir levels"
+            : "Source levels"}{" "}
+          for {config.displayName} from {config.primaryAuthority.acronym}.
+          {config.defaultConsumptionMld != null && (
+            <>
+              {" "}Daily consumption assumptions (~{config.defaultConsumptionMld} MLD
+              demand) are starting points; the sliders above let you substitute
+              your own.
+            </>
+          )}{" "}
+          See the
           <Link href={`/${cityId}/about`} className="text-blue-600 dark:text-blue-400 hover:underline mx-1">
             About page
           </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,6 +66,8 @@ const CITY_HOOKS: Record<string, string> = {
   // this map is not derived from the registry, so nothing catches it for you.
   pune:
     "Four dams on the Mutha, a water budget where the leak is bigger than the shortfall, groundwater drilled to taluka, and the corporation's own record of every tanker it sent.",
+  surat:
+    "A live flood chain from Ukai to five khadis, six editions of river monitoring, and two CETPs against their own consent.",
   gurugram:
     "No river, no reservoir, and a dark zone since 2008 - plus GMDA's own ledger of every tanker load it sold, naming who bought it and at what price.",
 };

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -34,6 +34,11 @@ const CITY_FOOTER_SOURCES: Record<
     { label: "WRD Pravah", href: "https://mwrdpravah.in/damsafety/control/main" },
     { label: "IN-GRES", href: "https://ingres.iith.ac.in/" },
   ],
+  surat: [
+    { label: "Surat Municipal Corporation", href: "https://www.suratmunicipal.gov.in/Home/RainfallInfo" },
+    { label: "CPCB NWMP", href: "https://cpcb.gov.in/water-quality-data/" },
+    { label: "GEMI", href: "https://gemi.gujarat.gov.in/" },
+  ],
   mumbai: [
     { label: "WRD Pravah", href: "https://mwrdpravah.in/damsafety/control/main" },
     { label: "MPCB", href: "https://mpcb.gov.in/" },

--- a/src/lib/cities/surat.ts
+++ b/src/lib/cities/surat.ts
@@ -284,5 +284,10 @@ export const SURAT: CityConfig = {
     singanpore: 'singanpor_weir',
   },
 
-  enabled: false,
+  // LIVE 2026-08-20. This flag is the only functional gate on the whole
+  // cutover: [cityId]/layout.tsx reads it, and the `enabled` COLUMN in the
+  // cities table is read by no code at all. 048_surat_enable.sql exists so a
+  // fresh rebuild is honest about a city that is live, not because it switches
+  // anything.
+  enabled: true,
 };

--- a/supabase/migrations/046_surat_seed_disabled.sql
+++ b/supabase/migrations/046_surat_seed_disabled.sql
@@ -1,5 +1,5 @@
 -- =============================================================
--- 044_surat_seed_disabled.sql
+-- 046_surat_seed_disabled.sql
 -- Seeds Surat as a registered but disabled standalone CITY (the Delhi
 -- model, not Kolkata's region model).
 --

--- a/supabase/migrations/047_surat_water_sources.sql
+++ b/supabase/migrations/047_surat_water_sources.sql
@@ -1,5 +1,5 @@
 -- =============================================================
--- 045_surat_water_sources.sql
+-- 047_surat_water_sources.sql
 -- Surat's two tracked points on the Tapi. Neither is a reservoir, and
 -- that is the whole point.
 --

--- a/supabase/migrations/048_surat_enable.sql
+++ b/supabase/migrations/048_surat_enable.sql
@@ -1,0 +1,80 @@
+-- =============================================================
+-- 048_surat_enable.sql
+-- Launch cutover: flip Surat from registered-but-disabled to live.
+--
+-- 046_surat_seed_disabled.sql seeded the city with enabled=FALSE so the
+-- CityConfig, water_sources and nine routes could be built against
+-- city_id='surat' without exposing any of it. This is the promised follow-up.
+--
+-- RENUMBERED FROM 044/045. Surat's two seed migrations were authored as 044
+-- and 045 while this branch was open, and Pune took the same two numbers on
+-- main in the meantime, so the merged tree carried duplicate version prefixes.
+-- Nothing keyed on them - the remote ledger records only 001-016 and later
+-- migrations were applied out-of-band - so renaming is safe and makes a fresh
+-- rebuild deterministic instead of relying on 'p' sorting before 's'.
+--
+-- WHAT ACTUALLY GATES THE SITE - unchanged from 033_delhi_enable.sql,
+-- 039_hyderabad_enable.sql, 042_kolkata_enable.sql and 045_pune_enable.sql:
+--   The ONLY functional switch is `enabled: true` on the CityConfig in
+--   src/lib/cities/surat.ts, read by the frontend route guard in
+--   [cityId]/layout.tsx. Without it /surat 404s outside
+--   NEXT_PUBLIC_PREVIEW_CITIES and the landing board shows Surat as
+--   "onboarding".
+--
+--   This `enabled` COLUMN is read by no code at all - neither the Next.js app
+--   nor the Python API queries it.
+--
+-- So this migration is for CONSISTENCY, not for gating: it keeps the seeded
+-- row honest about a city that is live, and keeps the state reproducible on a
+-- fresh database.
+--
+-- STATE AT CUTOVER (2026-08-20), so a fresh rebuild can be checked against it:
+--   cities         1 row, ward_count=30 (the electoral wards SMC is elected
+--                  on, 4 corporators each - NOT the analytical unit, which is
+--                  the zone; see 046 for why "ward" means three incompatible
+--                  things in Surat), default_consumption_mld=NULL because SMC
+--                  publishes no measured delivery figure and inventing one
+--                  would put a number under a hero that is about flood
+--                  headroom, not supply runway. enabled flips FALSE -> TRUE.
+--   water_sources  2 rows, and NEITHER is a reservoir. Surat is run-of-river
+--                  like Kolkata: it impounds nothing of its own, so days-left
+--                  is undefined rather than un-backfilled. Both rows are
+--                  flow_station on purpose - ukai (full_tank_level_ft 345.0,
+--                  operated by the Gujarat Water Resources Department, ~100 km
+--                  upstream) and singanpor_weir, the weir-cum-causeway pond
+--                  SMC actually abstracts from, which is the one carrying
+--                  is_primary_drinking_source TRUE. Recording Ukai as a
+--                  reservoir would let its volume be counted as Surat storage,
+--                  which it is not: Surat's share is published nowhere.
+--   reservoir_daily_v2  NO ROWS, and none expected. There is nothing to fill
+--                  them with. The live chain is scraped to
+--                  surat-flood-chain.json by the launchd job, not to the
+--                  database, because SMC's page is a rolling ~10-reading
+--                  window with no archive and the artifact is what the
+--                  flood-headroom hero reads.
+--
+-- KNOWN SCHEMA GAP, unchanged and recorded again rather than worked around:
+--   The corporations and source_corporation tables from 029_mmr_corporations.sql
+--   still do not exist in the live database. No code queries either table, and
+--   Surat declares no corporations of its own, so it adds nothing to that debt.
+--
+-- ALSO NOTED AND NOT TOUCHED: Gurugram has been live since 15 Aug and still has
+--   no row in the cities table - 043_gurugram_seed_enabled.sql was never
+--   applied. Pre-existing, unrelated to Surat, and harmless for the same reason
+--   this migration is cosmetic: no code reads these rows to gate anything.
+--
+-- PREREQUISITE: 046 must already be applied. This raises rather than silently
+-- updating nothing if the row is absent.
+-- =============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cities WHERE city_id = 'surat') THEN
+    RAISE EXCEPTION
+      'surat is not seeded - apply 046_surat_seed_disabled.sql first';
+  END IF;
+END $$;
+
+UPDATE cities
+   SET enabled = TRUE
+ WHERE city_id = 'surat';


### PR DESCRIPTION
enabled:true on the CityConfig, which is the only functional gate - layout.tsx
reads it and no code reads the `enabled` column - plus 048_surat_enable.sql so
a fresh rebuild is honest about a city that is live.

NINE ROUTES. /surat/my-ward stays off with the other six, each with a reason
already in the exemption register. "Ward" in Surat means three incompatible
things and the authoritative one is behind a WMS with WFS disabled, so there is
no geometry to hang a ward page on.

MIGRATIONS RENUMBERED 044/045 -> 046/047. Pune took the same two numbers on
main while this branch was open, so the merged tree carried duplicate version
prefixes. Nothing keyed on them - the remote ledger records only 001-016 - so
renaming makes a fresh rebuild deterministic instead of relying on 'p' sorting
before 's'.

TWO CITY-KEYED MAPS WERE MISSING SURAT, found by auditing every Record in src/
keyed by cityId rather than by clicking: CITY_HOOKS in page.tsx (the landing
card would have rendered a Live badge above an empty line) and
CITY_FOOTER_SOURCES. ward-actions-card and wards-vintage are correctly absent -
Surat has no ward surfaces - and city-landmark falls back to GenericSkyline by
design.

THE DASHBOARD METHODOLOGY LINE WAS WRONG FOR THREE CITIES, not just Surat. It
asserted "Reservoir levels for <city> from <acronym>" unconditionally, so
Kolkata and Gurugram have both been live telling readers they have reservoirs
they do not have; and where defaultConsumptionMld is null it printed "~- MLD
demand" and then offered sliders to adjust a number that is not there. Both
clauses are now conditional, keyed on the same waterSources signal
ReservoirCards already uses. Madurai and Pune are unchanged.

Verified with the preview flag EMPTY and against the locked corpus: all nine
routes 200, /surat/my-ward 404s, /nagpur 404s as a control, no runtime errors
on any route, and the landing card reads Live. Database applied - cities and
water_sources rows in place, enabled flipped. Both CI jobs green locally.

Noted and not touched: Gurugram has been live since 15 Aug and still has no row
in the cities table; 043_gurugram_seed_enabled.sql was never applied. Harmless
for the same reason 048 is cosmetic, but it should be applied.