### PR TITLE
fix(basin): map review round - visible selection, honest live-storage rings, data-gated legend

### DIFF
--- a/src/components/basin/basin-overview.tsx
+++ b/src/components/basin/basin-overview.tsx
@@ -461,8 +461,10 @@ export function BasinOverview({
     return {
       // Separators must survive same-colour neighbours (most sub-basins share
       // a fill class): dark hairlines on the light basemap, light on dark.
-      // The selected outline flips too - near-black vanishes in dark mode.
-      color: isSel ? (tiles.isDark ? "#f8fafc" : "#0f172a") : tiles.isDark ? "#e2e8f0" : "#1e293b",
+      // The selected outline is amber - the old white pick was one shade off
+      // the light hairlines beside it, so a selection never visibly changed
+      // the map (Sundaresh, 2 Sep).
+      color: isSel ? (tiles.isDark ? "#facc15" : "#d97706") : tiles.isDark ? "#e2e8f0" : "#1e293b",
       weight: isSel ? 3 : 1.8,
       opacity: isSel ? 1 : 0.75,
       fillColor:
@@ -512,6 +514,25 @@ export function BasinOverview({
   const basinLine = tiles.isDark ? "#f0abfc" : "#d946ef";
   const beyondEdge = tiles.isDark ? "#94a3b8" : "#475569";
   const beyondFill = tiles.isDark ? "#94a3b8" : "#64748b";
+  // Live-storage reservoirs wear this ring: the old near-black ring sank into
+  // the dark imagery, so every teal dot read as "has live storage"
+  // (Sundaresh, 2 Sep).
+  const liveRing = tiles.isDark ? "#f8fafc" : "#0f172a";
+
+  // Legend gates - a row appears only when its symbol is actually drawn. The
+  // sub-basin block was advertising tanks and stations that C8/C9 don't have,
+  // and the basin-wide reservoir key hid until a selection was made.
+  const hasInSub = (fc: FeatureCollection | null) =>
+    !!selectedKey && !!fc?.features.some((f) =>
+      (f.properties as Record<string, unknown>)?.subBasin === selectedKey && f.geometry?.type === "Point");
+  const subHasTanks = hasInSub(tanks);
+  const subHasStations = hasInSub(stations);
+  const isLiveFeature = (f: Feature) => {
+    const code = (f.properties as Record<string, unknown>)?.liveCode;
+    return !!(code && live[code as string]);
+  };
+  const hasLiveReservoirs = !!reservoirs?.features.some(isLiveFeature);
+  const hasLocationOnly = !!reservoirs?.features.some((f) => f.geometry?.type === "Point" && !isLiveFeature(f));
 
   // Selected sub-basin profile - rendered INLINE under its card in the
   // list (clicking the bottom card must not teleport focus to the top).
@@ -920,7 +941,7 @@ export function BasinOverview({
                 // as markers, not data - the grey fill was muddying into the
                 // choropleth colours.
                 pathOptions={isLive
-                  ? { color: "#0f172a", weight: 1, fillColor: "#0891b2", fillOpacity: 0.9 }
+                  ? { color: liveRing, weight: 1.5, fillColor: "#0891b2", fillOpacity: 0.9 }
                   : { color: "#334155", weight: 1.5, fillColor: "#ffffff", fillOpacity: 0.85 }}
               >
                 <LeafletTooltip>{reservoirInfo}</LeafletTooltip>
@@ -988,6 +1009,11 @@ export function BasinOverview({
                 no data
               </div>
             )}
+            {/* The choropleth's provenance, in the frame where it's read - the
+                sources section is a whole panel-scroll away (Sundaresh, 2 Sep). */}
+            {manifest.metricSources?.[metric] && (
+              <div className="text-slate-400 dark:text-slate-500">Source: {manifest.metricSources[metric]}</div>
+            )}
             {/* Line layers - rows appear only when the data files exist.
                 Labels name the frame in full (Madhuri, 31 Aug): "stretch
                 drawn to CPCB length" and "named rivers" said how the lines
@@ -1017,7 +1043,7 @@ export function BasinOverview({
                     .filter(Boolean))].join(" & ") || "river";
                   const km = contextRivers.features.reduce(
                     (a, f) => a + Number((f.properties as Record<string, unknown>)?.lengthKm ?? 0), 0);
-                  return `${names} river stretch above the state line${km ? ` (${Math.round(km)} km)` : ""}`;
+                  return `${names} river stretch beyond the state line${km ? ` (${Math.round(km)} km)` : ""}`;
                 })()}
               </div>
             )}
@@ -1091,23 +1117,36 @@ export function BasinOverview({
                 </>
               );
             })()}
-            {/* Marker key - shown while a sub-basin is in focus and its own
-                points are on the map. Every rendered symbol gets a legend row. */}
-            {selectedKey && (
+            {/* Reservoir markers draw basin-wide, selection or not, so their
+                key lives here rather than in the sub-basin block below. */}
+            {hasLiveReservoirs && (
+              <div className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-full border-2 shrink-0" style={{ backgroundColor: "#0891b2", borderColor: liveRing }} />Reservoir - live storage</div>
+            )}
+            {hasLocationOnly && (
+              <div className="flex items-center gap-1.5"><span className="inline-block w-2.5 h-2.5 rounded-full border-2 border-slate-600 bg-white shrink-0" />Reservoir / tank - location only</div>
+            )}
+            {/* Marker key - a row appears only when the focused sub-basin
+                actually has that symbol on the map (gate on data, not the
+                selection). */}
+            {(subHasTanks || subHasStations) && (
               <>
                 <div className="pt-1 mt-0.5 border-t border-slate-200 dark:border-slate-700 font-semibold text-slate-700 dark:text-slate-200">In this sub-basin</div>
-                <div className="flex items-center gap-1.5"><span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: "#0284c7" }} />MI tank</div>
+                {subHasTanks && (
+                  <div className="flex items-center gap-1.5"><span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: "#0284c7" }} />MI tank</div>
+                )}
                 {/* Diamonds, one per class band, matching the markers - a
                     single red dot claiming "colour = worst class" made the
                     reader do the mapping themselves (Madhuri, 31 Aug). */}
-                <div>WQ station - worst recorded class:</div>
-                <div className="flex items-center gap-2 flex-wrap pl-1">
-                  {([["A-B", "#10b981"], ["C", "#f59e0b"], ["D", "#f97316"], ["E", "#dc2626"], ["none", "#94a3b8"]] as [string, string][]).map(([label, color]) => (
-                    <span key={label} className="flex items-center gap-0.5"><LegendDiamond color={color} />{label}</span>
-                  ))}
-                </div>
-                <div className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-full border border-slate-900 shrink-0" style={{ backgroundColor: "#0891b2" }} />Reservoir - live storage</div>
-                <div className="flex items-center gap-1.5"><span className="inline-block w-2.5 h-2.5 rounded-full border-2 border-slate-600 bg-white shrink-0" />Reservoir / tank - location only</div>
+                {subHasStations && (
+                  <>
+                    <div>WQ station - worst recorded class:</div>
+                    <div className="flex items-center gap-2 flex-wrap pl-1">
+                      {([["A-B", "#10b981"], ["C", "#f59e0b"], ["D", "#f97316"], ["E", "#dc2626"], ["none", "#94a3b8"]] as [string, string][]).map(([label, color]) => (
+                        <span key={label} className="flex items-center gap-0.5"><LegendDiamond color={color} />{label}</span>
+                      ))}
+                    </div>
+                  </>
+                )}
               </>
             )}
             </div>

--- a/src/lib/basins/cauvery-ka.ts
+++ b/src/lib/basins/cauvery-ka.ts
@@ -30,6 +30,12 @@ export const CAUVERY_KA: BasinManifest = {
   relatedBasins: [
     { basinId: "cauvery-tn", label: "Tamil Nadu side of the Cauvery" },
   ],
+  // Same KWRIS views feed both metrics - the sources list at the panel foot
+  // carries the fuller note (period under verification).
+  metricSources: {
+    rainfallDeviationPct: "KWRIS geomGIS sub-basin views (KSNDMC/IMD basis)",
+    gwLevelM: "KWRIS geomGIS sub-basin views (KSNDMC/IMD basis)",
+  },
   rivers: [],
   layers: [
     // Not read on this basin's surface: overview mode (basin-overview.tsx)

--- a/src/lib/basins/kabini.ts
+++ b/src/lib/basins/kabini.ts
@@ -126,7 +126,9 @@ export const KABINI: BasinManifest = {
     { family: "prs-drains", label: "Drains reaching them", floor: "hydrology", geom: "line", color: "#facc15", defaultOn: false, kindFilter: "drain-line" },
 
     // ── Floor 2: Monitoring - the station-readings pilot ──
-    { family: "flow-stations", label: "CWC monitoring points (tap for readings)", floor: "monitoring", geom: "point", color: "#0e7490", defaultOn: true, readings: true },
+    // cyan-500, not the old cyan-700: the darker dot sank into the dark
+    // imagery (Sundaresh, 2 Sep).
+    { family: "flow-stations", label: "CWC monitoring points (tap for readings)", floor: "monitoring", geom: "point", color: "#06b6d4", defaultOn: true, readings: true },
     // readings: the 5 river-table stations carry CPCB annual BOD/DO/FC trend
     // packs (build_basin_wq_param_packs.py); lake stations stay location-only.
     { family: "monitoring-points", label: "KSPCB monitoring points (tap for readings)", floor: "monitoring", geom: "point", color: "#059669", defaultOn: true, readings: true },

--- a/src/lib/basins/types.ts
+++ b/src/lib/basins/types.ts
@@ -194,6 +194,10 @@ export interface BasinManifest {
   /** Sibling basins worth cross-linking (e.g. the other state's share of the
    *  same river). Rendered as navigation links in overview mode. */
   relatedBasins?: { basinId: string; label: string }[];
+  /** Overview-mode choropleths: one-line source attribution shown in the map
+   *  legend while that metric is active, keyed by metric ("rainfallDeviationPct",
+   *  "gwLevelM"). Prose stays here in data, never hardcoded in the component. */
+  metricSources?: Record<string, string>;
   displayName: string;
   displayNameLocal?: string;
   /** Landing blurb (plain text). */


### PR DESCRIPTION
Review round on the Cauvery (Karnataka) overview and Kabini deep-dive maps.

- Selected sub-basin now outlines in amber (dark #facc15, light #d97706). The old white/near-black pick was one shade off the unselected hairlines, so tapping a sub-basin never visibly changed the map.
- Live-storage reservoirs wear a theme-flipped ring (white on dark, near-black on light). The old near-black ring vanished into the dark imagery, and every teal dot read as 'has live storage'.
- Legend rows now gate on what is actually drawn. The reservoir key shows whenever the markers do (they draw basin-wide, selection or not), and the 'In this sub-basin' block drops rows for symbols the focused sub-basin does not have (C8/C9 carry no MI tanks and no WQ stations).
- The Kabini's Wayanad reach is labelled 'beyond the state line' instead of 'above the state line', which read as a riddle.
- CWC gauge dots on the Kabini deep dive go cyan-500; cyan-700 sank into the dark imagery.
- The rainfall and groundwater choropleths name their source in the legend (KWRIS geomGIS sub-basin views, KSNDMC/IMD basis) through a new optional manifest.metricSources field - prose stays in data, not the component.

Verified in a real browser against a dev build: C2 selected in both themes, C9 legend gating, rainfall legend source line, Kabini monitoring floor. Preflight green end to end: lint 0 errors, tsc clean, vitest, data:check, generator-drift, L2 gate, ruff check + format, pytest 152 passed.