### PR TITLE
Mithi waterway M1+M2: measured baseline and satellite pass (DRAFT, not for merge)

### DIFF
--- a/docs/waterways/mithi/DECISIONS.md
+++ b/docs/waterways/mithi/DECISIONS.md
@@ -1,0 +1,109 @@
+# Mithi waterway page: editorial constitution and decisions
+
+Waterway 3, and the first outside Chennai. The constitution the canal and
+the Cooum wrote still governs: progressive disclosure (W2),
+receipts-on-every-number (W3), banned corrected figures (W4),
+attributed-never-averaged capacities (W5), no scorecards (W6),
+width-confidence tiers (W7 addendum). Recorded here are only the
+decisions this river forced.
+
+Status 27 Aug 2026: M1 complete (geometry + widths). M2 (satellite) and
+M3 (curation) not started. The page does not build yet: it has no
+curation layer, and it must not be given one by invention.
+
+## Decisions
+
+- **M1 Extent.** The full river as OSM maps it: relation **6245575**, ten
+  member ways forming one unbroken chain (exactly two free endpoints, no
+  gap to bridge, unlike the canal's 1.4 km jump). Vihar Lake outlet
+  (19.1440, 72.8998) to the Mahim Causeway mouth (19.0487, 72.8369).
+
+- **M2 Length is 17.84 km, and the number has one honest derivation.**
+  The chained centerline measures 17.84 km, which matches MCGM's
+  published 17.84 km exactly. Two WRONG derivations both give 18.20 km
+  and must never be used: summing the member ways' raw lengths, and
+  reading `public/geojson/mumbai-rivers.geojson`. Both double-count
+  shared endpoints. An earlier note in this project quoted 18.20 km and
+  was corrected on measurement.
+
+- **M3 Chain on longitude, not latitude.** The final 300 m below Mahim
+  Causeway runs west and slightly NORTH, so the mouth endpoint
+  (lat 19.048725) sits at a *higher* latitude than the junction just
+  upstream of it (19.048071). A lat-axis chain therefore picks that
+  junction as its extreme, walks straight out to the mouth and
+  terminates after five points, yielding a 0.3 km "river". Longitude is
+  monotonic end to end (72.8998 at Vihar down to 72.8369 at the mouth).
+  Chainage zero at Vihar, increasing to the mouth.
+
+- **M4 The tidal limit is DECLARED at km 10, not inferred.** OSM tags the
+  entire course `water=river` with no distinction, so nothing in the data
+  flags the change. Below km 10 (19.0855, 72.8787, the Kurla / CST Road
+  area) the Mithi is tidal and becomes Mahim Creek, and the mapped water
+  surface encloses intertidal flats: one inner ring of relation/2310505
+  is tagged `wetland=tidalflat`. Consequences, all binding on curation:
+  widths below km 10 are an INTERTIDAL ENVELOPE and are labelled as
+  such; they are never compared against the widening programme's design
+  widths; and no single river-wide median is published, because the
+  river measures two different quantities.
+  The measured step is unambiguous: km 0-9 medians run 19-42 m, km 10
+  onward 56-149 m.
+
+- **M5 `open_water_m` is deliberately NOT the instrument for M4.**
+  Considered and rejected. The measured widths run continuously from
+  56 m to 242 m through the tidal reach with no natural break, so any
+  threshold slices the distribution arbitrarily (199 m kept, 200 m
+  flagged) and discards a real, separable measurement. The tidal reach
+  is a defined channel between banks; it is wide, not un-separable. This
+  is unlike the canal's Ennore km 0-13, which genuinely railed inside a
+  creek/salt-pan complex and correctly read OPEN_WATER. The boundary is
+  carried by the reach table and stated in curation instead.
+
+- **M6 Reach table (8 reaches), with km 10 as a hard boundary:**
+  r1 0-2.5, r2 2.5-5, r3 5-8, r4 8-10 (channel);
+  r5 10-12, r6 12-14.5, r7 14.5-16.5, r8 16.5-17.84 (tidal).
+  Measured 27 Aug 2026: 357 transects at 50 m, 341 OK (95%), median
+  40.3 m overall - a figure that is itself only meaningful split at
+  km 10 (channel median 27.1 m, tidal median 89.3 m).
+
+- **M7 The photo layer will ship short of parity, and says so.**
+  Commons holds six usable Mithi frames; five are by one photographer on
+  one day, 13 September 2008, which predates the post-2005 widening and
+  walling, so they show a channel that no longer exists. Against the
+  canal's 13 photos from 11 authors this is a real gap, and it is named
+  in the methods panel the way every other gap is, with each frame
+  date-stamped. A field shoot completes parity later without a rebuild.
+  EXCLUDED by provenance rule: `Mithi river.jpg`, credited "hindustan
+  times" but uploaded CC BY-SA 4.0 - a newspaper photograph is not the
+  uploader's to license.
+
+- **M8 Water quality is one station and it is three years old.** MPCB
+  monitors a single Mithi point (2168, Mithi Bridge / Kurla). Verified
+  live 27 Aug 2026: mpcb.gov.in water-quality editions run 2011-12 to
+  2023-24 with nothing newer, so there is no live monthly series of the
+  kind that leads the Cooum page (C6). The Today panel is therefore
+  satellite-led, and the WQ series is presented with its vintage on its
+  face. Dahisar, Poisar and Oshiwara are unmonitored entirely.
+
+- **M9 Desilting is a ledger, not a scandal.** The desilting programme
+  has published annual volumes and is the natural occupant of the
+  `silt_ledger` slot. The press frame is an EOW/ED matter; ours is the
+  ledger and the works programme. Standing rule: government-facing prose
+  never reads as lapse or blame.
+
+- **M10 Last-edit is not an imagery date.** The reaches carry tracing
+  vintage resolved from each multipolygon's OUTER rings (see the W7
+  addendum). That is a bound, not a survey date: km 10-11 rests on
+  way/123262828, which reads v10 / 2026 while tagged `source=Yahoo`, an
+  imagery source retired around 2011. The 272 m reading at km 10.95 sits
+  on that way and is already OFFSET-flagged. Spot-QA against current
+  sub-metre imagery stays a listed curation task.
+
+## Open, before anything ships
+
+- M3 curation has no research base yet. Claims must come from a sourced
+  dossier, not from this file.
+- A 350 m unmapped gap at km 9.45-9.80 (NO_POLYGON) sits exactly at the
+  tidal transition. Tracing it into OSM is the durable fix.
+- The spectral width calibration (#301 machinery) has not been run; it is
+  the mechanical check on the tidal reach.
+- No verified Maharashtra equivalent of TN's OCMMS consent sweep.

--- a/docs/waterways/mithi/DECISIONS.md
+++ b/docs/waterways/mithi/DECISIONS.md
@@ -98,6 +98,51 @@ curation layer, and it must not be given one by invention.
   on that way and is already OFFSET-flagged. Spot-QA against current
   sub-metre imagery stays a listed curation task.
 
+- **M11 The satellite seasons are Mumbai's, and Chennai's windows are
+  wrong here.** Measured 27 Aug 2026 over km 12 (Sentinel-2 scenes /
+  under 20% cloud / under 5% cloud): pre-monsoon Feb-May 2026 46/43/31;
+  MONSOON Jun-Aug 2026 **42/1/0**; post-monsoon Oct-Dec 2025 45/32/25.
+  Mumbai's southwest monsoon is effectively opaque to optical satellite -
+  one usable scene in three months, none clear. The first M2 run copied
+  the canal/Cooum Jun-Aug "recent" window and returned water fraction
+  ~0.00 across the entire river including km 13, where the dry window
+  reads 0.55. An estuary does not lose its water in flood; the composite
+  was cloud-masked emptiness resting on a single 5 Jun scene, which the
+  build log said out loud. Corrected pair for a west-coast monsoon river:
+  WET = post-monsoon (Oct-Dec 2025, maximum water), DRY = pre-monsoon
+  (Feb-May 2026, minimum). The config key is still named `recent` for
+  pipeline compatibility; it carries the post-monsoon window and curation
+  must label it by its dates. **There is no honest current-monsoon
+  reading of this river from orbit**, so nothing on the page may be
+  presented as a live August condition.
+
+- **M12 Sentinel-2 is blind to the upper Mithi, in both seasons.**
+  Effective NDWI width against OSM-measured width, by km:
+  km 0-7 ratio 0.00-0.02 in dry AND wet - the satellite detects
+  essentially no water where the channel is 19-33 m; km 8-9 goes 0.00
+  dry to 0.24-0.25 wet (the river appears only in flood); km 10-14 runs
+  0.27-0.70 dry to 0.57-0.87 wet; km 15-17.84 barely moves seasonally
+  (0.37-0.43 dry, 0.41-0.45 wet). Cause in the upper reach: 19-33 m is
+  two to four Sentinel-2 pixels inside the densest urban fabric in India,
+  and the corridor reads 57-99% vegetation - weed and waste mats, bank
+  growth and tree canopy over a narrow channel, plus building shadow.
+  Consequence, binding: **no satellite-derived width ships for km 0-9**,
+  and the methods panel states the blindness with these numbers, the way
+  the Cooum states its failed spectral gate. The satellite layer works
+  only where the Mithi is an estuary, which is the inverse of where the
+  widening and desilting programmes act.
+  Corollary: `veg_frac` in km 0-7 is NOT a usable floating-vegetation
+  proxy at this channel width - the corridor it averages over is mostly
+  not river. It is reported for the tidal reach only.
+
+- **M13 Two different boundaries, both real, and they are not the same
+  one.** The OSM width step is at km 10 (M4) and is a geometry fact. The
+  satellite's seasonal-amplitude step is lower, around km 15: km 10-14
+  swings strongly between seasons while km 15-17.84 hardly moves, which
+  is what tide-dominated rather than rain-dominated water looks like. So
+  km 10 marks where tidal influence BEGINS and km 15 where it dominates.
+  Curation states both and conflates neither.
+
 ## Open, before anything ships
 
 - M3 curation has no research base yet. Claims must come from a sourced

--- a/schemas/nvdm/scopes.json
+++ b/schemas/nvdm/scopes.json
@@ -19,6 +19,7 @@
   "tamil-nadu": "state",
   "buckingham-canal": "waterway",
   "cooum": "waterway",
-  "surat": "city"
+  "surat": "city",
+  "mithi": "waterway"
  }
 }

