### PR TITLE
Every ULB in the Kabini sub-basin gets a card, silent ones included

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -29,7 +29,7 @@
     "2026-08-22: the Cauvery-KA snapshot + NWMP trends release, tagged corpus-2026-08-22-cauvery-ka-snapshot at 051cb616163281c0c85afadb740d69666bf46d5f (data#43 squash; counts verified against the tree API). ADDS 12 artifacts, so expected_files moves 513/117 -> 525/117: the five canonical 2025 stretch lines replacing the KWRIS-vintage blobs on the cauvery-ka overview (priorities + max BOD from the CPCB Oct-2025 report), named river centrelines + the full-basin context outline from Paani's Aug-2026 hydrology package, and ten CPCB annual BOD/DO/FC trend packs on the Kabini + Arkavathi NWMP stations, all L2-enveloped."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "10403281c47495d4e772acd54ec7bfdd3366eab6",
+  "sha": "efcd79e92f1e34a7030969ef33e3a4c1a3a10005",
   "expected_files": {
     "data": 527,
     "geojson": 117

--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -723,7 +723,7 @@
    "family": "basins",
    "scope": "arkavathi",
    "dataset": "accountability",
-   "bytes": 67683,
+   "bytes": 67713,
    "schema": {
     "kind": "object",
     "keys": [
@@ -2559,7 +2559,7 @@
    "family": "basins",
    "scope": "cauvery-ka",
    "dataset": "accountability-C2",
-   "bytes": 21350,
+   "bytes": 65478,
    "schema": {
     "kind": "object",
     "keys": [
@@ -4097,7 +4097,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "accountability",
-   "bytes": 22419,
+   "bytes": 66547,
    "schema": {
     "kind": "object",
     "keys": [
@@ -26531,7 +26531,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 90102,
+   "bytes": 134260,
    "schema_variants": 2,
    "registered": true,
    "has_consumer": true
@@ -26579,7 +26579,7 @@
    "scopes": [
     "cauvery-ka"
    ],
-   "bytes": 21350,
+   "bytes": 65478,
    "schema_variants": 1,
    "registered": false,
    "has_consumer": true

--- a/docs/architecture/dataset-catalogue.md
+++ b/docs/architecture/dataset-catalogue.md
@@ -11,7 +11,7 @@ Machine-readable detail: `dataset-catalogue.json` (per-file schema fingerprints,
 |---|--:|--:|--:|--:|--:|
 | cascade | 58 | 150.0 | 5 | 58 | 0 |
 | geojson-layers | 117 | 97.6 | 11 | 110 | 6 |
-| basins | 152 | 50.9 | 5 | 57 | 9 |
+| basins | 152 | 51.0 | 5 | 57 | 9 |
 | data-root | 173 | 30.6 | 10 | 141 | 31 |
 | rich-bodies | 127 | 1.5 | 2 | 127 | 0 |
 | waterways | 14 | 0.5 | 2 | 8 | 6 |

--- a/public/data/basins/arkavathi/accountability.json
+++ b/public/data/basins/arkavathi/accountability.json
@@ -9,7 +9,8 @@
     },
     "actionPlan": {
       "label": "KSPCB Action Plan for Rejuvenation of River Arkavathi (January 2019)",
-      "url": "https://kspcb.karnataka.gov.in/"
+      "url": "https://kspcb.karnataka.gov.in/",
+      "asOf": "January 2019"
     },
     "banner": "September 2025 is the last stretch-wise MPR edition; from October 2025 the format drops per-stretch narrative, and the April-2026 dossier carries only state-level items plus annexure tables (station classes, STP lists). The September edition repeats the August position, so the figures below are unchanged between them. Categories cite the edition each fact was last reported in.",
     "otherSources": [

--- a/public/data/basins/cauvery-ka/accountability-C2.json
+++ b/public/data/basins/cauvery-ka/accountability-C2.json
@@ -1,6 +1,6 @@
 {
   "question": "Do the Action Plan and the MPRs address all potential pollution contributors on the Kabini stretch?",
-  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the 9 km below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
+  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the reach below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report, for every urban local body in the sub-basin and not only the towns the reports choose to itemise. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
   "baseline": {
     "primary": {
       "label": "NMCG Monthly Progress Report (Karnataka, Kabini stretch)",
@@ -17,7 +17,8 @@
       "KSPCB NWMP monthly classification 2025-26",
       "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative",
       "Revised District Environmental Plan of Mysuru District (May 2022) - the only source that reports Sargur and T. Narasipura, the two towns the October-2025 redraw added to the stretch",
-      "KSPCB hazardous-waste authorisations under the 2016 Rules (per-unit Form 2 grants, e.g. 318149 for Jubilant Generics at KIADB Nanjangud)"
+      "KSPCB hazardous-waste authorisations under the 2016 Rules (per-unit Form 2 grants, e.g. 318149 for Jubilant Generics at KIADB Nanjangud)",
+      "Karnataka GIS urban local body boundaries, via Paani Earth (Aug 2026) - the 11 ULBs whose area falls inside the sub-basin, which is how this matrix knows which towns the documents leave out"
     ]
   },
   "legalLibrary": {
@@ -164,7 +165,14 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Sargur"
+        ]
+      }
     },
     {
       "kind": "ulb",
@@ -271,7 +279,14 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Nanjanagud"
+        ]
+      }
     },
     {
       "kind": "ulb",
@@ -378,6 +393,1052 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "T.Narasipura"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hd-kote",
+      "name": "H.D. Kote (TMC)",
+      "inBasinNote": "In-basin ULB above the Kabini reservoir, about 2 km off the mapped stretch. Whatever it discharges enters the impoundment the stretch begins below.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for H.D. Kote - the reporting gap is the finding.",
+            "The Mysuru district plan gives the town 2.46 MLD of sewage, no STP and no sewerage network, with a faecal sludge plant approved and not built (May 2022, pp.57-59)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "H.D.Kote"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "kadakola",
+      "name": "Kadakola (TP)",
+      "inBasinNote": "In-basin town panchayat about 3 km off the stretch, on the Mysuru to Nanjangud road.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Kadakola - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Kadakola"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "srirampura",
+      "name": "Srirampura (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 7 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Srirampura - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Srirampura"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "mysuru",
+      "name": "Mysuru (City Corporation)",
+      "inBasinNote": "97% of the city corporation's area falls inside the Kabini sub-basin, about 12 km off the mapped stretch. It is by far the largest sewage source in the district, and no document we hold states which river its flow reaches.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Mysuru - the reporting gap is the finding.",
+            "The district plan puts city sewage at 180 MLD of the district's 206.74, against 199.41 MLD of installed capacity, and reports 105.34 MLD reaching water bodies untreated or partially treated (May 2022, p.59). None of it is attributed to a river."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Mysuru"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "bogadi",
+      "name": "Bogadi (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 14 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Bogadi - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Bogadi"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "rammanahalli",
+      "name": "Rammanahalli (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 14 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Rammanahalli - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Rammanahalli"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hootagalli",
+      "name": "Hootagalli (CMC)",
+      "inBasinNote": "In-basin city municipal council in the Mysuru urban fringe, about 19 km off the stretch; the Hootagalli and Hootagalli Food industrial areas sit within it.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Hootagalli - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Hootagalli"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "gundlupete",
+      "name": "Gundlupet (TMC)",
+      "inBasinNote": "In-basin ULB on the Gundal, the Kabini's eastern tributary, in Chamarajanagara district. No monitoring station on this map sits on the Gundal at all.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Gundlupet - the reporting gap is the finding.",
+            "Its own district plan gives the town two STPs of 2.1 and 1.5 MLD, records that 100% underground drainage is not complete, and states that untreated sewage is not quantified (Chamarajanagara, Jun 2021)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "GUNDLUPETE"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hunsur",
+      "name": "Hunsur (CMC)",
+      "inBasinNote": "In-basin ULB about 23 km off the Kabini stretch, on the Lakshmanathirtha - a tributary with its own CPCB polluted stretch. Listed here because its area drains into this sub-basin, not because the Kabini's documents cover it.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Hunsur"
+        ]
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "public-stps"
+        }
       ]
     },
     {
@@ -427,7 +1488,19 @@
           ],
           "legalRef": "hazardous-waste"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "pressures-industrial",
+        "prop": "name",
+        "contains": [
+          "Nanjangud",
+          "Thandya",
+          "Adakanahally"
+        ],
+        "kinds": [
+          "industrial-area"
+        ]
+      }
     },
     {
       "kind": "gp",

--- a/public/data/basins/kabini/accountability.json
+++ b/public/data/basins/kabini/accountability.json
@@ -29,7 +29,7 @@
     "produced_by": "Authored on the cauvery-ka overview (accountability-C2.json) and carried verbatim by scripts/build_kabini_sources.py."
   },
   "question": "Do the Action Plan and the MPRs address all potential pollution contributors on the Kabini stretch?",
