### PR TITLE
Allow waterparliament.net to embed the basin atlases

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,6 +45,9 @@ const EMBED_FRAME_ANCESTORS = [
   "https://forrivers.life",
   "https://www.forrivers.life",
   "https://orchid-wildcat-815854.hostingersite.com",
+  "https://waterparliament.net",
+  "https://www.waterparliament.net",
+  "https://water-parliament.vercel.app",
   ...(process.env.NODE_ENV === "development" ? ["http://localhost:*"] : []),
 ].join(" ");
 const embedHeaders = securityHeaders.map((h) => {


### PR DESCRIPTION
Water Parliament's launch page (SOW1) carries a Neer Vazhvu basin atlas as its "registry, live" section, framed from `/embed/basins/...`. Same pattern as the forrivers.life allowance in #320.

Adds to `EMBED_FRAME_ANCESTORS`:
- `https://waterparliament.net` and `https://www.waterparliament.net` (production, GoDaddy domain being attached)
- `https://water-parliament.vercel.app` (the site's stable Vercel alias, used for Water Parliament's review before the domain is live)

`/embed/*` remains the only framable namespace; everything else keeps `frame-ancestors 'none'`. Headers are not hot-reloaded, so this takes effect on deploy.

Context: `docs/partnerships/water-parliament/integration-plan-2026-08.md` (phase 1).