### PR TITLE
Release: pin the corpus at corpus-2026-09-01-atlas-satara and publish Satara

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -36,9 +36,9 @@
     "2026-09-01: the Kabini after Madhuri's review, tagged corpus-2026-09-01-kabini-feedback at 636001a7863a8cf00f14e1a345afc26f664d6a3e (data#55 squash; counts verified against the tree API). ADDS 2 artifacts - the Kerala context waterbodies and the tributary skeleton that connects them to the river system - so expected_files moves 814/161 -> 816/161. Four modified: command-areas drops the K R Sagar command, inventory carries the two new families, and the two CWC readings packs carry the reworded chart captions."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "c00f5987f239b4880c75787b3d4f73d43b1ef1ce",
+  "sha": "15c16a853e79d3836893c5302d3b556a99dd52f7",
   "expected_files": {
-    "data": 818,
+    "data": 890,
     "geojson": 161
   }
 }

--- a/src/lib/atlas/registry.ts
+++ b/src/lib/atlas/registry.ts
@@ -83,7 +83,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     name: "Satara",
     hook: "Koyna country with a dry eastern edge: the same district holds talukas at 20% and talukas at 76% of their groundwater.",
     hasCuratedBriefs: true,
-    published: false,
+    published: true,
     irrigationCurrentSource: {
       label: "District Socio-Economic Review",
       nextStep:


### PR DESCRIPTION
## What

`corpus.lock` moves to `15c16a85` (neer-vazhvu-data#57, tag `corpus-2026-09-01-atlas-satara`): the 72 Satara artifacts under `data/atlas/mh/satara/` (directory, boundaries, JJM, Census, groundwater, projection, rainfall, water bodies from the First Census of Water Bodies, the verified District Environment Plan transcription, assessments, briefs, the Marul Haveli reviewed brief) plus the daily feeds that moved since the last release. Data 818 -> 890 files, geojson 161 unchanged. Verified with a real `CORPUS_SOURCE=remote` fetch in a throwaway worktree: 890/161 synced, all 72 Satara files present, `directory.json` byte-identical to the checkout.

Satara leaves the preview gate in the same PR (`published: true`): it lists on the Districts tab, its freshness checks (directory and rainfall, 45 days) activate, and its routes join the sitemap. The JJM pairings and block rows the reviewer has not affirmed stay labelled unverified on the page.

## Why

Production serves the corpus at the pin, so #342 alone changed nothing under `/atlas/mh/satara`; this is the release that makes the district real.

## How to test

1. After merge: `curl -s https://www.neervazhvu.org/data/atlas/mh/satara/directory.json | head -c 300` returns the envelope; `/atlas/mh/satara` renders with the verdict, the census water bodies and the plan section.
2. `npm test` (272), `npx tsx scripts/check-data-freshness.ts --validate` (50 checks, Satara's two included).

## Checklist

- [x] `npm run build` passes (CI locked-corpus job)
- [x] `npm run lint` passes
- [x] Tested in demo mode (no Supabase required)
- [x] For Python changes: `ruff check .` passes
