### PR TITLE
Release: pin corpus-2026-09-02-mh-dep-verified

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -37,7 +37,7 @@
     "2026-09-02: the facts-quality release, tagged corpus-2026-09-02-facts-quality at 30f3a1d16c00802c4e07567e2fe5c15b405bef7b (data#59 squash; counts verified against the tree API). Modification-only: the five facts-*.json from neer-vazhvu#347 - 37 stale Live badges re-tiered across Delhi, Hyderabad, Kolkata, Surat and Pune, data_dates added so badges show their vintage, and Pune's flood-line fact corrected to the statewide register - none added or removed, so expected_files stays 1030/161 and this bump moves only the sha."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "8e7dbe025a99dd39213c7cfc10e4422cd83faaad",
+  "sha": "b2792e5791443c7d24ad4dbc06165575baefdf6c",
   "expected_files": {
     "data": 1196,
     "geojson": 161


### PR DESCRIPTION
Pin the corpus at data-repo b2792e57 (from neer-vazhvu-data#61): the two Maharashtra environment plans flip to review: verified, clearing the awaiting-review label from the live pages. File counts unchanged (1,196/161); verified with a real remote fetch in a throwaway worktree.