--- a/scripts/waterways/mithi.json
+++ b/scripts/waterways/mithi.json
@@ -88,5 +88,61 @@
       72.8369,
       19.0487
     ]
+  },
+  "satellite": {
+    "_doc": "Windows are MUMBAI seasons and they are NOT Chennai's. Measured 27 Aug 2026 over km 12 (Sentinel-2 scene counts / under 20% cloud / under 5% cloud): pre-monsoon Feb-May 2026 46/43/31; MONSOON Jun-Aug 2026 42/1/0; post-monsoon Oct-Dec 2025 45/32/25. Mumbai's southwest monsoon is effectively opaque to optical satellite - exactly ONE usable scene in three months and none clear - so a Jun-Aug window is not a composite, it is a single 5 Jun scene, and the first run with that window returned water_frac ~0 even across the tidal reach, which cannot be real for an estuary in flood. The seasonal contrast for a west-coast monsoon river is therefore post-monsoon (WET, maximum water) against pre-monsoon (DRY, minimum). The 'recent' key keeps its name for pipeline compatibility but carries the post-monsoon 2025 window; it is a WET reading, not a current one, and curation must label it by its dates. There is no honest current-monsoon reading of this river from orbit. Anchors are chainage points on the built centerline; place names belong to curation.",
+    "windows": {
+      "dry": [
+        "2026-02-01",
+        "2026-05-15"
+      ],
+      "recent": [
+        "2025-10-01",
+        "2025-12-31"
+      ]
+    },
+    "ndvi_veg": 0.35,
+    "default_half_w": 25,
+    "margin": 8,
+    "chip_every_km": 1,
+    "chip_buffer_m": 300,
+    "min_water_ha_for_ndti": 1.0,
+    "sites": {
+      "vihar-outlet": {
+        "lon": 72.8998,
+        "lat": 19.144,
+        "half_m": 500
+      },
+      "upper-channel-km04": {
+        "lon": 72.8849,
+        "lat": 19.1298,
+        "half_m": 500
+      },
+      "kurla-approach-km08": {
+        "lon": 72.8802,
+        "lat": 19.1023,
+        "half_m": 500
+      },
+      "tidal-limit-km10": {
+        "lon": 72.8787,
+        "lat": 19.0866,
+        "half_m": 700
+      },
+      "widest-reach-km14": {
+        "lon": 72.8667,
+        "lat": 19.0558,
+        "half_m": 900
+      },
+      "mahim-mouth": {
+        "lon": 72.8373,
+        "lat": 19.0486,
+        "half_m": 900
+      }
+    }
+  },
+  "veg_calendar": {
+    "start_year": 2019,
+    "end_year": 2026,
+    "end_month": 8
   }
 }

