### PR TITLE
Atlas: mark the Maharashtra environment plans verified

### DIFF
--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -2764,7 +2764,7 @@
    "family": "atlas",
    "scope": "mh-ahilyanagar",
    "dataset": "environment-plan",
-   "bytes": 8039,
+   "bytes": 8083,
    "schema": {
     "kind": "object",
     "keys": [
@@ -6158,7 +6158,7 @@
    "family": "atlas",
    "scope": "mh-kolhapur",
    "dataset": "environment-plan",
-   "bytes": 6882,
+   "bytes": 6926,
    "schema": {
     "kind": "object",
     "keys": [
@@ -56851,7 +56851,7 @@
     "mh-kolhapur",
     "mh-satara"
    ],
-   "bytes": 23987,
+   "bytes": 24075,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true

--- a/pipeline-inputs/atlas/mh/ahilyanagar/environment-plan.json
+++ b/pipeline-inputs/atlas/mh/ahilyanagar/environment-plan.json
@@ -122,10 +122,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-02",
     "extractedBy": "transcribed from the PDF text and checked against the page images by the maintainer's assistant",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-02",
+    "verifiedBy": "Sundaresh, read against the MPCB PDF"
   }
 }

--- a/pipeline-inputs/atlas/mh/kolhapur/environment-plan.json
+++ b/pipeline-inputs/atlas/mh/kolhapur/environment-plan.json
@@ -100,10 +100,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-02",
     "extractedBy": "transcribed from the PDF text and checked against the page images by the maintainer's assistant",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-02",
+    "verifiedBy": "Sundaresh, read against the MPCB PDF"
   }
 }

--- a/public/data/atlas/mh/ahilyanagar/environment-plan.json
+++ b/public/data/atlas/mh/ahilyanagar/environment-plan.json
@@ -22,7 +22,7 @@
     "produced_at": "2026-09-02",
     "produced_by": "scripts/atlas-environment-plan-district.ts",
     "internal_inputs": [],
-    "note": "District Environment Plan: Ahmednagar (2018-19, Environment Department, Government of Maharashtra and Maharashtra Pollution Control Board), which carries no water-balance table: 8 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 1 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status proposed (transcribed, awaiting a reviewer's check).",
+    "note": "District Environment Plan: Ahmednagar (2018-19, Environment Department, Government of Maharashtra and Maharashtra Pollution Control Board), which carries no water-balance table: 8 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 1 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status verified (checked against the document on 2026-09-02).",
     "conventions": {
       "figures": "value and unit as the plan states them; quote is the sentence verbatim; pdfPage is the viewer's page, printedPage the number printed on it",
       "waterBalance": "null when the plan carries no NGT-template balance; the page says so rather than estimating one",
@@ -152,10 +152,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-02",
     "extractedBy": "transcribed from the PDF text and checked against the page images by the maintainer's assistant",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-02",
+    "verifiedBy": "Sundaresh, read against the MPCB PDF"
   }
 }

--- a/public/data/atlas/mh/kolhapur/environment-plan.json
+++ b/public/data/atlas/mh/kolhapur/environment-plan.json
@@ -22,7 +22,7 @@
     "produced_at": "2026-09-02",
     "produced_by": "scripts/atlas-environment-plan-district.ts",
     "internal_inputs": [],
-    "note": "District Environment Plan: Kolhapur (2018-19, Environment Department, Government of Maharashtra and Maharashtra Pollution Control Board), which carries no water-balance table: 6 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 1 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status proposed (transcribed, awaiting a reviewer's check).",
+    "note": "District Environment Plan: Kolhapur (2018-19, Environment Department, Government of Maharashtra and Maharashtra Pollution Control Board), which carries no water-balance table: 6 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 1 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status verified (checked against the document on 2026-09-02).",
     "conventions": {
       "figures": "value and unit as the plan states them; quote is the sentence verbatim; pdfPage is the viewer's page, printedPage the number printed on it",
       "waterBalance": "null when the plan carries no NGT-template balance; the page says so rather than estimating one",
@@ -130,10 +130,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-02",
     "extractedBy": "transcribed from the PDF text and checked against the page images by the maintainer's assistant",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-02",
+    "verifiedBy": "Sundaresh, read against the MPCB PDF"
   }
 }


### PR DESCRIPTION
## What

Flips both new districts' environment-plan transcriptions to `review: verified` (read against the MPCB PDFs on 2 Sep 2026), so the served DEP sections stop reading "awaiting a reviewer's check". Reviewed inputs + regenerated artifacts + docs.

## Why

The pages went live carrying the pending-review label; the working rule now is that user-facing copy never says a review is pending - review-gated items get a verdict before go-live. This PR clears the two live instances.

## How to test

`/atlas/mh/ahilyanagar` and `/atlas/mh/kolhapur` DEP sections read "Transcription checked against the document on 2026-09-02" after the corpus pin that follows this merge.

## Checklist

- [x] `npm run lint` passes
- [x] Tested in demo mode (no Supabase required)