### PR TITLE
Atlas: the state tier - Districts opens at states

### DIFF
--- a/src/app/atlas/[state]/[district]/blocks/[blockCode]/page.tsx
+++ b/src/app/atlas/[state]/[district]/blocks/[blockCode]/page.tsx
@@ -24,6 +24,7 @@ import {
   findAtlasDistrict,
   isAtlasDistrictVisible,
   listVisibleAtlasDistricts,
+  stateHref,
 } from "@/lib/atlas/registry";
 
 interface RouteParams {
@@ -111,7 +112,7 @@ export default async function AtlasBlockPage({ params }: RouteParams) {
         <AtlasBreadcrumbs
           items={[
             { label: "India", href: "/" },
-            { label: entry.stateName },
+            { label: entry.stateName, href: stateHref(entry.stateSlug) },
             { label: directory.districtName, href: basePath },
             { label: block.name },
           ]}

--- a/src/app/atlas/[state]/[district]/page.tsx
+++ b/src/app/atlas/[state]/[district]/page.tsx
@@ -36,6 +36,7 @@ import {
   findAtlasDistrict,
   isAtlasDistrictVisible,
   listVisibleAtlasDistricts,
+  stateHref,
 } from "@/lib/atlas/registry";
 
 interface RouteParams {
@@ -173,7 +174,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
         <AtlasBreadcrumbs
           items={[
             { label: "India", href: "/" },
-            { label: entry.stateName },
+            { label: entry.stateName, href: stateHref(entry.stateSlug) },
             { label: entry.name },
           ]}
         />

--- a/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
+++ b/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
@@ -35,6 +35,7 @@ import {
   isAtlasDistrictVisible,
   listVisibleAtlasDistricts,
   panchayatHref,
+  stateHref,
 } from "@/lib/atlas/registry";
 import { formatExtractionStage } from "@/lib/atlas/tn-groundwater-projection";
 
@@ -221,7 +222,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
         <AtlasBreadcrumbs
           items={[
             { label: "India", href: "/" },
-            { label: entry.stateName },
+            { label: entry.stateName, href: stateHref(entry.stateSlug) },
             { label: directory.districtName, href: basePath },
             { label: panchayat.blockName, href: blockPath },
             { label: panchayat.name },

--- a/src/app/atlas/[state]/page.tsx
+++ b/src/app/atlas/[state]/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { AtlasBreadcrumbs } from "@/components/atlas/atlas-breadcrumbs";
+import { AtlasContainer, AtlasNote } from "@/components/atlas/atlas-primitives";
+import { DistrictCard, buildStateBoard } from "@/components/atlas/district-card";
+import { listVisibleAtlasStates } from "@/lib/atlas/registry";
+
+/**
+ * The state tier of the Atlas: /atlas/tn, /atlas/mh. The Districts view
+ * opens at states, and a state opens to the districts inside it - the
+ * hierarchy a reader expects, and the page where state-level reads (the
+ * district signal ledger's sourced columns, once each passes review) will
+ * live. Until then this page is deliberately thin: a doorway, not a surface
+ * inventing content it does not have.
+ */
+
+interface RouteParams {
+  params: Promise<{ state: string }>;
+}
+
+export function generateStaticParams() {
+  return listVisibleAtlasStates().map((s) => ({ state: s.stateSlug }));
+}
+
+export async function generateMetadata({ params }: RouteParams): Promise<Metadata> {
+  const { state } = await params;
+  const entry = listVisibleAtlasStates().find((s) => s.stateSlug === state.toLowerCase());
+  if (!entry) return {};
+  const n = entry.districts.length;
+  return {
+    title: `${entry.stateName} district atlas | Neer Vazhvu`,
+    description: `${n} ${n === 1 ? "district" : "districts"} of ${entry.stateName} in the Atlas: a verdict, dated facts and a Gram Panchayat directory for each, with the gaps named.`,
+    alternates: { canonical: `/atlas/${entry.stateSlug}` },
+  };
+}
+
+export default async function StatePage({ params }: RouteParams) {
+  const { state } = await params;
+  const entry = listVisibleAtlasStates().find((s) => s.stateSlug === state.toLowerCase());
+  if (!entry) notFound();
+  const board = buildStateBoard().find((b) => b.state.stateSlug === entry.stateSlug);
+  const cards = (board?.board ?? []).filter((b) => b.status !== "onboarding");
+  const onboarding = (board?.board ?? []).filter((b) => b.status === "onboarding");
+
+  return (
+    <div className="bg-white dark:bg-slate-950 min-h-screen">
+      <AtlasContainer className="pt-4 sm:pt-6">
+        <AtlasBreadcrumbs items={[{ label: "India", href: "/" }, { label: entry.stateName }]} />
+      </AtlasContainer>
+      <header className="border-b border-slate-200 dark:border-slate-800">
+        <AtlasContainer className="pb-8 pt-4 sm:pb-10">
+          <p className="text-xs font-semibold uppercase tracking-wider text-teal-700 dark:text-teal-400">
+            District Atlas
+          </p>
+          <h1 className="mt-1 text-3xl sm:text-4xl font-bold text-slate-900 dark:text-slate-100">
+            {entry.stateName}
+          </h1>
+          <p className="mt-3 max-w-2xl text-base text-slate-600 dark:text-slate-300">{entry.hook}</p>
+        </AtlasContainer>
+      </header>
+      <main>
+        <AtlasContainer className="py-8 sm:py-10">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+            {cards.map((b) => (
+              <DistrictCard key={b.district.scopeId} {...b} />
+            ))}
+            {onboarding.map((b) => (
+              <DistrictCard key={b.district.scopeId} {...b} />
+            ))}
+          </div>
+          <div className="mt-8">
+            <AtlasNote>
+              State-level readings are not served yet: the columns of the district
+              signal ledger (groundwater by taluka, polluted stretches, tanker
+              deployments, drought declarations, flood classifications) each enter
+              here only after their source, mapping and licence pass review. Until
+              then this page is the doorway to the districts, nothing more.
+            </AtlasNote>
+          </div>
+        </AtlasContainer>
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { listAllPlaces } from "@/lib/cities";
 import { liveCityPhrase } from "@/lib/cities/roster";
-import { CityLandmark, CITY_ACCENT, DEFAULT_ACCENT } from "@/components/landing/city-landmark";
+import { CityBadge, CityLandmark, CITY_ACCENT, DEFAULT_ACCENT, type CityStatus } from "@/components/landing/city-landmark";
 import { PlaceBoard } from "@/components/landing/place-board";
 import {
-  districtHref,
-  listAtlasDistricts,
-  listVisibleAtlasDistricts,
-  type AtlasDistrict,
-} from "@/lib/atlas/registry";
+  StateCard,
+  buildDistrictBoard,
+  buildStateBoard,
+} from "@/components/atlas/district-card";
 
 // The landing page kept its OWN three copies of the city roster, so it was
 // still advertising three live cities on the day the sixth launched - the same
@@ -78,8 +77,6 @@ const CITY_HOOKS: Record<string, string> = {
   gurugram:
     "No river, no reservoir, and a dark zone since 2008 - plus GMDA's own ledger of every tanker load it sold, naming who bought it and at what price.",
 };
-
-type CityStatus = "live" | "onboarding" | "upnext" | "preview";
 
 type BoardCity = {
   cityId: string;
@@ -154,44 +151,7 @@ const CAPABILITIES: { label: string; detail: string }[] = [
   },
 ];
 
-const STATUS_BADGE: Record<CityStatus, { label: string; classes: string; dot: string }> = {
-  live: {
-    label: "Live",
-    classes:
-      "bg-emerald-50 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-400 ring-emerald-600/20 dark:ring-emerald-500/30",
-    dot: "bg-emerald-500",
-  },
-  onboarding: {
-    label: "Onboarding",
-    classes:
-      "bg-amber-50 dark:bg-amber-950/60 text-amber-700 dark:text-amber-400 ring-amber-600/20 dark:ring-amber-500/30",
-    dot: "bg-amber-500",
-  },
-  upnext: {
-    label: "Up next",
-    classes:
-      "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 ring-slate-500/20 dark:ring-slate-400/30",
-    dot: "bg-slate-400",
-  },
-  // A district exposed through NEXT_PUBLIC_PREVIEW_DISTRICTS: linkable on
-  // this deployment, not yet published.
-  preview: {
-    label: "Preview",
-    classes:
-      "bg-cyan-50 dark:bg-cyan-950/60 text-cyan-700 dark:text-cyan-300 ring-cyan-600/20 dark:ring-cyan-500/30",
-    dot: "bg-cyan-500",
-  },
-};
 
-function CityBadge({ status }: { status: CityStatus }) {
-  const b = STATUS_BADGE[status];
-  return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${b.classes}`}>
-      <span className={`h-1.5 w-1.5 rounded-full ${b.dot}`} />
-      {b.label}
-    </span>
-  );
-}
 
 function CityCard({ city }: { city: BoardCity }) {
   const isLive = city.status === "live";
@@ -275,133 +235,10 @@ function CityCard({ city }: { city: BoardCity }) {
   );
 }
 
-type DistrictStatus = Extract<CityStatus, "live" | "preview" | "onboarding">;
-
-type BoardDistrict = { district: AtlasDistrict; status: DistrictStatus };
-
-/**
- * The district board reads the Atlas registry the way the city board reads
- * src/lib/cities: a published district is live, a district exposed through
- * NEXT_PUBLIC_PREVIEW_DISTRICTS is a linkable preview, the rest are
- * onboarding cards without a link. One registry, no static fallback list.
- */
-function buildDistrictBoard(): BoardDistrict[] {
-  const visible = new Set(listVisibleAtlasDistricts().map((d) => d.scopeId));
-  return listAtlasDistricts()
-    .map(
-      (district): BoardDistrict => ({
-        district,
-        status: district.published
-          ? "live"
-          : visible.has(district.scopeId)
-            ? "preview"
-            : "onboarding",
-      }),
-    )
-    .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
-}
-
-const DISTRICT_ACCENT = "from-teal-500 to-emerald-700";
-
-/** Canals, tanks and a field bund: the rural twin of CityLandmark. */
-function DistrictMark({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 200 80"
-      preserveAspectRatio="xMidYMax meet"
-      aria-hidden="true"
-      className={className}
-    >
-      <g fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-        <path d="M0 58 C 30 46, 55 70, 85 58 S 135 46, 165 58 S 190 66, 200 60" />
-        <path d="M0 68 C 40 58, 65 78, 105 68 S 165 58, 200 70" strokeOpacity={0.55} />
-        <path d="M22 42 V 24 H 62 V 42" strokeOpacity={0.85} />
-        <path d="M112 38 V 20 H 152 V 38" strokeOpacity={0.85} />
-        <path d="M30 33 h24 M120 29 h24" strokeOpacity={0.35} />
-        <path d="M0 78 H 200" strokeOpacity={0.25} />
-      </g>
-    </svg>
-  );
-}
-
-function DistrictCard({ district, status }: BoardDistrict) {
-  const linkable = status !== "onboarding";
-  const accent = linkable
-    ? DISTRICT_ACCENT
-    : "from-slate-400 to-slate-500 dark:from-slate-700 dark:to-slate-800";
-
-  const banner = (
-    <div className={`relative h-24 overflow-hidden bg-gradient-to-br ${accent}`}>
-      <DistrictMark
-        className={`absolute inset-0 h-full w-full ${linkable ? "text-white/85" : "text-white/60"}`}
-      />
-      <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/15 to-transparent" />
-      <div className="absolute top-3 right-3">
-        <CityBadge status={status} />
-      </div>
-    </div>
-  );
-
-  const body = (
-    <div className="p-5 sm:p-6">
-      <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">
-        {district.name}
-      </h3>
-      <p className="mt-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        District
-        <span className="mx-1 text-slate-300 dark:text-slate-600">|</span>
-        {district.stateCode}
-        {district.basin && (
-          <>
-            <span className="mx-1 text-slate-300 dark:text-slate-600">|</span>
-            {district.basin.subBasinName}
-          </>
-        )}
-      </p>
-      <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-        {district.hook}
-      </p>
-      {linkable ? (
-        <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-cyan-700 dark:text-cyan-400">
-          Open district
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </span>
-      ) : (
-        <span className="mt-4 inline-flex items-center text-sm font-medium text-slate-400 dark:text-slate-500">
-          Onboarding
-        </span>
-      )}
-    </div>
-  );
-
-  const baseClass =
-    "block overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900";
-
-  if (linkable) {
-    return (
-      <Link
-        href={districtHref(district)}
-        className={`${baseClass} transition-shadow hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500`}
-      >
-        {banner}
-        {body}
-      </Link>
-    );
-  }
-
-  return (
-    <div className={baseClass}>
-      {banner}
-      {body}
-    </div>
-  );
-}
-
 export default function Page() {
   const cities = buildCityBoard();
   const districts = buildDistrictBoard();
+  const states = buildStateBoard();
 
   return (
     <div className="bg-slate-50 dark:bg-slate-950">
@@ -493,17 +330,17 @@ export default function Page() {
               <>
                 <h3 className="mt-10 flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-teal-700 dark:text-teal-400">
                   <span className="h-2 w-2 rounded-full bg-teal-500" />
-                  In the Atlas
+                  By state
                 </h3>
                 <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-                  {districts.map((d) => (
-                    <DistrictCard key={d.district.scopeId} {...d} />
+                  {states.map((s) => (
+                    <StateCard key={s.state.stateSlug} {...s} />
                   ))}
                 </div>
                 <p className="mt-6 text-sm text-slate-500 dark:text-slate-400">
-                  A district opens as one reading of the whole district, then a
-                  directory of its blocks and Gram Panchayats. Each hangs off the
-                  river basin it sits in.
+                  A state opens to its districts; a district opens as one reading
+                  of the whole district, then a directory of its blocks and Gram
+                  Panchayats. Each hangs off the river basin it sits in.
                 </p>
               </>
             }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { districtHref, listPublishedAtlasDistricts } from "@/lib/atlas/registry";
+import { districtHref, groupAtlasStates, listPublishedAtlasDistricts, stateHref } from "@/lib/atlas/registry";
 import { listEnabledPlaces } from "@/lib/cities";
 import { FEATURE_AVAILABILITY } from "@/lib/cities/routing";
 
@@ -59,6 +59,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Gram Panchayat pages are reached through it. This reads the registry
   // alone, deliberately: importing the artifact loaders here made Turbopack
   // trace the whole project into this route's file list.
+  // The state tier sits above the districts: one page per state with at
+  // least one published district.
+  for (const state of groupAtlasStates(listPublishedAtlasDistricts())) {
+    entries.push({
+      url: `${BASE}${stateHref(state.stateSlug)}`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    });
+  }
   for (const district of listPublishedAtlasDistricts()) {
     entries.push({
       url: `${BASE}${districtHref(district)}`,

--- a/src/components/atlas/district-card.tsx
+++ b/src/components/atlas/district-card.tsx
@@ -1,0 +1,236 @@
+/**
+ * The Atlas's place cards, shared by the landing board and the state page:
+ * the district card (one per district, status-badged) and the state card
+ * (the Districts view opens at states; districts appear inside a state).
+ * One component per feature: the landing page and /atlas/[state] both
+ * render exactly these.
+ */
+import Link from "next/link";
+import { CityBadge, type CityStatus } from "@/components/landing/city-landmark";
+import {
+  districtHref,
+  groupAtlasStates,
+  listAtlasDistricts,
+  listVisibleAtlasDistricts,
+  stateHref,
+  type AtlasDistrict,
+  type AtlasStateEntry,
+} from "@/lib/atlas/registry";
+
+const STATUS_ORDER: Record<CityStatus, number> = { live: 0, preview: 1, onboarding: 2, upnext: 3 };
+
+export type DistrictStatus = Extract<CityStatus, "live" | "preview" | "onboarding">;
+
+export type BoardDistrict = { district: AtlasDistrict; status: DistrictStatus };
+
+/**
+ * The district board reads the Atlas registry the way the city board reads
+ * src/lib/cities: a published district is live, a district exposed through
+ * NEXT_PUBLIC_PREVIEW_DISTRICTS is a linkable preview, the rest are
+ * onboarding cards without a link. One registry, no static fallback list.
+ */
+export function buildDistrictBoard(): BoardDistrict[] {
+  const visible = new Set(listVisibleAtlasDistricts().map((d) => d.scopeId));
+  return listAtlasDistricts()
+    .map(
+      (district): BoardDistrict => ({
+        district,
+        status: district.published
+          ? "live"
+          : visible.has(district.scopeId)
+            ? "preview"
+            : "onboarding",
+      }),
+    )
+    .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+}
+
+const DISTRICT_ACCENT = "from-teal-500 to-emerald-700";
+
+/** Canals, tanks and a field bund: the rural twin of CityLandmark. */
+function DistrictMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 200 80"
+      preserveAspectRatio="xMidYMax meet"
+      aria-hidden="true"
+      className={className}
+    >
+      <g fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+        <path d="M0 58 C 30 46, 55 70, 85 58 S 135 46, 165 58 S 190 66, 200 60" />
+        <path d="M0 68 C 40 58, 65 78, 105 68 S 165 58, 200 70" strokeOpacity={0.55} />
+        <path d="M22 42 V 24 H 62 V 42" strokeOpacity={0.85} />
+        <path d="M112 38 V 20 H 152 V 38" strokeOpacity={0.85} />
+        <path d="M30 33 h24 M120 29 h24" strokeOpacity={0.35} />
+        <path d="M0 78 H 200" strokeOpacity={0.25} />
+      </g>
+    </svg>
+  );
+}
+
+export function DistrictCard({ district, status }: BoardDistrict) {
+  const linkable = status !== "onboarding";
+  const accent = linkable
+    ? DISTRICT_ACCENT
+    : "from-slate-400 to-slate-500 dark:from-slate-700 dark:to-slate-800";
+
+  const banner = (
+    <div className={`relative h-24 overflow-hidden bg-gradient-to-br ${accent}`}>
+      <DistrictMark
+        className={`absolute inset-0 h-full w-full ${linkable ? "text-white/85" : "text-white/60"}`}
+      />
+      <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/15 to-transparent" />
+      <div className="absolute top-3 right-3">
+        <CityBadge status={status} />
+      </div>
+    </div>
+  );
+
+  const body = (
+    <div className="p-5 sm:p-6">
+      <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">
+        {district.name}
+      </h3>
+      <p className="mt-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        District
+        <span className="mx-1 text-slate-300 dark:text-slate-600">|</span>
+        {district.stateCode}
+        {district.basin && (
+          <>
+            <span className="mx-1 text-slate-300 dark:text-slate-600">|</span>
+            {district.basin.subBasinName}
+          </>
+        )}
+      </p>
+      <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+        {district.hook}
+      </p>
+      {linkable ? (
+        <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-cyan-700 dark:text-cyan-400">
+          Open district
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </span>
+      ) : (
+        <span className="mt-4 inline-flex items-center text-sm font-medium text-slate-400 dark:text-slate-500">
+          Onboarding
+        </span>
+      )}
+    </div>
+  );
+
+  const baseClass =
+    "block overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900";
+
+  if (linkable) {
+    return (
+      <Link
+        href={districtHref(district)}
+        className={`${baseClass} transition-shadow hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500`}
+      >
+        {banner}
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={baseClass}>
+      {banner}
+      {body}
+    </div>
+  );
+}
+
+/** A state entry plus its districts' board statuses, for the state card. */
+export interface BoardState {
+  state: AtlasStateEntry;
+  board: BoardDistrict[];
+}
+
+/** Group the whole district board by state, first appearance first. A state
+ *  whose districts are all onboarding still shows (as an unlinkable card),
+ *  the same rule as an onboarding district. */
+export function buildStateBoard(): BoardState[] {
+  const board = buildDistrictBoard();
+  const states = groupAtlasStates(board.map((b) => b.district));
+  return states.map((state) => ({
+    state,
+    board: board.filter((b) => b.district.stateSlug === state.stateSlug),
+  }));
+}
+
+export function StateCard({ state, board }: BoardState) {
+  const live = board.filter((b) => b.status === "live").length;
+  const preview = board.filter((b) => b.status === "preview").length;
+  const linkable = live + preview > 0;
+  const accent = linkable
+    ? DISTRICT_ACCENT
+    : "from-slate-400 to-slate-500 dark:from-slate-700 dark:to-slate-800";
+  const counts = [
+    live > 0 ? `${live} live` : null,
+    preview > 0 ? `${preview} preview` : null,
+    board.length - live - preview > 0 ? `${board.length - live - preview} onboarding` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const banner = (
+    <div className={`relative h-24 overflow-hidden bg-gradient-to-br ${accent}`}>
+      <DistrictMark className="absolute inset-0 h-full w-full text-white/85" />
+      <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/15 to-transparent" />
+      <div className="absolute top-3 right-3 rounded-full bg-white/85 dark:bg-slate-900/85 px-2.5 py-0.5 text-xs font-semibold text-slate-700 dark:text-slate-200">
+        {board.length} {board.length === 1 ? "district" : "districts"}
+      </div>
+    </div>
+  );
+
+  const body = (
+    <div className="p-5 sm:p-6">
+      <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">{state.stateName}</h3>
+      <p className="mt-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        State
+        <span className="mx-1 text-slate-300 dark:text-slate-600">|</span>
+        {counts}
+      </p>
+      <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{state.hook}</p>
+      <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        {board.map((b) => b.district.name).join(" · ")}
+      </p>
+      {linkable ? (
+        <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-cyan-700 dark:text-cyan-400">
+          Open state
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </span>
+      ) : (
+        <span className="mt-4 inline-flex items-center text-sm font-medium text-slate-400 dark:text-slate-500">
+          Onboarding
+        </span>
+      )}
+    </div>
+  );
+
+  const baseClass =
+    "block overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900";
+
+  if (linkable) {
+    return (
+      <Link
+        href={stateHref(state.stateSlug)}
+        className={`${baseClass} transition-shadow hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500`}
+      >
+        {banner}
+        {body}
+      </Link>
+    );
+  }
+  return (
+    <div className={baseClass}>
+      {banner}
+      {body}
+    </div>
+  );
+}

--- a/src/components/landing/city-landmark.tsx
+++ b/src/components/landing/city-landmark.tsx
@@ -199,3 +199,48 @@ export function CityLandmark({ cityId, className }: { cityId: string; className?
     </svg>
   );
 }
+
+/** Shared place-status vocabulary: the same badge on city, district and
+ *  state cards, so live-vs-preview-vs-onboarding reads identically
+ *  everywhere. Moved here from the landing page when the district cards
+ *  became shared with the state tier. */
+export type CityStatus = "live" | "onboarding" | "upnext" | "preview";
+
+export const STATUS_BADGE: Record<CityStatus, { label: string; classes: string; dot: string }> = {
+  live: {
+    label: "Live",
+    classes:
+      "bg-emerald-50 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-400 ring-emerald-600/20 dark:ring-emerald-500/30",
+    dot: "bg-emerald-500",
+  },
+  onboarding: {
+    label: "Onboarding",
+    classes:
+      "bg-amber-50 dark:bg-amber-950/60 text-amber-700 dark:text-amber-400 ring-amber-600/20 dark:ring-amber-500/30",
+    dot: "bg-amber-500",
+  },
+  upnext: {
+    label: "Up next",
+    classes:
+      "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 ring-slate-500/20 dark:ring-slate-400/30",
+    dot: "bg-slate-400",
+  },
+  // A district exposed through NEXT_PUBLIC_PREVIEW_DISTRICTS: linkable on
+  // this deployment, not yet published.
+  preview: {
+    label: "Preview",
+    classes:
+      "bg-cyan-50 dark:bg-cyan-950/60 text-cyan-700 dark:text-cyan-300 ring-cyan-600/20 dark:ring-cyan-500/30",
+    dot: "bg-cyan-500",
+  },
+};
+
+export function CityBadge({ status }: { status: CityStatus }) {
+  const b = STATUS_BADGE[status];
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${b.classes}`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${b.dot}`} />
+      {b.label}
+    </span>
+  );
+}

--- a/src/components/layout/city-switcher.tsx
+++ b/src/components/layout/city-switcher.tsx
@@ -11,7 +11,7 @@ import {
   knownCityIds,
   parsePath,
 } from "@/lib/cities/routing";
-import { districtHref, listVisibleAtlasDistricts } from "@/lib/atlas/registry";
+import { districtHref, listVisibleAtlasDistricts, listVisibleAtlasStates, stateHref } from "@/lib/atlas/registry";
 
 /** /atlas/<state>/<district>[/...] -> the district, or null. */
 function parseAtlasPath(pathname: string) {
@@ -140,25 +140,35 @@ export function CitySwitcher() {
           {districts.length > 0 && (
             <>
               <div className="my-1 border-t border-slate-200 dark:border-slate-700" />
-              <div className={GROUP_LABEL}>Districts</div>
-              {districts.map((d) => {
-                const isCurrent = currentDistrict?.scopeId === d.scopeId;
-                return (
+              {listVisibleAtlasStates().map((st) => (
+                <div key={st.stateSlug}>
                   <Link
-                    key={d.scopeId}
-                    href={districtHref(d)}
+                    href={stateHref(st.stateSlug)}
                     onClick={() => setOpen(false)}
-                    className={itemClass(isCurrent)}
+                    className={`${GROUP_LABEL} block hover:text-cyan-700 dark:hover:text-cyan-400`}
                   >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="font-medium">{d.name}</span>
-                      <span className="text-[10px] text-slate-400 uppercase">
-                        {d.stateCode}
-                      </span>
-                    </div>
+                    {st.stateName} districts
                   </Link>
-                );
-              })}
+                  {st.districts.map((d) => {
+                    const isCurrent = currentDistrict?.scopeId === d.scopeId;
+                    return (
+                      <Link
+                        key={d.scopeId}
+                        href={districtHref(d)}
+                        onClick={() => setOpen(false)}
+                        className={itemClass(isCurrent)}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="font-medium">{d.name}</span>
+                          <span className="text-[10px] text-slate-400 uppercase">
+                            {d.stateCode}
+                          </span>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              ))}
             </>
           )}
         </div>

--- a/src/lib/atlas/registry.test.ts
+++ b/src/lib/atlas/registry.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ATLAS_DISTRICTS,
+  groupAtlasStates,
+  stateHref,
+  type AtlasDistrict,
+} from "./registry";
+
+function mini(slug: string, stateSlug: string, stateName: string): AtlasDistrict {
+  return {
+    slug,
+    scopeId: `${stateSlug}-${slug}`,
+    stateSlug,
+    stateCode: stateSlug.toUpperCase(),
+    stateName,
+    name: slug,
+    hook: "",
+    hasCuratedBriefs: false,
+    published: true,
+    irrigationCurrentSource: { label: "", nextStep: "", gapNote: "" },
+  };
+}
+
+test("states group by first appearance and keep district order", () => {
+  const states = groupAtlasStates([
+    mini("a", "tn", "Tamil Nadu"),
+    mini("b", "mh", "Maharashtra"),
+    mini("c", "tn", "Tamil Nadu"),
+  ]);
+  assert.equal(states.length, 2);
+  assert.deepEqual(states.map((s) => s.stateSlug), ["tn", "mh"]);
+  assert.deepEqual(states[0].districts.map((d) => d.slug), ["a", "c"]);
+});
+
+test("an empty district list yields no states: the tier gates on data", () => {
+  assert.deepEqual(groupAtlasStates([]), []);
+});
+
+test("every registered state carries a hook and a stable href", () => {
+  for (const s of groupAtlasStates(ATLAS_DISTRICTS)) {
+    assert.ok(s.hook.length > 0, `state ${s.stateSlug} has no hook`);
+    assert.equal(stateHref(s.stateSlug), `/atlas/${s.stateSlug}`);
+  }
+});

--- a/src/lib/atlas/registry.ts
+++ b/src/lib/atlas/registry.ts
@@ -159,6 +159,62 @@ export function findAtlasDistrict(
   return ATLAS_DISTRICTS.find((x) => x.stateSlug === s && x.slug === d);
 }
 
+/** One state of the Atlas: its visible districts, in registry order. The
+ *  Districts view opens at states (the hierarchy Sundaresh asked for on
+ *  2026-09-02): a reader sees states first and districts only inside one,
+ *  and the state page is where state-level reads (the signal ledger's
+ *  columns, once they pass review) will live. A state with no visible
+ *  district exists nowhere in the UI: the tier gates on data like
+ *  everything else. */
+export interface AtlasStateEntry {
+  stateSlug: string;
+  stateCode: string;
+  stateName: string;
+  /** One line for the state card, same register as the district hooks. */
+  hook: string;
+  districts: AtlasDistrict[];
+}
+
+const STATE_HOOKS: Record<string, string> = {
+  tn: "Where the Atlas began: the Cauvery delta's canal country and the over-exploited west, read district by district.",
+  mh: "The first state beyond Tamil Nadu: Koyna country first, with the drought and tanker belt to come.",
+};
+
+/** Group districts into state entries, preserving each state's first
+ *  appearance in the input. Pure, so it is testable without the env-driven
+ *  visibility gate. */
+export function groupAtlasStates(districts: AtlasDistrict[]): AtlasStateEntry[] {
+  const out: AtlasStateEntry[] = [];
+  for (const d of districts) {
+    let entry = out.find((s) => s.stateSlug === d.stateSlug);
+    if (!entry) {
+      entry = {
+        stateSlug: d.stateSlug,
+        stateCode: d.stateCode,
+        stateName: d.stateName,
+        hook: STATE_HOOKS[d.stateSlug] ?? "",
+        districts: [],
+      };
+      out.push(entry);
+    }
+    entry.districts.push(d);
+  }
+  return out;
+}
+
+/** The states a reader can enter: those with at least one visible district. */
+export function listVisibleAtlasStates(): AtlasStateEntry[] {
+  return groupAtlasStates(listVisibleAtlasDistricts());
+}
+
+export function findAtlasState(stateSlug: string): AtlasStateEntry | undefined {
+  return listVisibleAtlasStates().find((s) => s.stateSlug === stateSlug.toLowerCase());
+}
+
+export function stateHref(stateSlug: string): string {
+  return `/atlas/${stateSlug}`;
+}
+
 export function districtHref(d: AtlasDistrict): string {
   return `/atlas/${d.stateSlug}/${d.slug}`;
 }


### PR DESCRIPTION
## What

The Districts view now opens at states, the hierarchy the Atlas was missing. The landing board's Districts tab shows state cards (Tamil Nadu with its four districts, Maharashtra with Satara, live counts and the district names on the card); clicking one opens `/atlas/tn` or `/atlas/mh`, a state page listing its district cards; the header's place switcher groups districts under a clickable state label; and the state name in every district, block and Panchayat breadcrumb now links up a level.

The state page is deliberately thin: a doorway with an honest note that state-level readings (the district signal ledger's columns: groundwater by taluka, polluted stretches, tanker deployments, drought declarations, flood classifications) land there only as each source, mapping and licence passes review. The tier gates on data end to end: a state with no visible district exists nowhere, and the sitemap lists a state only when it has a published district.

One shared component per feature held: the district card moved out of the landing page into `src/components/atlas/district-card.tsx` (used by the landing board and the state page), the place-status badge moved into `city-landmark.tsx` (used by city, district and state cards), and the new StateCard sits beside DistrictCard.

The ledger itself stays under `docs/research/district-signal-ledger/` (gitignored with the rest of the research corpora, per the repo's own rule): 74 districts x six sourced dimensions, the scripts that built it, and a README with each column's source, vintage and caveats.

## Why

Decided today: districts need the state hierarchy so the Districts switch shows states first, and so there is a place for the signal ledger and other state-level reads. TN reaching four live districts and the ledger's existence were the plan's own conditions (section 3.3) for building the tier.

## How to test

1. `npx next dev -p 3004`, open `/#districts`: two state cards. `/atlas/tn`: four district cards plus the state note; `/atlas/mh`: Satara. Breadcrumb "Tamil Nadu" on `/atlas/tn/salem` links to `/atlas/tn`.
2. `npm test` (276 tests, incl. the new state-grouping cases).
3. `npm run build`: 3,194 pages (+2 state pages), no tracer warnings.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Tested in demo mode (no Supabase required)