--- a/scripts/waterways/mithi.json
+++ b/scripts/waterways/mithi.json
@@ -1,0 +1,92 @@
+{
+  "_doc": "Mithi river (waterway 3, Mumbai) pipeline config. Extent decision 27 Aug 2026: the FULL river as OSM maps it - relation 6245575, one unbroken chain of 10 ways (exactly 2 free endpoints, no gap to bridge), 17.84 km from the Vihar Lake outlet (19.1440, 72.8998) to the Mahim Causeway mouth (19.0487, 72.8369). That chained length matches MCGM's published 17.84 km exactly. Do NOT take the length from summing raw way lengths or from public/geojson/mumbai-rivers.geojson: both give 18.20 km by double-counting shared endpoints. Chainage 0 at the Vihar outlet, increasing to the mouth. Chain on LON, not lat: the final 300 m below Mahim Causeway runs west and slightly NORTH, so the mouth endpoint (19.048725) sits at a higher latitude than the junction just upstream of it (19.048071) and a lat-axis chain picks that junction as its extreme, walks straight out to the mouth and terminates after 5 points. Longitude is monotonic end to end (72.8998 at Vihar down to 72.8369 at the mouth). TIDAL: below ~km 10 (Kurla/CST Road) the river is tidal and becomes Mahim Creek; OSM tags the whole course water=river with no distinction, so the tidal limit is declared here and in curation, never inferred from tags.",
+  "id": "mithi",
+  "research_dir": "docs/research/mithi",
+  "curation": "docs/waterways/mithi/waterway-curation.json",
+  "geometry": {
+    "inputs": [
+      {
+        "file": "osm-mithi-centerline.json",
+        "keep_tags": null
+      }
+    ],
+    "clip": {
+      "axis": "lon",
+      "min": 72.83,
+      "max": 72.91
+    },
+    "chain": {
+      "axis": "lon",
+      "chainage_zero_at": "max",
+      "gap_m": 300.0,
+      "progress_tol_deg": 0.002
+    },
+    "sample_m": 50.0,
+    "transect_every_m": 50.0,
+    "half_transect_m": 300.0,
+    "open_water_m": 400.0,
+    "feature": {
+      "name": "Mithi River (Vihar outlet - Mahim Causeway mouth)",
+      "source": "OpenStreetMap via Overpass, ODbL, snapshot 2026-08",
+      "chainage_zero": "Vihar Lake outlet (19.1440, 72.8998), the upstream end of OSM relation 6245575"
+    }
+  },
+  "fetch": {
+    "mirror": "https://overpass.kumi.systems/api/interpreter",
+    "queries": {
+      "osm-mithi-centerline.json": "[out:json][timeout:240];relation(6245575);way(r)[\"waterway\"];out geom;",
+      "osm-water-polygons.json": "[out:json][timeout:240];relation(6245575);way(r)[\"waterway\"]->.r;(way[\"natural\"=\"water\"](around.r:250);relation[\"natural\"=\"water\"](around.r:250);way[\"waterway\"=\"riverbank\"](around.r:250);relation[\"waterway\"=\"riverbank\"](around.r:250););out geom;",
+      "osm-water-meta.json": "[out:json][timeout:240];relation(6245575);way(r)[\"waterway\"]->.r;(way[\"natural\"=\"water\"](around.r:250);relation[\"natural\"=\"water\"](around.r:250);way[\"waterway\"=\"riverbank\"](around.r:250);relation[\"waterway\"=\"riverbank\"](around.r:250););out meta;way(r);out meta;"
+    }
+  },
+  "tidal_limit_km": 10.0,
+  "_tidal_note": "Declared, not inferred. OSM tags the whole course water=river; below km 10 (19.0855, 72.8787, the Kurla/CST Road area) the Mithi is tidal and becomes Mahim Creek, and the mapped water surface there encloses intertidal flats - one inner ring of relation/2310505 is wetland=tidalflat. Widths below this chainage are an INTERTIDAL ENVELOPE, not a channel width, and must never be compared against the widening programme's design widths. open_water_m is deliberately NOT used to flag this: the measured widths run continuously from 56 m to 242 m through the tidal reach with no natural break, so any threshold would slice the distribution arbitrarily and throw away a real measurement. The reach table makes km 10 a hard boundary and the curation states the quantity change per reach.",
+  "reaches_km": [
+    [
+      1,
+      0,
+      2.5
+    ],
+    [
+      2,
+      2.5,
+      5.0
+    ],
+    [
+      3,
+      5.0,
+      8.0
+    ],
+    [
+      4,
+      8.0,
+      10.0
+    ],
+    [
+      5,
+      10.0,
+      12.0
+    ],
+    [
+      6,
+      12.0,
+      14.5
+    ],
+    [
+      7,
+      14.5,
+      16.5
+    ],
+    [
+      8,
+      16.5,
+      17.84
+    ]
+  ],
+  "mouths": {
+    "mithi": [
+      72.8369,
+      19.0487
+    ]
+  }
+}

