### PR TITLE
Serve the atlas-tn corpus release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -35,9 +35,9 @@
     "2026-08-28: the Paani Phase 3 release, tagged corpus-2026-08-28-cauvery-phase3 at 4aee6adcc93c2139a05843789f3c510870da4d23 (data#53 squash, after data#52 carried the Kerala context as first built; counts verified against the tree API). ADDS 6 artifacts, so expected_files moves 659/161 -> 665/161: the Kabini's full-watershed context outline and the Kerala reach above the state line (areaKm2 2,199, lengthKm 84.5, both roles reproduced by the ingest after the 28 Aug review), and the Cauvery-KA snapshot layers - state boundary, 25 India-WRIS waterbodies, Greater Bengaluru split by the divide (35.1% drains here), the Kabini above the basin. Also carries the Nanjangud register subtab on kabini/prs.json (345 consented / 217 operating), the review-fixed kabini flow-stations + inventories, and the daily feeds the scrapers pushed to code main since the 26 Aug release. The data repo's toolchain.lock was re-pinned to main 17c1e202 in the same release, so no dangling pins."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "4aee6adcc93c2139a05843789f3c510870da4d23",
+  "sha": "9676d20e2f66772ceb02d95c190609d6e6c2a418",
   "expected_files": {
-    "data": 665,
+    "data": 814,
     "geojson": 161
   }
 }


### PR DESCRIPTION
corpus.lock moves to the data repository's merge 9676d20e (immutable tag corpus-2026-09-01-atlas-tn): the 149 Thanjavur and Tiruchirappalli atlas artifacts from #336 plus the drifted daily feeds, produced with the toolchain at 0c7399fc, which the data repository's toolchain.lock pins reciprocally. Verified before opening: a real CORPUS_SOURCE=remote fetch against this pin in a throwaway worktree passed its count preflight and completed. Districts remain preview-gated; production pages are unchanged until published: true.