### PR TITLE
Fix: the sub-basin profile was unreachable on a phone

### DIFF
--- a/src/components/basin/basin-overview.tsx
+++ b/src/components/basin/basin-overview.tsx
@@ -521,8 +521,11 @@ export function BasinOverview({
 
   return (
     <div className="absolute inset-0 flex flex-col md:flex-row bg-white dark:bg-slate-950">
-      {/* Map */}
-      <div className="relative flex-1 min-h-[45vh]">
+      {/* Map. On mobile the column is map-then-panel, and the MAP takes the
+          fixed share: it is the panel that has to absorb whatever height the
+          content needs, by scrolling inside itself. On desktop the row puts
+          the map on the flexible side instead. */}
+      <div className="relative h-[45vh] shrink-0 md:h-full md:flex-1 md:shrink">
         <MapContainer
           center={manifest.mapCenter}
           zoom={manifest.mapZoom}
@@ -770,7 +773,7 @@ export function BasinOverview({
       </div>
 
       {/* Panel */}
-      <div className="w-full md:w-[380px] md:max-w-[45%] shrink-0 overflow-y-auto border-t md:border-t-0 md:border-l border-slate-200 dark:border-slate-700 p-3.5 space-y-3.5 text-slate-800 dark:text-slate-100">
+      <div className="w-full flex-1 min-h-0 overflow-y-auto overscroll-contain md:w-[380px] md:max-w-[45%] md:flex-none border-t md:border-t-0 md:border-l border-slate-200 dark:border-slate-700 p-3.5 space-y-3.5 text-slate-800 dark:text-slate-100">
         <div className="flex items-start justify-between gap-2">
           <div>
             <div className="text-[11px] uppercase tracking-wider text-slate-400">Basin overview</div>


### PR DESCRIPTION
Tapping Kabini on the Cauvery overview opens a profile about 2,300 px tall. On a 390x844 phone the panel rendered all of it inside an 813 px window and **nothing scrolled** - not the panel, not the page. The profile below the fold, the sub-basin list under it and the "Open the Kabini deep dive" button were all unreachable.

## Why

`overflow-y-auto` was already on the panel and did nothing. A flex child's default `min-height` is `auto`, so the panel grew to its content height rather than being constrained by the container - there was never any overflow for the rule to act on. Compounding it, the panel was `shrink-0` while the map was `flex-1`, so the map took the flexibility the panel needed.

Measured on a 390x844 viewport before the fix:

| element | client | scroll | scrolls? |
|---|---|---|---|
| wrapper (`absolute inset-0`) | 813 | 2708 | no, `overflow: visible` |
| map | 380 | 380 | - |
| panel | 2327 | 2327 | no |
| document | 844 | 844 | no |

## The fix

On mobile the map takes the fixed 45vh share it was already asking for through `min-h-[45vh]`, and the panel becomes the flexible child with `min-h-0`. Same numbers after:

| element | client | scroll | scrolls? |
|---|---|---|---|
| wrapper | 813 | 813 | no overflow |
| map | 380 | 380 | - |
| panel | 432 | 2327 | **yes** |

The `md` row layout is untouched - map flexible, panel 380 px and pinned - and I checked that at 1400x900. `overscroll-contain` stops scroll chaining into the host page, matching what the deep-dive atlas already does.

## Not changed

`src/components/cascade/catchment-atlas.tsx` has the same `shrink-0` + `overflow-y-auto` shape on its side panel. Its content currently fits, so I could not make it fail, and its map is canvas-rendered so I could not select a catchment headlessly to load the panel up. Leaving it rather than changing working code on a hunch, but it is the same latent shape and worth a look next time that page is open on a phone.