--- a/src/lib/waterways/index.ts
+++ b/src/lib/waterways/index.ts
@@ -1,12 +1,14 @@
 import type { WaterwayManifest } from "./types";
 import { BUCKINGHAM_CANAL } from "./buckingham-canal";
 import { COOUM } from "./cooum";
+import { MITHI } from "./mithi";
 
 export type { WaterwayManifest } from "./types";
 
 const REGISTRY: Record<string, WaterwayManifest> = {
   [BUCKINGHAM_CANAL.waterwayId]: BUCKINGHAM_CANAL,
   [COOUM.waterwayId]: COOUM,
+  [MITHI.waterwayId]: MITHI,
 };
 
 /**

--- a/src/lib/waterways/mithi.ts
+++ b/src/lib/waterways/mithi.ts
@@ -1,0 +1,38 @@
+import type { WaterwayManifest } from "./types";
+
+/**
+ * The Mithi, waterway 3 and the first outside Chennai: the Vihar Lake
+ * outlet to the Mahim Causeway mouth, 17.84 km, chainage 0 at Vihar.
+ * Research base and data vintages: docs/research/mithi/ (local);
+ * editorial layer: docs/waterways/mithi/waterway-curation.json;
+ * decisions: docs/waterways/mithi/DECISIONS.md.
+ *
+ * Two things the page states rather than hides. Below roughly km 10 the
+ * river is tidal and becomes Mahim Creek: OSM tags the whole course
+ * water=river, so the tidal limit is a declared boundary and widths
+ * below it are an intertidal envelope, not a channel. And the on-ground
+ * photography is thin - Commons holds six usable frames, five of them
+ * from one day in 2008, before the post-2005 rebuild - so the methods
+ * panel carries that gap the way it carries every other one.
+ *
+ * Preview-gated on arrival: NEXT_PUBLIC_PREVIEW_WATERWAYS=mithi.
+ */
+export const MITHI: WaterwayManifest = {
+  waterwayId: "mithi",
+  displayName: "The Mithi",
+  shortName: "Mithi",
+  stateCode: "MH",
+  description:
+    "Vihar Lake to Mahim Creek, 17.84 km, measured reach by reach: " +
+    "widths above and below the tidal limit, the satellite record, the " +
+    "single monitored water-quality station, the desilting ledger and " +
+    "the works programme's documents, every number with its source.",
+  center: [19.095, 72.875],
+  zoom: 12,
+  chainageNote:
+    "Chainage runs north to south: km 0 at the Vihar Lake outlet, " +
+    "km 17.8 at the Mahim Causeway mouth. The river is tidal below " +
+    "about km 10.",
+  cityIds: ["mumbai"],
+  enabled: false,
+};


