### PR TITLE
fix(atlas): let the prose run the table width

### DIFF
--- a/src/app/atlas/[state]/[district]/blocks/[blockCode]/page.tsx
+++ b/src/app/atlas/[state]/[district]/blocks/[blockCode]/page.tsx
@@ -104,7 +104,7 @@ export default async function AtlasBlockPage({ params }: RouteParams) {
           <h1 className="mt-2 text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             {block.name} block
           </h1>
-          <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-600 dark:text-slate-400">
+          <p className="mt-3 text-base leading-relaxed text-slate-600 dark:text-slate-400">
             {block.panchayatCount} Gram Panchayats, {block.waterProfileCount} of them with a water
             profile{reviewedHere > 0 ? `, ${reviewedHere} reviewed by a person` : ""}. Figures below are the
             block&rsquo;s share of the district roll-up

--- a/src/app/atlas/[state]/[district]/page.tsx
+++ b/src/app/atlas/[state]/[district]/page.tsx
@@ -135,7 +135,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
           <h1 className="mt-2 text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
             {reading.districtName} district
           </h1>
-          <div className="mt-5 max-w-3xl">
+          <div className="mt-5">
             <ToneBadge tone={verdict.tone} />
             <p className="mt-3 text-lg sm:text-xl leading-relaxed text-slate-800 dark:text-slate-200">
               {verdict.sentence}
@@ -161,7 +161,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
           </dl>
 
           {verdict.nextSteps.length > 0 ? (
-            <div className="mt-8 max-w-3xl">
+            <div className="mt-8">
               <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
                 What would sharpen this reading
               </h2>

--- a/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
+++ b/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
@@ -109,7 +109,7 @@ function Chapter({
 }) {
   return (
     <section id={id} aria-labelledby={`${id}-title`} className="scroll-mt-20 py-6 first:pt-0">
-      <header className="mb-3 max-w-2xl">
+      <header className="mb-3">
         <h2 id={`${id}-title`} className="text-lg sm:text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
           {title}
         </h2>
@@ -222,7 +222,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
             .{curated ? ` Reviewed by a person on ${curated.reviewedAt}.` : ""}
           </p>
 
-          <div className="mt-6 max-w-3xl">
+          <div className="mt-6">
             {verdict ? (
               <>
                 <ToneBadge tone={tone} />

--- a/src/components/atlas/atlas-primitives.tsx
+++ b/src/components/atlas/atlas-primitives.tsx
@@ -62,7 +62,7 @@ export function AtlasSection({
 }) {
   return (
     <section id={id} aria-labelledby={`${id}-title`} className={cn("scroll-mt-20 py-8 sm:py-10", className)}>
-      <header className="mb-4 max-w-3xl">
+      <header className="mb-4">
         <h2 id={`${id}-title`} className="text-xl sm:text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
           {title}
         </h2>
@@ -76,7 +76,7 @@ export function AtlasSection({
 /** A method or provenance note under a table or figure. */
 export function AtlasNote({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <p className={cn("mt-3 max-w-3xl text-xs sm:text-sm leading-relaxed text-slate-500 dark:text-slate-400", className)}>
+    <p className={cn("mt-3 text-xs sm:text-sm leading-relaxed text-slate-500 dark:text-slate-400", className)}>
       {children}
     </p>
   );
@@ -85,7 +85,7 @@ export function AtlasNote({ children, className }: { children: ReactNode; classN
 /** A finding written as text: the reading above a table, not a caption under it. */
 export function AtlasFinding({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <p className={cn("max-w-3xl text-sm sm:text-base leading-relaxed text-slate-800 dark:text-slate-200", className)}>
+    <p className={cn("text-sm sm:text-base leading-relaxed text-slate-800 dark:text-slate-200", className)}>
       {children}
     </p>
   );


### PR DESCRIPTION
## What

Atlas prose runs the full container width. The district verdict and its read-as-of line, the "what would sharpen this reading" list, section intros, findings paragraphs and method notes were capped at `max-w-3xl` (768 px) while the fact cards and tables filled the `max-w-6xl` container, so on a wide screen every paragraph stopped at two-thirds and the right third above each table sat empty. The caps come off in the shared primitives (`AtlasSection`, `AtlasNote`, `AtlasFinding`) and in the district, block and Gram Panchayat heroes; the water-bodies stat card keeps its own width because it is a card, not text. Eight lines across four files.

## Why

The measure cap is a readable-line convention the rest of the platform uses for standalone prose, but on these pages every paragraph sits directly above a full-width table or card row, and the mismatch reads as a layout fault rather than typography.

## How to test

1. `npm run dev`, open `/atlas/tn/tiruchirappalli` at a desktop width: the verdict sentence, the read-as-of line, the fact cards and the taluk table share one right edge (measured 1088 px each at 1440 wide).
2. Scroll to "Groundwater by taluk": the intro and the findings paragraph span the table width.
3. Open a block and a Gram Panchayat page: same.
4. Mobile, verified under real device emulation (Playwright iPhone 14 Pro, `isMobile`, not a narrow desktop window): district, block and Panchayat pages at 393 px report `innerWidth` 393 and `scrollWidth` 393 with zero elements past the edge outside their own scroll containers; `/chennai` as the control passes the same check. Wide tables scroll inside their container as before.

## Checklist

- [x] `npm run build` passes (1,057 static pages, zero Turbopack trace warnings)
- [x] `npm run lint` passes (0 errors; pre-existing warnings only)
- [x] `npx tsc --noEmit` clean; `npm test` passes
- [x] No data, API or generated-doc changes, so the API job and the catalogue/conformance regen do not apply
