### PR TITLE
fix(surat): a live city was flying a PREVIEW pill for an ingestion that is not coming

### DIFF
--- a/docs/architecture/exemptions.md
+++ b/docs/architecture/exemptions.md
@@ -12,8 +12,8 @@ This exists because a platform that treats data gaps as first-class has to be ab
 | Suppressed freshness checks | 1 |
 | Artifacts with no registered upstream | 84 |
 | Routes a city deliberately does not ship | 45 |
-| Absences the product states on the page | 24 |
-| **Total** | **154** |
+| Absences the product states on the page | 25 |
+| **Total** | **155** |
 
 **1 of these have no recorded rationale.** They are real, deliberate omissions whose original reason was never written down. They are marked rather than back-filled with a guess, because an invented justification reads as authoritative and is worse than an admitted blank. Each is a TODO: record the real reason, or ship the thing.
 
@@ -199,5 +199,6 @@ Gaps the UI itself renders rather than hiding: the reason below is the copy a re
 | pune | UI language: mr | Advertised as coming soon and rendered as a disabled chip. The mr dictionary is not populated, and must be translated by a native speaker rather than machine-generated, so the UI falls back to English by contract until it is. |
 | surat | storage history chart | Surat has no storage history and will not grow one. The city impounds nothing: it abstracts from a weir pond on the Tapi, which is a river reach rather than a reservoir, and the dam upstream belongs to the state irrigation department, which publishes a level but no volume and no Surat share. Level over a full-reservoir mark is not a quantity of water, so there is nothing here to chart. What Surat does have is the live flood chain at the top of this page. |
 | surat | UI language: gu | Advertised as coming soon and rendered as a disabled chip. The gu dictionary is not populated, and must be translated by a native speaker rather than machine-generated, so the UI falls back to English by contract until it is. |
+| surat | water source: Weir-cum-causeway (Singanpor) | The weir pond is the city’s actual intake. Level and outflow are published hourly; the impounded volume is not, and the pond is a river reach rather than a reservoir, so no capacity is carried. |
 | surat | water-bodies catchment atlas | Surat has no cascade view, and that is a judgement about the city rather than a missing dataset. The cascade layer reconstructs chained tank systems - the Tamil kanmoi networks and the Bengaluru kere chains, where each tank's surplus was engineered to feed the next over centuries. Surat's water bodies are coastal wetlands, tidal creeks and urban talavs on a flat estuarine plain. The algorithm would find downhill neighbours here because it always does, and drawing them as a cascade would assert an inheritance the city does not have. |
 

--- a/src/lib/cities/surat.ts
+++ b/src/lib/cities/surat.ts
@@ -165,7 +165,18 @@ export const SURAT: CityConfig = {
       catchmentAreaSqkm: null,
       displayOrder: 2,
       isPrimaryDrinkingSource: true,
-      hasPublicFeed: true,
+      // FALSE, and the flag's own doc is what decides it: "such sources are
+      // excluded from ingestion-liveness checks: they can never have a
+      // reading". This one can never have a reading. SMC publishes the weir's
+      // level hourly, so a feed plainly exists - but the liveness check asks
+      // whether a DAILY STORAGE reading can land in reservoir_daily_v2, and a
+      // level in metres on a river reach is not one. 048_surat_enable.sql
+      // records the same fact from the database side: no rows, and none
+      // expected. Left true, this put "PREVIEW - waiting for first daily
+      // ingestion" on a live city's dashboard, promising an ingestion that
+      // is not coming. Surat's live state is the flood-headroom hero, which
+      // reads the scraped artifact.
+      hasPublicFeed: false,
       noFeedNote:
         'The weir pond is the city’s actual intake. Level and outflow are published hourly; the impounded volume is not, and the pond is a river reach rather than a reservoir, so no capacity is carried.',
     },


### PR DESCRIPTION
The cutover shipped correctly and the dashboard still carried "PREVIEW -
waiting for first daily ingestion" next to the city name. Nothing is waiting.

singanpor_weir is Surat's primary drinking source and had hasPublicFeed:true,
so the liveness check looked for a reservoir_daily_v2 reading, found none, and
concluded the city was mid-onboarding. It will never find one. SMC publishes
the weir's level hourly - a feed plainly exists - but the check is asking
whether a daily STORAGE reading can land, and a level in metres on a river
reach is not one. 048_surat_enable.sql already records the same fact from the
database side: no rows, and none expected. Surat's live state is the
flood-headroom hero, which reads the scraped artifact, and that card was
rendering fine underneath the pill that said it was not.

hasPublicFeed:false is what the flag's own doc asks for here - "such sources
are excluded from ingestion-liveness checks: they can never have a reading" -
and it is what Delhi and Mumbai already use for the same reason.

The exemption register picked the change up on its own and now carries the
weir with its noFeedNote as the rationale, 155 entries.

Checked every city on production first: Surat was the only one showing the
pill. Madurai shows it locally only because this machine's database has no
ingestion, not from this change.