### PR DESCRIPTION
**Draft on purpose. Do not merge.** This is a milestone review gate, not a merge candidate: M3 curation does not exist, so the page does not build and the manifest ships `enabled: false`. Nothing here is shippable yet. Merging comes after M3 and after we are sure.

Waterway 3, and the first outside Chennai.

## What to actually review

Four load-bearing decisions, because everything in M3 gets written on top of them and they are expensive to revisit later.

**1. The tidal boundary at km 10, and the approach I rejected to get there.** OSM tags the whole course `water=river`, but below Kurla the Mithi is tidal and becomes Mahim Creek; an inner ring of `relation/2310505` is `wetland=tidalflat`, so the mapped surface encloses intertidal flats. The measured step is unambiguous: 19-42 m above, 56-149 m below.

I had planned to drop `open_water_m` to flag this and **rejected that after seeing the distribution**. The widths run continuously 56-242 m with no natural break, so any threshold slices arbitrarily (199 kept, 200 flagged) and discards a real measurement. The Mithi estuary is *wide*, not un-separable, unlike the canal's Ennore reaches that genuinely railed. So km 10 is a hard reach boundary, curation declares the quantity change, and **no river-wide median is published** because the river measures two different things. DECISIONS M4, M5.

**2. Chain on longitude, not latitude.** The last 300 m runs west and slightly *north*, so the mouth sits at a higher latitude than the junction above it. A lat-axis chain picks that junction as its extreme, walks out to the mouth and terminates after five points. It produced a 0.3 km "river" that built without any error. DECISIONS M3.