-  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the 9 km below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
+  "intro": "The Kabini's CPCB polluted stretch runs from Saragur village downstream to the T. Narasipura water-supply intake - 104.3 km at Priority V since CPCB redrew it in October 2025, where it was the reach below Nanjangud at Priority IV in 2018. This section compares the KSPCB Action Plan's commitments with what the monthly progress reports actually report, for every urban local body in the sub-basin and not only the towns the reports choose to itemise. 'Not reported' means absent from the documents, not necessarily absent on the ground.",
   "baseline": {
     "primary": {
       "label": "NMCG Monthly Progress Report (Karnataka, Kabini stretch)",
@@ -46,7 +46,8 @@
       "KSPCB NWMP monthly classification 2025-26",
       "NMCG MPR April 2026 - annexure tables only (station water-quality classes + state-wide STP lists); no per-stretch narrative",
       "Revised District Environmental Plan of Mysuru District (May 2022) - the only source that reports Sargur and T. Narasipura, the two towns the October-2025 redraw added to the stretch",
-      "KSPCB hazardous-waste authorisations under the 2016 Rules (per-unit Form 2 grants, e.g. 318149 for Jubilant Generics at KIADB Nanjangud)"
+      "KSPCB hazardous-waste authorisations under the 2016 Rules (per-unit Form 2 grants, e.g. 318149 for Jubilant Generics at KIADB Nanjangud)",
+      "Karnataka GIS urban local body boundaries, via Paani Earth (Aug 2026) - the 11 ULBs whose area falls inside the sub-basin, which is how this matrix knows which towns the documents leave out"
     ]
   },
   "legalLibrary": {
@@ -193,7 +194,14 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Sargur"
+        ]
+      }
     },
     {
       "kind": "ulb",
@@ -300,7 +308,14 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Nanjanagud"
+        ]
+      }
     },
     {
       "kind": "ulb",
@@ -407,6 +422,1052 @@
           "gaps": [],
           "legalRef": "public-stps"
         }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "T.Narasipura"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hd-kote",
