### PR TITLE
Serve the atlas-irrigation corpus release

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -36,9 +36,9 @@
     "2026-09-01: the Kabini after Madhuri's review, tagged corpus-2026-09-01-kabini-feedback at 636001a7863a8cf00f14e1a345afc26f664d6a3e (data#55 squash; counts verified against the tree API). ADDS 2 artifacts - the Kerala context waterbodies and the tributary skeleton that connects them to the river system - so expected_files moves 814/161 -> 816/161. Four modified: command-areas drops the K R Sagar command, inventory carries the two new families, and the two CWC readings packs carry the reworded chart captions."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "636001a7863a8cf00f14e1a345afc26f664d6a3e",
+  "sha": "c00f5987f239b4880c75787b3d4f73d43b1ef1ce",
   "expected_files": {
-    "data": 816,
+    "data": 818,
     "geojson": 161
   }
 }


### PR DESCRIPTION
corpus.lock moves to the data repository's c00f5987 (tag corpus-2026-09-01-atlas-irrigation): the two irrigation-current artifacts from the DES Season and Crop Report 2024-25, produced with the toolchain at f482db4f. Verified before opening: a real CORPUS_SOURCE=remote fetch against this pin passed its count preflight (818 data, 161 geojson). With this pin the published district pages open on the 2024-25 irrigation mix instead of the fallback.