**3. The satellite windows are Mumbai's, not Chennai's.** The first M2 run copied the canal/Cooum Jun-Aug window and returned water fraction ~0.00 across the whole river including km 13, where the dry window reads 0.55. An estuary does not lose its water in the monsoon.

Measured over km 12 (scenes / <20% cloud / <5% cloud):

| window | scenes | <20% | <5% |
|---|---|---|---|
| pre-monsoon Feb-May 2026 | 46 | 43 | 31 |
| **monsoon Jun-Aug 2026** | 42 | **1** | **0** |
| post-monsoon Oct-Dec 2025 | 45 | 32 | 25 |

Mumbai's monsoon is opaque; the composite was cloud-masked emptiness on a single 5 June scene, which the build log said out loud. Jun-Aug works for Chennai because Chennai rains Oct-Dec. Corrected to WET = post-monsoon 2025, DRY = pre-monsoon 2026. **There is no honest current-monsoon reading of this river from orbit**, so nothing may be presented as a live August condition. DECISIONS M11.

**4. Sentinel-2 is blind to the upper Mithi and that is not fixable.** Effective NDWI width as a ratio of OSM-measured width:

| km | OSM width | dry | wet |
|---|---|---|---|
| 0-7 | 19-33 m | **0.00-0.02** | **0.00-0.02** |
| 8-9 | 35-43 m | 0.00-0.01 | 0.24-0.25 |
| 10-14 | 57-150 m | 0.27-0.70 | 0.57-0.87 |
| 15-17.8 | 69-89 m | 0.37-0.43 | 0.41-0.45 |

19-33 m is two to four pixels inside the densest urban fabric in India, and the corridor reads 57-99% vegetation. Visually confirmed on the chips: the km 14 site chip shows an unmistakable river, km 4 shows no resolvable channel. So **no satellite width ships for km 0-9**, stated in methods with these numbers as the Cooum states its failed spectral gate. The satellite layer works only where the Mithi is an estuary, which is the inverse of where the widening and desilting programmes act. DECISIONS M12.

An unplanned corollary: seasonal amplitude collapses below about km 15, which is tide-dominated rather than rain-dominated water. So km 10 is where tidal influence *begins* and km 15 where it *dominates*. Two real boundaries, stated separately. DECISIONS M13.

## The measurement

OSM relation `6245575`, ten ways in one unbroken chain, two free endpoints, no gap to bridge (the canal needed a 1.4 km jump). **17.84 km, matching MCGM's published figure exactly.** 357 transects at 50 m, 341 measured (95%), bank vertex spacing 30.8 m so the 50 m floor holds. Reach medians, channel then tidal: 20.9, 27.2, 29.0, 38.5 | 67.8, 148.8, 74.5, 85.3.

Note the earlier 18.20 km figure in my notes was wrong and is corrected in DECISIONS M2: summing raw way lengths and reading `mumbai-rivers.geojson` both double-count shared endpoints.

This branch is also the first real exercise of #323 (outer-ring vintage). It corrects the reported tracing span on 5 of 8 reaches, most importantly r6 - the widest, most scrutinised reach - which the old logic labelled 2023 against an actual outer-ring 2026. No tier letters move.

## Two gaps this page will ship with, named not papered over

**Photos.** Commons holds six usable Mithi frames; five are by one photographer on 13 September 2008, predating the post-2005 widening, so they show a channel that no longer exists. Against the canal's 13 frames from 11 authors that is a real shortfall, named in methods with each frame date-stamped. `Mithi river.jpg` is excluded on provenance: credited "hindustan times" but uploaded CC BY-SA 4.0, and a newspaper photo is not the uploader's to license. DECISIONS M7.

**Water quality.** MPCB monitors one point (2168, Mithi Bridge / Kurla) and its editions stop at 2023-24, verified live 27 Aug. No live monthly series of the kind that leads the Cooum page. DECISIONS M8.

## Safety of merging this early, if we ever wanted to

`enabled: false` and there is no `generateStaticParams`, so the registry's visibility filter keeps `mithi` out of `/waterways`, out of Mumbai's nav, and 404s the page. No data artifacts are added, so the L2 gate reports nothing new. **Do not set `NEXT_PUBLIC_PREVIEW_WATERWAYS=mithi`** on any deploy yet: the page would try to load `public/data/waterways/mithi/*` which does not exist.

## Next

M3 is a sourced research pass and then roughly a hundred claims with per-claim citations. It is not started, and it will not be invented from this file.