+      "name": "H.D. Kote (TMC)",
+      "inBasinNote": "In-basin ULB above the Kabini reservoir, about 2 km off the mapped stretch. Whatever it discharges enters the impoundment the stretch begins below.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for H.D. Kote - the reporting gap is the finding.",
+            "The Mysuru district plan gives the town 2.46 MLD of sewage, no STP and no sewerage network, with a faecal sludge plant approved and not built (May 2022, pp.57-59)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for H.D. Kote in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for H.D. Kote - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "H.D.Kote"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "kadakola",
+      "name": "Kadakola (TP)",
+      "inBasinNote": "In-basin town panchayat about 3 km off the stretch, on the Mysuru to Nanjangud road.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Kadakola - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Kadakola in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Kadakola - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Kadakola"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "srirampura",
+      "name": "Srirampura (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 7 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Srirampura - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Srirampura in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Srirampura - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Srirampura"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "mysuru",
+      "name": "Mysuru (City Corporation)",
+      "inBasinNote": "97% of the city corporation's area falls inside the Kabini sub-basin, about 12 km off the mapped stretch. It is by far the largest sewage source in the district, and no document we hold states which river its flow reaches.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Mysuru - the reporting gap is the finding.",
+            "The district plan puts city sewage at 180 MLD of the district's 206.74, against 199.41 MLD of installed capacity, and reports 105.34 MLD reaching water bodies untreated or partially treated (May 2022, p.59). None of it is attributed to a river."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Mysuru in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Mysuru - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Mysuru"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "bogadi",
+      "name": "Bogadi (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 14 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Bogadi - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Bogadi in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Bogadi - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Bogadi"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "rammanahalli",
+      "name": "Rammanahalli (TP)",
+      "inBasinNote": "In-basin town panchayat in the Mysuru urban fringe, about 14 km off the stretch.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Rammanahalli - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Rammanahalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Rammanahalli - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Rammanahalli"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hootagalli",
+      "name": "Hootagalli (CMC)",
+      "inBasinNote": "In-basin city municipal council in the Mysuru urban fringe, about 19 km off the stretch; the Hootagalli and Hootagalli Food industrial areas sit within it.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Hootagalli - the reporting gap is the finding.",
+            "The Mysuru district plan's own list of urban local bodies names the corporation and eight towns; this one is not among them (May 2022, p.3)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Hootagalli in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Hootagalli - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Hootagalli"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "gundlupete",
+      "name": "Gundlupet (TMC)",
+      "inBasinNote": "In-basin ULB on the Gundal, the Kabini's eastern tributary, in Chamarajanagara district. No monitoring station on this map sits on the Gundal at all.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Gundlupet - the reporting gap is the finding.",
+            "Its own district plan gives the town two STPs of 2.1 and 1.5 MLD, records that 100% underground drainage is not complete, and states that untreated sewage is not quantified (Chamarajanagara, Jun 2021)."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Gundlupet in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Gundlupet - the reporting gap is the finding."
+          ],
+          "legalRef": "public-stps"
+        }
+      ],
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "GUNDLUPETE"
+        ]
+      }
+    },
+    {
+      "kind": "ulb",
+      "key": "hunsur",
+      "name": "Hunsur (CMC)",
+      "inBasinNote": "In-basin ULB about 23 km off the Kabini stretch, on the Lakshmanathirtha - a tributary with its own CPCB polluted stretch. Listed here because its area drains into this sub-basin, not because the Kabini's documents cover it.",
+      "grievance": {
+        "label": "Report illegal discharge (NMCG grievance module)",
+        "url": "https://nmcg.nic.in/ngtgrievance.aspx"
+      },
+      "mapMatch": {
+        "family": "admin-town",
+        "prop": "name",
+        "values": [
+          "Hunsur"
+        ]
+      },
+      "categories": [
+        {
+          "key": "public-stps",
+          "label": "Public STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No public sewage treatment commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention public sewage treatment for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "public-stps"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid waste commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention solid waste for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "solid-waste"
+        },
+        {
+          "key": "biomedical",
+          "label": "Biomedical Waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No biomedical waste commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention biomedical waste for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "biomedical"
+        },
+        {
+          "key": "fecal-sludge",
+          "label": "Fecal Sludge",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No faecal sludge commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention faecal sludge for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "fecal-sludge"
+        },
+        {
+          "key": "private-stps",
+          "label": "Private STPs",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No private sewage treatment commitment for Hunsur in the Kabini Action Plan, which names CMC Nanjangud as the only local body on the river.",
+            "cite": "Kabini Action Plan, p.3"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported in any Kabini MPR edition through September 2025.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Neither the Action Plan nor the MPRs mention private sewage treatment for Hunsur - the reporting gap is the finding.",
+            "Hunsur sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right - 'from D/S Hunsur to the water supply intake point of Hunsur town', Priority IV. Its obligations belong to that stretch's action plan, not this one."
+          ],
+          "legalRef": "public-stps"
+        }
       ]
     },
     {
@@ -456,7 +1517,19 @@
           ],
           "legalRef": "hazardous-waste"
         }
