### PR TITLE
fix(waterways): read tracing vintage from a multipolygon's outer rings

### DIFF
--- a/docs/waterways/buckingham-canal/DECISIONS.md
+++ b/docs/waterways/buckingham-canal/DECISIONS.md
@@ -90,6 +90,19 @@ docs/specs/buckingham-canal-story-build.md.
   C = not channel-measurable (creek complexes, junctions, open water).
   Jitter, not IQR, is the noise proxy: large IQR on reaches that open
   into backwaters is real physical variation.
+  Tracing median-year is read from the geometry the transects cross,
+  which for a multipolygon means its OUTER rings, not the relation
+  itself: a relation's timestamp moves when someone retags it or swaps a
+  member, and says nothing about when the bank line was drawn. Inner
+  rings are islands and are excluded. Each polygon contributes one
+  representative year to the >=2021 test so a many-ringed relation
+  cannot outvote the ways beside it, while the displayed span still
+  covers every ring touched. Meta snapshots taken before the fetch
+  carried member ways fall back to the relation's own year, which is
+  what the canal and Cooum builds used; both reproduce byte-for-byte.
+  This remains a last-edit bound, not an imagery date: a way can read
+  2026 on a v10 tag edit while its geometry still traces old aerials
+  (the Mithi's km 10-11 way carries source=Yahoo, retired ~2011).
 - **W10 Watch items that must update the page before public cutover:**
   TNPCB fish-kill lab results (pending 18 Aug 2026); CMRL Water Metro RFP
   content (live 19 Aug 2026); Ashok Leyland consent status.

--- a/scripts/build_waterway.py
+++ b/scripts/build_waterway.py
@@ -31,6 +31,7 @@ import argparse
 import csv
 import json
 import shutil
+import statistics
 import sys
 from pathlib import Path
 
@@ -51,7 +52,6 @@ def width_confidence(rows_all, ok_rows, way_year):
     """Tier the reach's width measurement (canal DECISIONS W7 addendum):
     A = well-covered recent tracing with low transect-to-transect jitter;
     B = measured but sparse or older tracing; C = not channel-measurable."""
-    import statistics
     share = len(ok_rows) / len(rows_all) if rows_all else 0.0
     if len(ok_rows) < 3:
         return {"tier": "C", "share_measured": round(share, 2),
@@ -71,10 +71,18 @@ def width_confidence(rows_all, ok_rows, way_year):
                 diffs.append(abs(ok_rows[j][1] - ok_rows[i][1]) / med * 100)
             break
     jitter = statistics.median(diffs) if diffs else None
-    years = [way_year[w] for _, _, ids in ok_rows
-             for w in ids.split(";") if w in way_year]
+    # way_year maps a polygon id to the tracing years of the geometry the
+    # transects actually cross: one year for a plain way, the OUTER rings'
+    # years for a multipolygon. Report the honest span across every ring
+    # touched, but gate on one representative year per polygon so that a
+    # relation with many rings does not outvote the ways beside it.
+    years = [y for _, _, ids in ok_rows
+             for w in ids.split(";") if w in way_year
+             for y in way_year[w]]
+    reps = [statistics.median(way_year[w]) for _, _, ids in ok_rows
+            for w in ids.split(";") if w in way_year]
     vintage = f"{min(years)}-{max(years)}" if years else None
-    vin_ok = bool(years) and statistics.median(years) >= 2021
+    vin_ok = bool(reps) and statistics.median(reps) >= 2021
     if share >= 0.7 and vin_ok and (jitter or 99) <= 25:
         tier = "A"
     elif share >= 0.4:
@@ -148,10 +156,27 @@ def main(waterway=None):
         (RESEARCH / "figures" / "photos" / "photos.json").read_text())
     osm_meta = json.loads(
         (RESEARCH / "data" / "osm-water-meta.json").read_text())
-    way_year = {}
+    # Tracing vintage per polygon. A relation's own timestamp records when
+    # the RELATION was last touched - a retag, a member swap - not when the
+    # water surface was traced, so it is not evidence about the bank line.
+    # Resolve a multipolygon from its OUTER rings instead: those are the
+    # geometry the transects intersect. Inner rings are islands and say
+    # nothing about width. Meta files fetched before the query carried
+    # member ways have no outer-ring metadata; those fall back to the
+    # relation's own year, which is what the build did throughout.
+    elem_year = {}
     for e in osm_meta.get("elements", []):
         if "timestamp" in e:
-            way_year[f"{e['type']}/{e['id']}"] = int(e["timestamp"][:4])
+            elem_year[f"{e['type']}/{e['id']}"] = int(e["timestamp"][:4])
+    way_year = {k: [v] for k, v in elem_year.items()}
+    for e in osm_meta.get("elements", []):
+        if e["type"] != "relation":
+            continue
+        outer = [elem_year[f"way/{m['ref']}"] for m in e.get("members", [])
+                 if m.get("type") == "way" and m.get("role") == "outer"
+                 and f"way/{m['ref']}" in elem_year]
+        if outer:
+            way_year[f"relation/{e['id']}"] = outer
     veg_ha_by_reach = {int(r["reach_id"]): float(r["veg_ha"]) for r in
                        csv.DictReader(open(RESEARCH / "data" / "current-veg-area.csv"))}
     veg_on_water = {int(r["reach_id"]): {

--- a/scripts/waterways/cooum.json
+++ b/scripts/waterways/cooum.json
@@ -36,7 +36,7 @@
     "queries": {
       "osm-cooum-centerline.json": "[out:json][timeout:240];relation(11901885);way(r)[\"waterway\"];out geom;",
       "osm-water-polygons.json": "[out:json][timeout:240];relation(11901885);way(r)[\"waterway\"]->.r;(way[\"natural\"=\"water\"](around.r:250);relation[\"natural\"=\"water\"](around.r:250);way[\"waterway\"=\"riverbank\"](around.r:250);relation[\"waterway\"=\"riverbank\"](around.r:250););out geom;",
-      "osm-water-meta.json": "[out:json][timeout:240];relation(11901885);way(r)[\"waterway\"]->.r;(way[\"natural\"=\"water\"](around.r:250);relation[\"natural\"=\"water\"](around.r:250);way[\"waterway\"=\"riverbank\"](around.r:250);relation[\"waterway\"=\"riverbank\"](around.r:250););out meta;"
+      "osm-water-meta.json": "[out:json][timeout:240];relation(11901885);way(r)[\"waterway\"]->.r;(way[\"natural\"=\"water\"](around.r:250);relation[\"natural\"=\"water\"](around.r:250);way[\"waterway\"=\"riverbank\"](around.r:250);relation[\"waterway\"=\"riverbank\"](around.r:250););out meta;way(r);out meta;"
     }
   },
   "satellite": {


### PR DESCRIPTION
## What

The width-confidence tier tests tracing median-year >= 2021. For a multipolygon it was reading the relation's own timestamp, which moves when someone retags the relation or swaps a member and says nothing about when the bank line was drawn.

Not a small share of the measurement: **350 of the Cooum's width rows and 343 of the canal's** resolve through a relation rather than a plain way.

## The fix

Resolve vintage from the **outer rings**, the geometry the transects actually intersect. Inner rings are islands and are excluded. Each polygon contributes one representative year to the gate so a many-ringed relation cannot outvote the ways beside it, while the displayed `tracing_years` span still covers every ring touched.

The meta query has to fetch member ways for that to work. Untagged outer rings never matched the old query, so no shipped meta snapshot carries them; those fall back to the relation's own year, which is what the builds already did. The canal keeps no fetch block on purpose (`fetch_note`: refetching would move its geometry baseline), so only the Cooum config changes.

## No shipped number moves

Both waterways rebuild **byte-for-byte** against the committed artifacts, and every confidence block is unchanged.

| gate | result |
|---|---|
| `verify_waterway_cooum` | PASS (110 claims, 13 reaches) |
| `verify_waterway_buckingham` | PASS (130 claims, 18 reaches) |
| `audit_waterway_numbers_cooum` | PASS (0 errors, 0 notes) |
| `audit_waterway_numbers` | PASS (0 errors, 0 notes) |
| `check-generator-drift` | PASS |
| NVDM selftest + conformance + catalogue freshness | PASS |
| `nvdm-l2-gate` vs main | PASS (no new artifacts) |
| `npm run data:check` | PASS |

## Where it showed up

Found while checking whether the Mithi could carry a waterway page. Fetching member metadata there shows what the old path was hiding:

| relation | as relation | outer ring |
|---|---|---|
| `relation/2310505` | 2023 | **2026** |
| `relation/311633` | 2021 | **2024** |

Both were *understated*, so no shipped tier is wrong today. The gate was conservative by luck rather than by construction, and the error is directionally arbitrary: a relation retagged recently over old outer rings would overstate instead.

## Still a bound, not a date

Last-edit remains an upper bound on tracing age, not an imagery date. The Mithi's km 10-11 way reads 2026 at v10 while its geometry carries `source=Yahoo`, an imagery source retired around 2011. Recorded in the W7 addendum alongside the rest.