### PR TITLE
Allow forrivers.life to embed the Arkavathi and Kabini atlases

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,13 +32,18 @@ const securityHeaders = [
 ];
 
 // /embed/* is the ONLY framable namespace: chrome-less atlas pages built for
-// partner sites (Paani Earth's Arkavathi deep dive). Everything else keeps
-// frame-ancestors 'none'. localhost is allowed in dev so embeds are testable.
-// Paani Earth lost edit access to paani.earth; the deep dive now lives on
-// their Hostinger staging origin until forrivers.life goes live (swap it in
-// here when it does). CSP host-sources take no trailing slash or path.
+// partner sites (Paani Earth's Arkavathi and Kabini deep dives). Everything
+// else keeps frame-ancestors 'none'. localhost is allowed in dev so embeds are
+// testable. CSP host-sources take no trailing slash or path, and each host is
+// its own source - www is NOT covered by the apex entry.
+// Paani Earth lost edit access to paani.earth and now publishes on
+// forrivers.life. The Hostinger staging origin that carried the deep dive in
+// between stays listed until they confirm the move is done; drop it then,
+// because Hostinger recycles those auto-generated subdomains.
 const EMBED_FRAME_ANCESTORS = [
   "'self'",
+  "https://forrivers.life",
+  "https://www.forrivers.life",
   "https://orchid-wildcat-815854.hostingersite.com",
   ...(process.env.NODE_ENV === "development" ? ["http://localhost:*"] : []),
 ].join(" ");


### PR DESCRIPTION
Paani Earth's deep dives have moved to `forrivers.life`. This adds that origin (apex and www) to the `/embed/*` `frame-ancestors` allowlist in `next.config.ts` so the atlases actually paint inside their iframe. Without it the browser refuses the frame and the reader gets an empty box.

This is the swap that has been pending since PR #231, when Paani Earth lost edit access to paani.earth and the deep dive moved to a Hostinger staging origin.

## What this covers

The allowlist is per-namespace, not per-basin, so one entry enables both atlases and any basin added later:

- `https://neervazhvu.org/embed/basins/arkavathi`
- `https://neervazhvu.org/embed/basins/kabini`

Embed snippet for their side (`allow="geolocation"` is needed or the browser silently denies the "Where am I?" control inside the iframe):

```html
<iframe src="https://neervazhvu.org/embed/basins/kabini"
        style="width:100%;height:80vh;border:0" allow="geolocation"
        title="Kabini Basin Atlas - Neer Vazhvu x Paani Earth Foundation"></iframe>
```

## Why the Hostinger origin stays

The staging origin is left in place so the embed they are running today does not break mid-migration. It should come out once they confirm the move is done: Hostinger recycles those auto-generated subdomains, so a recycled one would inherit the right to frame our pages. Say the word and I will drop it in this PR.

## Blast radius

Only `/embed/*` changes. Everything else keeps `frame-ancestors 'none'` and `X-Frame-Options: DENY`.

Verified against a production build (`npm run build` + `next start`), reading real response headers:

| Route | frame-ancestors | X-Frame-Options |
| --- | --- | --- |
| `/embed/basins/arkavathi` | `'self' https://forrivers.life https://www.forrivers.life https://orchid-wildcat-815854.hostingersite.com` | `SAMEORIGIN` |
| `/embed/basins/kabini` | same | `SAMEORIGIN` |
| `/bangalore/rivers` (control) | `'none'` | `DENY` |

## Gates

`npm run lint` (0 errors), `npx tsc --noEmit` (clean), `npm run test` (93/93), `npm run data:check`, `check-generator-drift.py`, `nvdm-encumbrance-report.py --selftest`, `nvdm-l2-gate.sh` (no new data artifacts) all pass.

## Note for later

The credit bar on both atlases still links `Paani Earth Foundation` to `https://paani.earth` via `manifest.collaboration.url`, which is the site they no longer control. Worth pointing at forrivers.life, but that is a content change and I have left it alone here.