### PR TITLE
Release: pin corpus-2026-09-02-atlas-ahilyanagar-kolhapur and publish both districts

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -37,9 +37,9 @@
     "2026-09-02: the facts-quality release, tagged corpus-2026-09-02-facts-quality at 30f3a1d16c00802c4e07567e2fe5c15b405bef7b (data#59 squash; counts verified against the tree API). Modification-only: the five facts-*.json from neer-vazhvu#347 - 37 stale Live badges re-tiered across Delhi, Hyderabad, Kolkata, Surat and Pune, data_dates added so badges show their vintage, and Pune's flood-line fact corrected to the statewide register - none added or removed, so expected_files stays 1030/161 and this bump moves only the sha."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "30f3a1d16c00802c4e07567e2fe5c15b405bef7b",
+  "sha": "8e7dbe025a99dd39213c7cfc10e4422cd83faaad",
   "expected_files": {
-    "data": 1030,
+    "data": 1196,
     "geojson": 161
   }
 }

--- a/src/lib/atlas/registry.ts
+++ b/src/lib/atlas/registry.ts
@@ -138,7 +138,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     name: "Ahilyanagar",
     hook: "The tanker district: 97 tankers were running in monsoon August 2026 while the assessment still reads semi-critical - the scarcity register sees what the annual number cannot.",
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: MH_IRRIGATION_GAP,
   },
   {
@@ -150,7 +150,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     name: "Kolhapur",
     hook: "Every taluka is within its groundwater; the water story here is the flood - the Krishna-Panchganga backwater that submerged the district in 2019 and 2021.",
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: MH_IRRIGATION_GAP,
   },
 ];


### PR DESCRIPTION
## What

Serve the corpus at `corpus-2026-09-02-atlas-ahilyanagar-kolhapur` (data-repo `8e7dbe02`, from neer-vazhvu-data#60) and flip `published: true` for Ahilyanagar and Kolhapur. corpus.lock moves 1,030 -> 1,196 data files, geojson unchanged at 161.

## Why

The Maharashtra flagship pair merged preview-gated in #351; this is their one release. Verified with a real remote fetch in a throwaway worktree: 1,196/161 synced, both districts' directories, registers, environment plans and boundary shards served.

## How to test

`CORPUS_SOURCE=remote CORPUS_USE_GIT_AUTH=1 bash scripts/fetch-corpus.sh` on this branch, then `/atlas/mh` on a dev server with no preview env: three district cards, both new pages render from the pin.

## Checklist

- [x] `npm run lint` passes
- [x] Tested in demo mode (no Supabase required)
