### PR TITLE
docs: catch the documentation up to the platform - the District Atlas, corpus-pinned serving, and stale counts

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -22,6 +22,10 @@ Per-city *features* live alongside in the same folder: [docs/cities/chennai/feat
 
 When adding a city, copy the Surat, Pune, Kolkata or Delhi folder as a template - those docs reflect the multi-city naming convention (per-city `-<cityId>` suffix on data files). Chennai's docs predate that and use unsuffixed legacy paths for back-compat.
 
+## District Atlas
+
+Districts (Thanjavur, Tiruchirappalli, Salem, Tirupathur, Satara) draw from government registers rather than utility feeds: the TNRD panchayat directory / the LGD catalog on data.gov.in, the JJM Citizen Corner service ledger, Census 2011 DCHB village tables, IN-GRES taluk assessments, TNGIS / DataMeet boundaries, the Season and Crop Report, the First Census of Water Bodies, and MPCB District Environment Plans. Their sources are documented per adapter rather than per district - the full breakdown, including the identity-resolution discipline and per-family provenance, is [docs/methodology/district-atlas-v1.md](docs/methodology/district-atlas-v1.md); reviewed inputs live under `pipeline-inputs/atlas/`.
+
 ## Documentation principle: record what the source refuses to say
 
 Kolkata added a second discipline alongside the hedging rule below. Where a publisher contradicts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neer Vazhvu
 
-**India's Water Intelligence** - An open-source platform that turns public water data into actionable intelligence for India's cities, districts and river basins. Live for Chennai, Madurai, Bengaluru, Mumbai, Delhi, Hyderabad, Kolkata, Gurugram, Pune and Surat today.
+**India's Water Intelligence** - An open-source platform that turns public water data into actionable intelligence for India's cities, districts and river basins. Live for Chennai, Madurai, Bengaluru, Mumbai, Delhi, Hyderabad, Kolkata, Gurugram, Pune and Surat today - plus the [District Atlas](#district-atlas): Thanjavur, Tiruchirappalli, Salem, Tirupathur and Satara at district, block and Gram Panchayat grain.
 
 **Live:** [neervazhvu.org](https://neervazhvu.org)
 
@@ -14,7 +14,7 @@ Every city dashboard, where the data exists, surfaces:
 - **Groundwater** - CGWB block exploitation classification, station-level depth time-series, and (where well density supports it) ward-level depth interpolation
 - **Rivers** - CPCB NWMP DO/BOD time-series with status badges derived from current readings via the shared CPCB Designated Best-Use classifier
 - **Water bodies** - OSM polygons, lost-tank inventory, restoration priority scoring (algorithm varies per city)
-- **Rich-data deep-zoom panel** - 21 flagship bodies onboarded (8 in Chennai + 13 in Bangalore). A click opens a full-screen panel with yearly satellite imagery 1984-present, cumulative water-loss and built-gain tints over the polygon and 1 km halo, per-year stats (water surface, built share, building counts in body vs halo), a play/pause timeline with event stamps, and a sources & methodology modal. Water-fraction series splices JRC GSW v1.4 (1984-2021) with Dynamic World V1 (2022-present) so the chart doesn't truncate at JRC's cutoff
+- **Rich-data deep-zoom panel** - 43 flagship bodies onboarded across all 8 rich-body cities (7 Chennai, 14 Bengaluru, 5 Mumbai, 5 Hyderabad, 5 Pune, 3 Delhi, 3 Kolkata, 1 Gurugram). A click opens a full-screen panel with yearly satellite imagery 1984-present, cumulative water-loss and built-gain tints over the polygon and 1 km halo, per-year stats (water surface, built share, building counts in body vs halo), a play/pause timeline with event stamps, and a sources & methodology modal. Water-fraction series splices JRC GSW v1.4 (1984-2021) with Dynamic World V1 (2022-present) so the chart doesn't truncate at JRC's cutoff
 - **Flood risk** - Hazard zones / drainage / sewerage where layers are public; narrative-only stub where they're not
 - **Shoreline change** (`/shoreline`, Chennai + Mumbai today) - Erosion/accretion along the Chennai coast, Mahabalipuram to Pulicat. The primary layer is our own MNDWI/DSAS satellite measurement (Landsat 5/7/8 + Sentinel-2 via Earth Engine, ~1,200 transects, **1990-2026** - extending past the study's 2024 cutoff), with a per-transect movement-over-time chart, an early-vs-recent acceleration check (≈72% of the eroding coast is eroding faster than before), and a per-transect confidence flag. The six study zones + named port hotspots from Anagha, Singh & Frappart (2026, *Environmental Challenges*) are drawn as faint context that validates the measurement
 - **My Ward** - Per-ward report aggregating every layer above with comparison + uplift planner (Chennai, Madurai, Bengaluru, Delhi). Deliberately withheld where the geometry is not public or nothing is joined to it: Mumbai until the ward build lands, Hyderabad because the 300-ward delimitation gazetted 25 Dec 2025 has no published boundaries, Kolkata because the only public ward geometry covers 141 of 144 wards - the three missing ones are 9.2% of the city - Pune because no ward rows exist in the database, and Gurugram because although all 36 ward polygons are harvested, GMDA's layer publishes a ward number and a zone code with no ward name and nothing is joined to them. Every omission and its reason is in [docs/architecture/exemptions.md](docs/architecture/exemptions.md)
@@ -79,6 +79,10 @@ Per-city deep-dives:
 
 **Place-config-driven multi-city.** Adding a city = adding a `CityConfig` in `src/lib/cities/`. The routes at `src/app/[cityId]/...` resolve it via `tryGetPlaceConfig(cityId)`. `heroMode` (`days-left` | `allocation` | `cauvery-pumping` | `none`) picks the dashboard hero variant. Per-city water sources, ward counts, `urbanSupply` allocation context, capability flags (`hasCommitments`, `hasAllocationLedger`, `hasShoreline`, ...), language state (`availableLanguages` + `upcomingLanguages` for greyed coming-soon toggles), and region structure (`placeKind: 'region'` + `corporations[]` for the MMR) all flow from the same config. See [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-city) for the full walkthrough.
 
+**Corpus-pinned serving.** `public/data` + `public/geojson` are developed in this repo but production does not read them from the checkout: `npm run build` starts with `scripts/fetch-corpus.sh`, and with `CORPUS_SOURCE=remote` (Vercel, the locked-corpus CI job) it replaces both roots wholesale with the private data repo (`neer-vazhvu-data`) at the exact commit pinned in [corpus.lock](corpus.lock). Deploys are reproducible and rolling back the site rolls back the data - and a data change only reaches production through a release: a data-repo PR, an immutable `corpus-YYYY-MM-DD-<slug>` tag, and a pin PR here moving `corpus.lock` (helper: `scripts/release_corpus.py`). Locally the default `CORPUS_SOURCE=repo` is a no-op and the checkout serves as-is.
+
+**District Atlas routing.** Districts are places too, but they resolve through their own registry (`src/lib/atlas/registry.ts`) rather than `src/lib/cities/`: routes live at `/atlas/[state]/[district]` with block and Gram Panchayat pages beneath, all statically generated from the corpus at build time. See the [District Atlas](#district-atlas) section below.
+
 Earth Engine Phase 1 jobs live under `neer-vazhvu-api/app/gee/` and write small summary tables into Supabase instead of serving raster layers directly to the frontend.
 
 ## Data Sources
@@ -93,6 +97,8 @@ We integrate 50+ distinct sources across the cities we cover - from utility-publ
 - [docs/cities/hyderabad/data-sources.md](docs/cities/hyderabad/data-sources.md)
 - [docs/cities/kolkata/data-sources.md](docs/cities/kolkata/data-sources.md)
 - [docs/cities/gurugram/data-sources.md](docs/cities/gurugram/data-sources.md)
+- [docs/cities/pune/data-sources.md](docs/cities/pune/data-sources.md)
+- [docs/cities/surat/data-sources.md](docs/cities/surat/data-sources.md)
 - [DATA_SOURCES.md](DATA_SOURCES.md) - top-level index with a cross-city parity matrix (the contributor cheat-sheet for what each city has covered)
 
 ## Tech Stack
@@ -113,12 +119,12 @@ We integrate 50+ distinct sources across the cities we cover - from utility-publ
 Earth Engine is used as a summary layer (catchment rainfall context, water-body NDWI seasonality) and as the build-time source for the rich-data deep-zoom panel's yearly chips and zonal stats — not a raster explorer. Methodology, guardrails, and operations live in dedicated docs:
 
 - [GEE_PHASE2_3_PLAN.md](GEE_PHASE2_3_PLAN.md), [GEE_PHASE2_CHECKLIST.md](GEE_PHASE2_CHECKLIST.md)
-- Shipped-method write-ups: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md), [docs/methodology/coastal-shoreline-change-v1.md](docs/methodology/coastal-shoreline-change-v1.md), [docs/methodology/cascade-reconstruction-v1.md](docs/methodology/cascade-reconstruction-v1.md)
+- Shipped-method write-ups: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md), [docs/methodology/coastal-shoreline-change-v1.md](docs/methodology/coastal-shoreline-change-v1.md), [docs/methodology/cascade-reconstruction-v1.md](docs/methodology/cascade-reconstruction-v1.md), [docs/methodology/district-atlas-v1.md](docs/methodology/district-atlas-v1.md)
 - (The phase-1 planning documents were retired to local archives once the work shipped; the methodology folder is the maintained record.)
 
 ## Rich-Data Deep-Zoom Panel
 
-21 flagship bodies have a dedicated deep-zoom experience layered on top of the standard `/water-bodies` map. Onboarded bodies today: 8 in Chennai (Pallikaranai Marsh, Sholavaram, Red Hills/Puzhal, Chembarambakkam, Porur, Velachery, Perumbakkam, Chitlapakkam) + 13 in Bengaluru (Bellandur, Varthur, Hesaraghatta, Hebbal, Ulsoor, Sankey, Madivala, Agara, Jakkur, Rachenahalli, Iblur, Kempambudhi, Puttenahalli, Yelahanka).
+43 flagship bodies have a dedicated deep-zoom experience layered on top of the standard `/water-bodies` map. Onboarded today: 7 in Chennai (Pallikaranai Marsh, Sholavaram, Red Hills/Puzhal, Chembarambakkam, Porur, Velachery, Perumbakkam), 14 in Bengaluru (Bellandur, Varthur, Hesaraghatta, Hebbal, Ulsoor, Sankey, Madivala, Agara, Jakkur, Rachenahalli, Iblur, Kempambudhi, Puttenahalli, Yelahanka), 5 in Mumbai (Powai, Vihar, Tulsi, Tansa, Bhatsa), 5 in Hyderabad (Hussain Sagar, Osman Sagar, Himayat Sagar, Durgam Cheruvu, Ameenpur), 5 in Pune (Khadakwasla, Panshet, Warasgaon, Temghar, Pawana), 3 in Delhi (Najafgarh Jheel, Bhalswa, Sanjay), 3 in Kolkata (Rabindra Sarobar, Subhash Sarobar, Santragachi Jheel) and 1 in Gurugram (Sultanpur).
 
 For each body the build-time pipeline produces:
 
@@ -137,6 +143,20 @@ To onboard a new body, see [docs/cities/chennai/features.md](docs/cities/chennai
 The "Catchments" view mode on `/[city]/water-bodies` makes every lake clickable to show its **area of influence**: the catchment that drains into it, the feeder streams, the upstream/downstream tanks, the downstream flow path to the river, and a rooftop rainwater-harvest estimate. Live for Chennai, Madurai, and Bengaluru; quality bar is the Hyderabad Lake Atlas.
 
 Catchments are delineated from a 30 m bare-earth DEM (FABDEM) with WhiteboxTools hydrology - a threshold-free own / received / total contributing-area model, plus a per-lake downstream flow path traced through the cascade to the river. Lake names are backfilled from authoritative open sources where OSM is sparse (Bengaluru: the ATREE/CSEI named-lake census on OpenCity), and the downstream river is named by snapping the flow path to the mapped river network. Full methodology: [docs/methodology/catchment-atlas-v1.md](docs/methodology/catchment-atlas-v1.md).
+
+## District Atlas
+
+The platform's rural surface: a page per district at `/atlas/[state]/[district]`, a page per block (TN) or taluka (MH), and a page per Gram Panchayat - 3,088 GP pages across five districts today. Where a city dashboard reads utility feeds, a district's water state lives in government registers, and the Atlas turns those registers into place pages without inventing anything between them: every joined identity is either exact or a human-reviewed proposal, and every page states which registers could not be bound and why.
+
+| District | State | GPs | Blocks/Talukas | The hook |
+|---|---|---|---|---|
+| [Thanjavur](https://neervazhvu.org/atlas/tn/thanjavur) | TN | 589 | 14 | The rice bowl: the district's water year is decided upstream at Mettur |
+| [Tiruchirappalli](https://neervazhvu.org/atlas/tn/tiruchirappalli) | TN | 404 | 14 | Thanjavur's inverse: water security is a groundwater question |
+| [Salem](https://neervazhvu.org/atlas/tn/salem) | TN | 385 | 20 | Holds Mettur, the delta's canal head - and 13 of 14 taluks are over-exploited |
+| [Tirupathur](https://neervazhvu.org/atlas/tn/tirupathur) | TN | 208 | 6 | The Palar tannery belt without a canal: all irrigation is from wells |
+| [Satara](https://neervazhvu.org/atlas/mh/satara) | MH | 1,502 | 11 | Koyna country with a dry eastern edge |
+
+Two identity adapters exist - Tamil Nadu's register adapter (TNRD directory, JJM Citizen Corner, Census 2011 DCHB, TNGIS boundaries, IN-GRES taluks, Season and Crop Report irrigation) and the LGD adapter that onboarded Maharashtra (LGD catalog on data.gov.in, DataMeet village polygons, First Census of Water Bodies, MPCB District Environment Plan) - so a new district on an existing adapter is roughly a day of register fetches plus human review of the staged name-resolution proposals. District verdicts are composed, never scored: the severest present reading leads and unmeasured dimensions are named on the page. A monthly GitHub Actions run ([.github/workflows/atlas-refresh.yml](.github/workflows/atlas-refresh.yml)) re-fetches registers whose upstream editions moved. Full methodology: [docs/methodology/district-atlas-v1.md](docs/methodology/district-atlas-v1.md).
 
 ## Getting Started
 

--- a/docs/cities/surat/features.md
+++ b/docs/cities/surat/features.md
@@ -36,8 +36,14 @@ Load-bearing behaviours, all deliberate:
 
 - **No threshold is ours.** Every one is scraped from the publisher into `surat-flood-chain.json`.
   None is in config, precisely so config and source cannot drift apart silently.
-- **Negative headroom renders as negative.** The causeway routinely sits above its overflow level
-  during the monsoon and is closed; clamping that to zero would hide the true state.
+- **Negative headroom is never clamped to zero.** The causeway routinely sits above its overflow
+  level during the monsoon and is closed; hiding that would hide the true state. It renders as a
+  distance with the direction in the label ("0.86 m over the crest"), never as a signed number
+  against a directional label.
+- **The "live" badge is gated on the data, not asserted.** Production serves this JSON from the
+  corpus pin, so readings age between releases; past 48 hours the badge switches to the reading's
+  date and the footer says the card is that day's snapshot. An all-zero rainfall pass says no rain
+  fell instead of naming a "wettest zone".
 - **No storage-history chart.** `reservoirHistoryAbsentNote` explains that Surat will never have
   one, rather than promising a chart that "fills in automatically" (the Delhi lesson: a live feed
   does not imply a storage series).

--- a/docs/methodology/district-atlas-v1.md
+++ b/docs/methodology/district-atlas-v1.md
@@ -1,0 +1,90 @@
+# District Atlas: Methodology Note
+
+**neer-vazhvu district atlas v1**
+**Status: as-built, shipped for Thanjavur, Tiruchirappalli, Salem, Tirupathur (Tamil Nadu) and Satara (Maharashtra)**
+
+## Abstract
+
+The District Atlas is the platform's rural surface: a district page at `/atlas/[state]/[district]`, a page per block (TN) or taluka (MH) under `blocks/`, and a page per Gram Panchayat under `panchayats/` - 3,088 GP pages across the five shipped districts. Where a city dashboard reads utility feeds, a district's water state lives in government registers: the panchayat directory, the Jal Jeevan Mission service ledger, the Census 2011 village tables, the IN-GRES groundwater assessment, the state's irrigation statistics. The Atlas turns those registers into place pages without inventing anything between them: every joined identity is either exact, or a staged proposal a human reviewed, and every page states which registers could not be bound and why.
+
+This note is the as-built record of how a district is onboarded, what each artifact family holds, and how the monthly refresh runs. The Lake Catchment Atlas (`catchment-atlas-v1.md`) is a different feature - a per-lake drainage view on the city water-bodies map - that happens to share a word.
+
+## 1. Places, registry, gating
+
+`src/lib/atlas/registry.ts` is the list of Atlas districts. Each entry carries the slug, the NVDM scope id (`tn-salem`, `mh-satara`), an optional basin join (Thanjavur, Tiruchirappalli and Salem hang off `cauvery-tn` sub-basins), the one-line hook the landing card shows, and `published`. A district ships `published: false` first: its data can be released to the corpus and its pages reviewed on a dev server (`NEXT_PUBLIC_PREVIEW_DISTRICTS=<slug>`) while the routes 404 in production. Flipping `published: true` is what activates the landing card, the sitemap entries and the freshness checks - usually folded into the corpus pin PR once review is done.
+
+## 2. Adapters
+
+Two identity adapters exist. A district's `pipeline-inputs/atlas/<state>/<slug>/refresh-plan.json` names its adapter, its register ids, and `expectedCounts` for every register - a fetch that returns a different count fails loudly instead of shipping a shorter directory.
+
+| | Tamil Nadu (registers adapter) | Maharashtra (LGD adapter) |
+|---|---|---|
+| GP directory | TNRD LGD PDF + TNRD master codes | LGD Local Bodies via the data.gov.in catalog (Ministry of Panchayati Raj, monthly) |
+| Blocks | TNRD master | LGD Sub-Districts (talukas stand in for blocks, 1:1 in Satara, documented) |
+| Villages / Census | Census 2011 DCHB workbook, sha-pinned | LGD Villages (carries the Census 2011 code) + Census 2011 MH workbook |
+| Service ledger | JJM Citizen Corner, per village | same, joined through the crosswalk |
+| Boundaries | TNGIS panchayat/taluk layers | DataMeet village polygons (ODbL, share-alike), GP = MultiPolygon of member villages |
+| Groundwater | IN-GRES taluk assessment | IN-GRES taluka assessment |
+| Irrigation | Season and Crop Report Table III-B (reviewed extraction) | named gap: the District Socio-Economic Review stops at 2015-16 with wells not stated |
+| Water bodies | TNGIS all-water-bodies layer (counts) | First Census of Water Bodies via data.gov.in (GODL), assigned to GPs by village code |
+| Environment plan | not yet on file | MPCB District Environment Plan, reviewed figure-by-figure with page cites |
+
+Adapter firsts are made byte-neutral for existing districts before they merge: the 2021 TNRD PDF lists 2019-formed districts with six-digit codes (Tirupathur 296958), and `censusSubdistrictCodes` scopes a Census extract to the parent district's taluks (Tirupathur's villages sit under Vellore in Census 2011, and the page's vintage line says so from the rows themselves).
+
+## 3. Identity resolution, and what a human reviews
+
+Registers disagree on names, so binding them is staged, never silent:
+
+- `atlas:stage-blocks` proposes the block alignment across registers (`block-alignment.json`: MAC. CHOULTRY = Macdonalds Choultry; Jaoli = Jawali).
+- `atlas:stage-resolution` proposes JJM-to-directory pairings that name similarity alone cannot settle (`crosswalk-resolution.json`), and writes the leftovers to a local `review-queue.md` that is deliberately not committed.
+- Every proposal carries `review.status: proposed` until a human confirms it. Units that stay unbound render as directory-only rows, counted on the page rather than dropped.
+
+The same discipline covers reviewed inputs that are extractions rather than joins: the irrigation table rows (`irrigation-des.json`, from the Season and Crop Report PDF with the printed page cited) and Satara's environment-plan figures (each with a quote and a PDF page) enter as `pipeline-inputs/` files a human verifies.
+
+## 4. Artifact families (per district, `public/data/atlas/<state>/<slug>/`)
+
+| Artifact | Content | Source |
+|---|---|---|
+| `directory.json` | GPs, blocks, crosswalk state, uncovered villages, unbound units, per-register vintages | TNRD / LGD + JJM + Census |
+| `boundaries/` (MH) | taluka shards of GP MultiPolygons, simplified ~20 m | DataMeet (ODbL) |
+| `groundwater-taluks.json` | stage of extraction and category per taluk/taluka, all published assessment years | IN-GRES |
+| `groundwater-projection.json` | each GP assigned to its assessment unit (spatial for TN, membership for MH); deferrals named per GP | derived |
+| `census-2011/` | per-block village shards: households, water source and availability | Census 2011 DCHB |
+| `jjm-service/` | per-village tap connections and sample history | JJM Citizen Corner |
+| `rainfall.json` | last-30-day reading per GP centroid against the normal | Open-Meteo (grid-node assignment, exact-point escalation past 10 km) |
+| `water-bodies/` | counts per GP (TN); census register rows with points, unassigned rows counted per block (MH) | TNGIS / First Census of Water Bodies |
+| `irrigation-current.json` (TN) | net area irrigated by source, district row | Season and Crop Report 2024-25 |
+| `environment-plan.json` (MH) | reviewed DEP figures with page cites, water balance explicitly null where the plan prints none | MPCB DEP |
+| `assessments/`, `briefs/`, `curated-briefs.json` | per-place capability assessment and the brief each page renders; curated briefs are hand-written and reviewed | derived |
+
+All artifacts are NVDM-enveloped at L2 and validated by the same gates as city data.
+
+## 5. Verdict composition
+
+A district verdict is composed, not scored: each family contributes a reading under its own contract, the severest present reading leads, and unmeasured dimensions are named on the page rather than averaged away. Salem leads with 13 of 14 taluks over-exploited; Satara reads "Within limits" with its tap-coverage gap named; a JJM register that reports exactly 100.0% is flagged as a reporting convention, not celebrated. There is no composite index anywhere in the Atlas, by rule.
+
+## 6. Refresh and operations
+
+- `.github/workflows/atlas-refresh.yml` runs monthly (2nd, 07:00 IST) over the district matrix, or on dispatch per slug. The chain (`scripts/atlas-refresh-district.sh`) re-runs registers whose upstream digests moved, skips what has not changed, revalidates, regenerates the catalogue and conformance docs, and commits to main.
+- Production serves the corpus at `corpus.lock`, not the git checkout - so a refresh reaches the site only through the release chain: data-repo PR, merge, immutable `corpus-YYYY-MM-DD-<slug>` tag, and a pin PR moving `corpus.lock` (helper: `scripts/release_corpus.py prepare` / `pin`).
+- JJM is the long pole (a few seconds per village; Satara's 1,742 villages run in hours), so the workflow ceiling is set accordingly.
+
+## 7. Honest limits, as shipped
+
+- TNGIS layers are used for counts and boundaries while the licence question is open; water-body detail beyond counts waits on it.
+- Satara has no current irrigation reading - the gap and its reason are on the page (see the registry's `irrigationCurrentSource`).
+- The MH water-bodies census templates its waterspread column, so area is `withheld` rather than reprinted.
+- Tirupathur's Census axis is weak by construction (238 Vellore-taluk rows for 208 GPs); binding rates are printed, not smoothed.
+- A GP whose centroid falls outside every taluk polygon defers its groundwater projection, named per GP (`no-containing-taluk`).
+
+## 8. Shipped districts
+
+| District | State | GPs | Blocks/Talukas | Groundwater | Hook |
+|---|---|---|---|---|---|
+| Thanjavur | TN | 589 | 14 | canal-fed delta | The rice bowl: the district's water year is decided upstream at Mettur |
+| Tiruchirappalli | TN | 404 | 14 | wells-led | Thanjavur's inverse: water security is a groundwater question |
+| Salem | TN | 385 | 20 | 147.5%, 13 of 14 taluks OE | Holds Mettur, the delta's canal head, and irrigates almost none of its own farmland from it |
+| Tirupathur | TN | 208 | 6 | 142.9%, 4 of 4 taluks OE | The Palar tannery belt without a canal: all irrigation is from wells |
+| Satara | MH | 1,502 | 11 | Within limits (2 talukas semi-critical) | Koyna country with a dry eastern edge |
+
+Onboarding cost after the adapters: roughly a day per district on an existing adapter, dominated by register fetches and human review of the staged proposals.


### PR DESCRIPTION
The Atlas shipped across #336 (Thanjavur + Tiruchirappalli), #342 (Satara), #344 (Salem + Tirupathur) and #345 (go-live) with zero documentation outside code comments, and the README's architecture section predates the corpus split entirely. This catches the written record up to the platform.

## New: docs/methodology/district-atlas-v1.md

The as-built method note, same convention as catchment-atlas-v1: what the Atlas is (district / block / GP pages, 3,088 GP pages across five districts), the two identity adapters (TN registers, LGD) and their register sources side by side, the staged human-review discipline (block alignment, crosswalk resolution, review queue - nothing joins silently), the artifact families with per-family provenance, verdict composition (severest-present leads, unmeasured dimensions named, no composite score by rule), the monthly refresh runner and the release chain, and the honest limits as shipped (TNGIS licence pending, Satara's irrigation gap, withheld waterspread, Tirupathur's weak Census axis).

## README

- A **District Atlas** section: the five districts with verified GP/block counts (589 / 404 / 385 / 208 / 1,502 - read from the shipped directory.json files, not quoted from memory), the adapter model, and the methodology link. The intro line now names the districts beside the ten cities.
- **Corpus-pinned serving** documented in the architecture section for the first time: production replaces public/data + public/geojson from the private data repo at the corpus.lock commit, so a data change reaches the site only through a release. This has been true since July and was written down nowhere outside scripts/fetch-corpus.sh's header.
- **Atlas routing** noted beside the city-config paragraph (districts resolve through src/lib/atlas/registry.ts, not src/lib/cities/).
- **Deep-zoom counts corrected**: 21 -> 43 flagship bodies across 8 cities, with the per-city list regenerated from the registry (Chitlapakkam is no longer in it; Chennai is 7, not 8).
- Pune and Surat added to the per-city data-sources link list (the docs existed, the links did not).
- district-atlas-v1 added to the methodology write-up list.

## DATA_SOURCES.md

A District Atlas entry: district sources are documented per adapter rather than per district, pointing at the methodology note and pipeline-inputs/atlas/.

## docs/cities/surat/features.md

The flood-headroom bullets now match what #347 shipped: negative headroom renders as a distance with the direction in the label, and the "live" badge is gated on the data's age because production serves the corpus pin.

Docs only - no code, no data. Counts verified against the shipped artifacts and the rich-body registry before writing.
