### PR TITLE
fix: clicking any Surat water body took the page down, and three links pointed at 404s

### DIFF
--- a/src/app/[cityId]/about/pune-page-descriptions.tsx
+++ b/src/app/[cityId]/about/pune-page-descriptions.tsx
@@ -293,11 +293,14 @@ export function PunePageDescriptions({ cityId, cityName }: Props) {
             a substitute for this layer.
           </p>
         </Gap>
+        {/* NOT A LINK. This said "Ward boundaries" as a link to /{cityId}/my-ward,
+            and Pune's my-ward route is deliberately off - the cutover turned it
+            off because no ward rows exist in the database, so the page rendered
+            a heading and nothing else. The geometry this sentence describes is
+            real; the page that would show it is not, so the prose stands on its
+            own rather than pointing at a 404. */}
         <p className={P}>
-          <Link href={`/${cityId}/my-ward`} className={A}>
-            Ward boundaries
-          </Link>{" "}
-          are the 41 electoral prabhags of the 2025 delimitation, used for the
+          Ward boundaries are the 41 electoral prabhags of the 2025 delimitation, used for the
           2026 PMC election. The published boundary file carries no ward names at
           all - only numbers - so the names come from PMC&apos;s own election
           results, joined 41 of 41. PMC separately runs 15 administrative ward

--- a/src/app/[cityId]/commitments/commitments-client.tsx
+++ b/src/app/[cityId]/commitments/commitments-client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { isFeatureSupportedForCity } from "@/lib/cities/routing";
 
 /* ── The Commitments Register ───────────────────────────────────────────
    Dated commitments by named institutions, with a verification lifecycle. UX contract (locked with
@@ -10,6 +11,12 @@ import Link from "next/link";
    dates) that expands to the what/history/citations; slipped and overdue
    float to the top. Shared surface: city = commitments-{cityId}.json +
    hasCommitments flag. No cityId branches. */
+
+/* THE ALLOCATION LEDGER IS NOT UNIVERSAL. This register cross-links to it in
+   two places, and both used to render unconditionally - so Surat, which ships
+   commitments but has no published entitlement instrument to build a ledger
+   from, put two links to a 404 on its own page. Gate them on the same
+   FEATURE_AVAILABILITY map the nav uses. */
 
 type CommitmentStatus = "delivered" | "on-track" | "slipped" | "overdue" | "stalled" | "unverified";
 
@@ -140,7 +147,7 @@ function CommitmentRow({ p, cityId, highlight }: { p: TrackedCommitment; cityId:
           )}
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-slate-500">
             {p.next_check && <span>Next check: {p.next_check}</span>}
-            {p.ledger_id && (
+            {p.ledger_id && isFeatureSupportedForCity("/allocations", cityId) && (
               <Link href={`/${cityId}/allocations#${p.ledger_id}`} className="text-blue-600 dark:text-blue-400 hover:underline">
                 Who is owed this water? →
               </Link>
@@ -213,10 +220,14 @@ export default function CommitmentsClient({ cityId }: { cityId: string }) {
           <span className="uppercase tracking-wider">Commitments Register</span>
           <span>·</span>
           <span>Updated {data.updated}</span>
-          <span>·</span>
-          <Link href={`/${cityId}/allocations`} className="text-blue-600 dark:text-blue-400 hover:underline">
-            Allocation Ledger →
-          </Link>
+          {isFeatureSupportedForCity("/allocations", cityId) && (
+            <>
+              <span>·</span>
+              <Link href={`/${cityId}/allocations`} className="text-blue-600 dark:text-blue-400 hover:underline">
+                Allocation Ledger →
+              </Link>
+            </>
+          )}
         </div>
         <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
           {data.headline}

--- a/src/components/my-ward/ward-selector.tsx
+++ b/src/components/my-ward/ward-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { hasWardRankings } from "@/lib/ward-rankings/cities";
 import Link from "next/link";
 import { useLanguage } from "@/lib/i18n/context";
 import type { Language } from "@/lib/i18n/translations";
@@ -259,6 +260,10 @@ export function WardSelector({ onSelect, selectedWard, cityId = "chennai" }: War
             entry point for everyone else (journalists, residents
             who don't know their ward number, planners) - those
             users had nothing to click before. */}
+        {/* Only where a rankings bundle exists. Gurugram has a my-ward page but
+            no bundle, so this link rendered and /gurugram/my-ward/rankings
+            404ed - the route calls loadWardRankings, gets null, notFound(). */}
+        {hasWardRankings(cityId) && (
         <div className="mt-5">
           <Link
             href={
@@ -271,6 +276,7 @@ export function WardSelector({ onSelect, selectedWard, cityId = "chennai" }: War
             Browse all wards ranked &rarr;
           </Link>
         </div>
+        )}
 
         {/* Recent wards */}
         {recentWards.length > 0 && (

--- a/src/components/water-bodies/unified-detail-panel.tsx
+++ b/src/components/water-bodies/unified-detail-panel.tsx
@@ -662,8 +662,21 @@ export function UnifiedDetailPanel({ selected, restorationData, lostNarrative, c
       return () => controller.abort();
     }
 
+    // NOT EVERY WATER BODY HAS AN OSM ID. The satellite context is keyed on
+    // one, and bodies that come from a national atlas rather than OSM do not
+    // carry it - all 3,418 of Surat's are SAC wetland-atlas polygons with an
+    // atlas `id` and no `osm_id` at all. Without this guard the panel fired
+    // `?osm_id=undefined` for every one of them.
     const osmId = selected.props.osm_id;
-    fetch(`/api/water-bodies/gee?osm_id=${selected.props.osm_id}`, {
+    if (osmId == null) {
+      // No setState here on purpose: the derived guard below already requires
+      // a non-null osm_id on BOTH sides, so stale state cannot leak into this
+      // body's panel, and clearing it synchronously in an effect is what
+      // react-hooks/set-state-in-effect exists to stop.
+      return () => controller.abort();
+    }
+
+    fetch(`/api/water-bodies/gee?osm_id=${osmId}`, {
       signal: controller.signal,
     })
       .then(async (response) => {
@@ -692,8 +705,18 @@ export function UnifiedDetailPanel({ selected, restorationData, lostNarrative, c
     return () => controller.abort();
   }, [selected]);
 
+  // THIS CRASHED EVERY ATLAS-SOURCED BODY. The old test was
+  // `satelliteSummaryState?.osmId === selected.props.osm_id`, which reads as a
+  // null-guard and is not one: with no fetch in flight the left side is
+  // `undefined`, and for a body with no OSM id the right side is `undefined`
+  // too, so `undefined === undefined` passed and the next line read `.summary`
+  // off null. Clicking any of Surat's 3,418 water bodies took the page down.
+  // Compare the ids only once both are known to exist.
   const satelliteSummary =
-    selected.kind === "current" && satelliteSummaryState?.osmId === selected.props.osm_id
+    selected.kind === "current" &&
+    satelliteSummaryState != null &&
+    selected.props.osm_id != null &&
+    satelliteSummaryState.osmId === selected.props.osm_id
       ? satelliteSummaryState.summary
       : null;
 

--- a/src/lib/ward-rankings/cities.ts
+++ b/src/lib/ward-rankings/cities.ts
@@ -1,0 +1,27 @@
+/**
+ * Which cities have a ward-rankings bundle.
+ *
+ * SINGLE SOURCE OF TRUTH, and it exists because there were two. `loadWardRankings`
+ * carried this list inline as a chain of `if (cityId === ...) return load...()`,
+ * and `ward-selector.tsx` rendered its "Browse all wards ranked" link with no
+ * check at all. Gurugram has a my-ward page but no rankings bundle, so the link
+ * rendered and the route it pointed at 404ed - `/gurugram/my-ward/rankings`
+ * calls `loadWardRankings`, gets null, and calls notFound().
+ *
+ * This module is deliberately free of `fs` so a client component can import it;
+ * load-rankings.ts reads files and cannot be imported from the browser.
+ *
+ * Adding a city: add its id here AND a loader branch in load-rankings.ts. The
+ * test in ward-rankings-cities.test.ts asserts the two agree.
+ */
+export const CITIES_WITH_WARD_RANKINGS: ReadonlySet<string> = new Set([
+  "chennai",
+  "madurai",
+  "bangalore",
+  "mumbai",
+  "delhi",
+]);
+
+export function hasWardRankings(cityId: string): boolean {
+  return CITIES_WITH_WARD_RANKINGS.has(cityId);
+}

--- a/src/lib/ward-rankings/load-rankings.ts
+++ b/src/lib/ward-rankings/load-rankings.ts
@@ -7,6 +7,7 @@ import {
   type WardRankings,
 } from "@/lib/utils/ward-rankings";
 import { loadProfilesServer } from "@/lib/utils/load-profiles-server";
+import { hasWardRankings } from "./cities";
 
 /**
  * Normalised "one row per ward" shape that powers the rankings table.
@@ -74,6 +75,10 @@ export interface WardRankingsBundle {
 /** Public entry point: returns the ranking bundle for a city, or null
  *  if no ranking data is available for that city. */
 export function loadWardRankings(cityId: string): WardRankingsBundle | null {
+  // The membership test lives in ./cities so a client component can ask the
+  // same question without importing this fs-backed module. Keep the branches
+  // below in step with that set - ward-rankings-cities.test.ts asserts it.
+  if (!hasWardRankings(cityId)) return null;
   if (cityId === "madurai") return loadMaduraiRankings();
   if (cityId === "chennai") return loadChennaiRankings();
   if (cityId === "bangalore") return loadBangaloreRankings();

--- a/src/lib/ward-rankings/ward-rankings-cities.test.ts
+++ b/src/lib/ward-rankings/ward-rankings-cities.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+import { CITIES_WITH_WARD_RANKINGS, hasWardRankings } from "./cities";
+
+/**
+ * The set in ./cities and the loader branches in ./load-rankings must agree.
+ *
+ * They did not: load-rankings listed five cities inline and ward-selector.tsx
+ * linked to /<city>/my-ward/rankings with no check, so Gurugram - which has a
+ * my-ward page and no rankings bundle - shipped a link to a 404. Parsing the
+ * loader rather than importing it keeps this test free of `fs`-backed module
+ * loading and of the JSON those loaders read.
+ */
+test("every loader branch in load-rankings is in CITIES_WITH_WARD_RANKINGS", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "src/lib/ward-rankings/load-rankings.ts"),
+    "utf8",
+  );
+  const body = src.slice(src.indexOf("export function loadWardRankings"));
+  const end = body.indexOf("\n}");
+  const branches = [...body.slice(0, end).matchAll(/cityId === "([a-z-]+)"/g)].map(
+    (m) => m[1],
+  );
+
+  assert.ok(branches.length > 0, "no loader branches found - did the shape change?");
+  for (const city of branches) {
+    assert.ok(
+      hasWardRankings(city),
+      `${city} has a loader branch but is missing from CITIES_WITH_WARD_RANKINGS`,
+    );
+  }
+  for (const city of CITIES_WITH_WARD_RANKINGS) {
+    assert.ok(
+      branches.includes(city),
+      `${city} is in CITIES_WITH_WARD_RANKINGS but has no loader branch`,
+    );
+  }
+});
+
+test("a city with no rankings bundle is reported as having none", () => {
+  assert.equal(hasWardRankings("gurugram"), false);
+  assert.equal(hasWardRankings("surat"), false);
+  assert.equal(hasWardRankings("pune"), false);
+  assert.equal(hasWardRankings("chennai"), true);
+});


### PR DESCRIPTION
CLICKING A WATER BODY CRASHED THE PANEL. `Cannot read properties of null
(reading 'summary')`, on production, for all 3,418 of Surat's bodies.

The guard read

    satelliteSummaryState?.osmId === selected.props.osm_id ? satelliteSummaryState.summary : null

which looks like a null check and is not one. With no fetch in flight the left
side is `undefined`. Surat's water bodies come from the SAC wetland atlas, not
OSM, so they carry an atlas `id` and no `osm_id` at all - every one of them -
and the right side is `undefined` too. `undefined === undefined` passed, and
the next line read `.summary` off null. Now compares the ids only once both are
known to exist. The same effect was also firing
`/api/water-bodies/gee?osm_id=undefined` for every atlas body; it returns early
instead.

Chennai and Bangalore still open their panels - checked, because those cities
DO have osm_id and the fix must not cost them the satellite section.

THREE DEAD LINKS, found by crawling every internal link on every route of all
ten cities and checking each one resolves:

- `/surat/allocations`, linked twice from Surat's own commitments page. Surat
  ships commitments and has no allocation ledger - no published entitlement
  instrument exists to build one from - so both links 404ed. Gated on the
  FEATURE_AVAILABILITY map the nav already uses.
- `/pune/my-ward`, linked from Pune's about page under "Ward boundaries". That
  route was deliberately turned off at cutover because no ward rows exist. The
  geometry the sentence describes is real, so the prose stays and the link goes.
- `/gurugram/my-ward/rankings`, linked from Gurugram's my-ward page. Gurugram
  has a my-ward page but no rankings bundle, so the route calls
  loadWardRankings, gets null and 404s.

The last one was the recurring shape again: `loadWardRankings` carried its city
list inline as five `if (cityId === ...)` branches, and the link checked
nothing. Both now read `CITIES_WITH_WARD_RANKINGS` from one module, kept free
of `fs` so a client component can import it. A test asserts the set and the
loader branches agree in both directions, and was proven to fail when a city is
removed from either side.

Every route that 404s here does so by design and carries a recorded exemption -
surat:allocations, pune:commitments, pune:my-ward, gurugram:commitments and the
rest. Nothing was turned on; the links stopped claiming otherwise.

Re-audited after: no dead internal links across any city.