-      ]
+      ],
+      "mapMatch": {
+        "family": "pressures-industrial",
+        "prop": "name",
+        "contains": [
+          "Nanjangud",
+          "Thandya",
+          "Adakanahally"
+        ],
+        "kinds": [
+          "industrial-area"
+        ]
+      }
     },
     {
       "kind": "gp",

--- a/src/components/basin/basin-atlas.tsx
+++ b/src/components/basin/basin-atlas.tsx
@@ -388,7 +388,10 @@ export interface AccountabilityData {
   portalNote?: string;
   baseline: {
     primary: { label: string; asOf: string; note?: string };
-    actionPlan: { label: string; url: string };
+    /** asOf dates the plan itself. It was hardcoded as "2019" in both surfaces,
+     *  which is the Arkavathi's edition and nobody else's - the Kabini and
+     *  Shimsha plans carry no date we can establish, so they render without one. */
+    actionPlan: { label: string; url: string; asOf?: string };
     banner?: string;
     otherSources?: string[];
   };
@@ -2798,7 +2801,7 @@ export function AccountabilityMatrix({ data, onShowRegion }: { data: Accountabil
                   </summary>
                   <div className="mt-1.5 ml-4 space-y-1.5">
                     <div className="rounded-md bg-slate-50 dark:bg-slate-800/60 px-2 py-1.5">
-                      <div className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold">Action Plan (2019)</div>
+                      <div className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold">Action Plan{data.baseline.actionPlan.asOf ? ` (${data.baseline.actionPlan.asOf})` : ""}</div>
                       <p className="text-[12px] text-slate-700 dark:text-slate-200 leading-snug">{c.actionPlan.summary}</p>
                       {c.actionPlan.cite && <p className="text-[10px] text-slate-400 mt-0.5">{c.actionPlan.cite}</p>}
                     </div>

--- a/src/components/basin/basin-pdf-report.tsx
+++ b/src/components/basin/basin-pdf-report.tsx
@@ -522,7 +522,7 @@ function AccRegionBlock({ region, acc }: { region: AccRegion; acc: Accountabilit
               />
             </View>
             <Text style={[s.small, { marginTop: 1.5 }]}>
-              Action Plan (2019): {c.actionPlan.summary}
+              Action Plan{acc.baseline.actionPlan.asOf ? ` (${acc.baseline.actionPlan.asOf})` : ""}: {c.actionPlan.summary}
               {c.actionPlan.cite ? ` [${c.actionPlan.cite}]` : ""}
             </Text>
             <Text style={s.small}>


### PR DESCRIPTION
The accountability matrix carried three towns: the ones the progress reports itemise. That quietly reproduced the reports' own blind spot, which is the opposite of what this surface is for. Paani made the point in her review and she is right.

Twelve urban local bodies have area inside the sub-basin. All twelve are on the matrix now, and **eleven are silent on every category** - the Kabini Action Plan names CMC Nanjangud as the only local body on the river (p.3), and no MPR edition through September 2025 mentions any of the others. The Arkavathi already worked this way; the Kabini now matches it.

## Silence is not the whole story

Where other documents do say something, the cards carry it:

- **H.D. Kote** has 2.46 MLD of sewage, no STP and no network, sitting immediately above the reservoir the stretch begins below.
- **Gundlupet** has two STPs of 2.1 and 1.5 MLD, and a district plan that records untreated sewage as not quantified.
- **Mysuru** puts 97% of its corporation area inside this sub-basin and 180 MLD of the district's 206.74 through it, with no document saying which river that reaches.
- **Five towns** - Kadakola, Srirampura, Bogadi, Rammanahalli, Hootagalli - are not in the Mysuru district plan's own list of urban local bodies at all.

**Hunsur** is included with its reason: it is in the sub-basin but sits on the Lakshmanathirtha, which CPCB lists as a polluted stretch in its own right, so its obligations belong to that plan. Listing it and saying so beats leaving a town on the map with no card and no explanation.

## Two things fixed while in here

Every region is wired to its polygon, which the Kabini regions never were. Clicking a town highlights it on the map, as it does on the Arkavathi. All twelve names verified against the layer.

`Action Plan (2019)` was hardcoded into both the atlas panel and the PDF. That is the Arkavathi's edition and nobody else's, so the Kabini and Shimsha matrices were stamping a date onto documents that carry no date we can establish, 72 times a page. The year comes from the data now: the Arkavathi keeps January 2019 on its own baseline record, the other two render without a parenthetical.

## Verification

Both CI jobs locally: 0 lint errors, clean build, 93 frontend + 152 API tests, i18n, drift, sample-corpus, basin-contract and NVDM validators green, L2 gate clean. PDF re-rendered for both basins: Kabini has no `(2019)` left, Arkavathi keeps its 72 correct ones.

Corpus side is **data#47**, green. The `corpus.lock` bump follows once that merges, same as the last chain.