### PR TITLE
Release: pin the corpus at corpus-2026-09-02-atlas-salem-tirupathur and publish both districts

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -36,9 +36,9 @@
     "2026-09-01: the Kabini after Madhuri's review, tagged corpus-2026-09-01-kabini-feedback at 636001a7863a8cf00f14e1a345afc26f664d6a3e (data#55 squash; counts verified against the tree API). ADDS 2 artifacts - the Kerala context waterbodies and the tributary skeleton that connects them to the river system - so expected_files moves 814/161 -> 816/161. Four modified: command-areas drops the K R Sagar command, inventory carries the two new families, and the two CWC readings packs carry the reworded chart captions."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "15c16a853e79d3836893c5302d3b556a99dd52f7",
+  "sha": "ccf7f75dd2dbfccecf499ca39fa8b49780fdc93d",
   "expected_files": {
-    "data": 890,
+    "data": 1030,
     "geojson": 161
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -78,6 +78,13 @@ const nextConfig: NextConfig = {
       "./public/tiles/**",
       "./public/images/**",
       "./public/data/rich-bodies/**",
+      // The Atlas corpus is read only at build time by SSG district, block
+      // and Panchayat pages (src/lib/atlas/data.ts); no serverless function
+      // reads it. At 163 MB and growing with every district, leaving it in
+      // the whole-public trace pushed [cityId]/water-bodies to 270 MB
+      // uncompressed - past Vercel's 250 MB limit - when Salem and
+      // Tirupathur's corpus landed (2026-09-02).
+      "./public/data/atlas/**",
     ],
   },
   outputFileTracingIncludes: {

--- a/src/lib/atlas/registry.ts
+++ b/src/lib/atlas/registry.ts
@@ -84,7 +84,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     hook: "Holds Mettur, the delta's canal head, and irrigates almost none of its own farmland from it: 13 of 14 taluks draw more groundwater than recharges.",
     basin: { basinId: "cauvery-tn", subBasinKey: "129", subBasinName: "Tirumanimuttar" },
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {
@@ -96,7 +96,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     name: "Tirupathur",
     hook: "The Palar tannery belt without a canal: every taluk is over-exploited and all irrigation is from wells.",
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {


### PR DESCRIPTION
## What

Serve the corpus at `corpus-2026-09-02-atlas-salem-tirupathur` (data-repo `ccf7f75d`, from neer-vazhvu-data#58) and flip `published: true` for Salem and Tirupathur. corpus.lock moves 890 -> 1030 data files, geojson unchanged at 161.

## Why

The pair merged preview-gated in #344; this is the one release for both districts. The pin was verified with a real remote fetch in a throwaway worktree: 1030/161 synced, Salem and Tirupathur directories, registers and shards all served.

## How to test

1. `CORPUS_SOURCE=remote CORPUS_USE_GIT_AUTH=1 bash scripts/fetch-corpus.sh` on this branch, then `/atlas/tn/salem` and `/atlas/tn/tirupathur` on a dev server with no preview env: both render from the pin, landing cards and sitemap carry them.
2. `npx tsx scripts/atlas-generate-assessments.ts --district salem --validate` (and `tirupathur`) against the fetched tree.

## Checklist

- [x] `npm run lint` passes
- [x] Tested in demo mode (no Supabase required)
