### PR TITLE
fix(kabini): PRS review round - register wording, 17-Cat detail, the Jubilant check, ia-region parity

### DIFF
--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -24645,7 +24645,7 @@
    "family": "basins",
    "scope": "cauvery-ka",
    "dataset": "accountability-C2",
-   "bytes": 65478,
+   "bytes": 67992,
    "schema": {
     "kind": "object",
     "keys": [
@@ -26321,7 +26321,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "accountability",
-   "bytes": 66547,
+   "bytes": 69061,
    "schema": {
     "kind": "object",
     "keys": [
@@ -27514,7 +27514,7 @@
    "family": "basins",
    "scope": "kabini",
    "dataset": "prs",
-   "bytes": 43708,
+   "bytes": 44967,
    "schema": {
     "kind": "object",
     "keys": [
@@ -56969,7 +56969,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 134260,
+   "bytes": 136774,
    "schema_variants": 2,
    "registered": true,
    "has_consumer": true
@@ -57017,7 +57017,7 @@
    "scopes": [
     "cauvery-ka"
    ],
-   "bytes": 65478,
+   "bytes": 67992,
    "schema_variants": 1,
    "registered": false,
    "has_consumer": true
@@ -57391,7 +57391,7 @@
     "arkavathi",
     "kabini"
    ],
-   "bytes": 176884,
+   "bytes": 178143,
    "schema_variants": 4,
    "registered": true,
    "has_consumer": true

--- a/public/data/basins/cauvery-ka/accountability-C2.json
+++ b/public/data/basins/cauvery-ka/accountability-C2.json
@@ -1449,7 +1449,7 @@
       "categories": [
         {
           "key": "effluent",
-          "label": "Industrial effluent",
+          "label": "Industrial effluent / CETP",
           "verdict": "tracked",
           "actionPlan": {
             "status": "addressed",
@@ -1463,7 +1463,7 @@
           },
           "gaps": [
             "The zero-discharge claim is the board's own assertion, unverified by any published effluent data - for a sugar/distillery/pharma cluster upstream of a Priority-IV stretch, that is the matrix's biggest open question.",
-            "No OCEMS-style public feed exists for these units to check the claim against."
+            "The one public OCEMS enrolment among these units (Jubilant Generics) reports every parameter as NA, and the same site shows no connection on CPCB's live dashboard - there is no working public feed to check the claim against (checked 2 September 2026)."
           ],
           "legalRef": "effluent"
         },
@@ -1487,6 +1487,59 @@
             "No public return reports what any unit on this stretch actually generated, so the ceiling is the only figure in the public record."
           ],
           "legalRef": "hazardous-waste"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for the industrial areas found in the Kabini Action Plan."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported for the estates in any ingested MPR edition.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Solid waste for the Nanjangud industrial areas appears in neither the action plan nor the MPRs - the reporting gap is the finding."
+          ]
+        },
+        {
+          "key": "sewage",
+          "label": "Sewage",
+          "verdict": "in-plan-not-reported",
+          "actionPlan": {
+            "status": "addressed",
+            "summary": "The plan's blanket assertion covers sewage as well: every industry in the taluk has an effluent or sewage treatment plant, with treated water used on land within premises.",
+            "cite": "Kabini Action Plan, section 2.5"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "The MPR compliance table counts ETPs and effluent volumes; no separate sewage figure is reported for the estates.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Estate sewage rides the same unverified zero-discharge assertion as effluent; no published measurement separates the two."
+          ]
+        },
+        {
+          "key": "reuse",
+          "label": "Treated-water reuse",
+          "verdict": "in-plan-not-reported",
+          "actionPlan": {
+            "status": "addressed",
+            "summary": "Treated water is stated to be used on land for gardening within premises - reuse is the mechanism behind the plan's zero-discharge position.",
+            "cite": "Kabini Action Plan, section 2.5"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No MPR edition reports reuse volumes for these estates.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "The reuse claim carries no reported volume, so the share of the 9.03 MLD of effluent actually returned to land is not in the public record."
+          ]
         }
       ],
       "mapMatch": {

--- a/public/data/basins/kabini/accountability.json
+++ b/public/data/basins/kabini/accountability.json
@@ -25,7 +25,7 @@
       }
     ],
     "method": "manual",
-    "produced_at": "2026-08-26",
+    "produced_at": "2026-09-02",
     "produced_by": "Authored on the cauvery-ka overview (accountability-C2.json) and carried verbatim by scripts/build_kabini_sources.py."
   },
   "question": "Do the Action Plan and the MPRs address all potential pollution contributors on the Kabini stretch?",
@@ -1478,7 +1478,7 @@
       "categories": [
         {
           "key": "effluent",
-          "label": "Industrial effluent",
+          "label": "Industrial effluent / CETP",
           "verdict": "tracked",
           "actionPlan": {
             "status": "addressed",
@@ -1492,7 +1492,7 @@
           },
           "gaps": [
             "The zero-discharge claim is the board's own assertion, unverified by any published effluent data - for a sugar/distillery/pharma cluster upstream of a Priority-IV stretch, that is the matrix's biggest open question.",
-            "No OCEMS-style public feed exists for these units to check the claim against."
+            "The one public OCEMS enrolment among these units (Jubilant Generics) reports every parameter as NA, and the same site shows no connection on CPCB's live dashboard - there is no working public feed to check the claim against (checked 2 September 2026)."
           ],
           "legalRef": "effluent"
         },
@@ -1516,6 +1516,59 @@
             "No public return reports what any unit on this stretch actually generated, so the ceiling is the only figure in the public record."
           ],
           "legalRef": "hazardous-waste"
+        },
+        {
+          "key": "solid-waste",
+          "label": "Solid waste",
+          "verdict": "silent",
+          "actionPlan": {
+            "status": "absent",
+            "summary": "No solid-waste commitment for the industrial areas found in the Kabini Action Plan."
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "Not reported for the estates in any ingested MPR edition.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Solid waste for the Nanjangud industrial areas appears in neither the action plan nor the MPRs - the reporting gap is the finding."
+          ]
+        },
+        {
+          "key": "sewage",
+          "label": "Sewage",
+          "verdict": "in-plan-not-reported",
+          "actionPlan": {
+            "status": "addressed",
+            "summary": "The plan's blanket assertion covers sewage as well: every industry in the taluk has an effluent or sewage treatment plant, with treated water used on land within premises.",
+            "cite": "Kabini Action Plan, section 2.5"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "The MPR compliance table counts ETPs and effluent volumes; no separate sewage figure is reported for the estates.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "Estate sewage rides the same unverified zero-discharge assertion as effluent; no published measurement separates the two."
+          ]
+        },
+        {
+          "key": "reuse",
+          "label": "Treated-water reuse",
+          "verdict": "in-plan-not-reported",
+          "actionPlan": {
+            "status": "addressed",
+            "summary": "Treated water is stated to be used on land for gardening within premises - reuse is the mechanism behind the plan's zero-discharge position.",
+            "cite": "Kabini Action Plan, section 2.5"
+          },
+          "mpr": {
+            "status": "not-reported",
+            "summary": "No MPR edition reports reuse volumes for these estates.",
+            "asOf": "September 2025"
+          },
+          "gaps": [
+            "The reuse claim carries no reported volume, so the share of the 9.03 MLD of effluent actually returned to land is not in the public record."
+          ]
         }
       ],
       "mapMatch": {

--- a/public/data/basins/kabini/prs.json
+++ b/public/data/basins/kabini/prs.json
@@ -57,10 +57,19 @@
         "url": "https://indiawris.gov.in/wris/",
         "license": "India-WRIS website policy: material 'may be reproduced free of charge in any format or media without requiring specific permission', subject to accurate reproduction and prominent acknowledgement of the source; third-party material on the site excluded - GoI publication, cited with attribution",
         "role": "asserts"
+      },
+      {
+        "title": "CPCB OCEMS public portal - industry details for Jubilant Generics (Nanjangud) and the realtime connectivity dashboard entry for Jubilant Pharmova Limited",
+        "publisher": "Central Pollution Control Board",
+        "url": "https://cems.cpcb.gov.in/public/#/l/site-info/eyJvYmoiOiJpbmR1c3RyeV8zNjIwIn0%3D",
+        "closed": true,
+        "as_of": "2026-09-02",
+        "role": "input",
+        "license": "government portal, cited with attribution"
       }
     ],
     "method": "manual",
-    "produced_at": "2026-08-27",
+    "produced_at": "2026-09-02",
     "produced_by": "Authored from the documents' own tables, page-cited; the 2018 stretch length is KSPCB's own figure because the delivered geometry maps only part of it. Nanjangud industrial-register counts come from scripts/build_kabini_fregister.py."
   },
   "river": "Kabini",
@@ -256,13 +265,13 @@
           "label": "The same taluk, on the board's own register",
           "level": "taluk",
           "layerRef": "pressures-industrial",
-          "body": "The plan's table of 140 units can be read against KSPCB's own F-register for Regional Office Mysore-2, the 2020-21 edition as on 31 March 2021. That register carries 345 consented units in Nanjangud taluk, 217 of them recorded as operating. The two records agree on the categories that matter most for a polluted stretch, and part company lower down the scale.",
+          "body": "The action plan's table of 140 units can be read against KSPCB's own F-register for Regional Office Mysore-2, the 2020-21 edition as on 31 March 2021. That register carries 345 consented units in Nanjangud taluk, 217 of them recorded as operating. On operating units the two records broadly agree for the Red and Green categories, and diverge on Orange and White.",
           "points": [
             "Red category: 71 consented on the register, 30 of them operating, against 29 in the plan's table. Green: 135 consented, 87 operating, against 84. On operating units the two records line up.",
             "Orange: 64 consented, 32 operating, against 17 in the plan. White: 75 consented, 68 operating, against 10. These two categories are where the plan's table and the register diverge.",
-            "Nanjangud carries the largest Red-category list of the seven taluks in this register (71 of 197), which is consistent with the belt sitting at the head of the stretch.",
+            "Nanjangud carries the largest Red-category list of the seven taluks in this register, 71 of 197 - the belt at the head of the polluted stretch is also where the register's highest-pollution-potential units concentrate.",
             "The register is a 31 March 2021 snapshot and the plan is earlier still, so neither speaks to units consented since. A current count needs the 2025-26 edition.",
-            "The register's 17-category flag is incomplete (only five rows carry it), so the count of 17-category units on this stretch is not available from it."
+            "The register's 17-category flag is incomplete: only five rows in the whole register carry it - Bannari Amman Sugars, Chamundi Distilleries, Gemini Distillery, Jubilant Generics and Solara Active Pharma Sciences, the two distilleries recorded as closed - so a 17-category count for this stretch cannot be read from this source."
           ],
           "sourceTier": "other"
         },
@@ -270,13 +279,17 @@
           "key": "check",
           "label": "What would let anyone check it",
           "level": "stretch",
-          "body": "The zero-discharge position is the board's own assertion. For a sugar, distillery, pulp-and-paper and pharmaceutical cluster upstream of a polluted stretch, no published effluent data exists to test it: there is no public OCEMS-style feed for these units, and the compliance table reports a count, not a measurement.",
+          "body": "The zero-discharge position is the board's own assertion. For a sugar, distillery, pulp-and-paper and pharmaceutical cluster upstream of a polluted stretch, no published effluent data exists to test it: the one unit with a public OCEMS enrolment reports no data through it, and the compliance table reports a count, not a measurement.",
           "noData": true,
           "sourceTier": "other",
           "link": {
-            "url": "https://cems.cpcb.gov.in/public/#/l/realtime-connectivity-status-dashboard",
-            "label": "Open CPCB's live connectivity dashboard"
-          }
+            "url": "https://cems.cpcb.gov.in/public/#/l/site-info/eyJvYmoiOiJpbmR1c3RyeV8zNjIwIn0%3D",
+            "label": "Jubilant Pharmova on CPCB's connectivity dashboard"
+          },
+          "points": [
+            "One concrete check exists: Jubilant Generics (KIADB Nanjangud) is enrolled on CPCB's public OCEMS portal to report BOD, COD, pH, TSS and treated-water flow, and every value reads NA with no last-updated date (checked 2 September 2026).",
+            "CPCB's live connectivity dashboard lists the same site as Jubilant Pharmova Limited with a blank connection status and no date of last data received, while neighbouring entries show live same-day feeds."
+          ]
         }
       ]
     },


### PR DESCRIPTION
Review round on the Kabini industrial-effluent panel plus framework parity for the accountability matrix.

**Register subtab** ('The same taluk, on the board's own register')
- 'The action plan's table of 140 units' now names the document.
- The agree/diverge sentence says plainly where the two records line up (Red, Green) and where they part (Orange, White) - 'part company lower down the scale' read as a riddle.
- The head-of-stretch point states the fact directly instead of 'which is consistent with'.
- The 17-Cat bullet now names all five flagged rows - Bannari Amman Sugars, Chamundi Distilleries, Gemini Distillery, Jubilant Generics, Solara Active Pharma Sciences - and notes the two distilleries recorded as closed. Verified against a fresh parse of Mysore-2_1.pdf (row markers on pp.1-2 and 28); matches docs/research/kabini-fregister-counts.json.

**'What would let anyone check it'** now carries the one concrete check instead of a bare 'no public feed' claim, both halves verified 2 Sep 2026 against CPCB's own portals:
- Jubilant Generics (KIADB Nanjangud) is enrolled on the public OCEMS portal for BOD, COD, pH, TSS and treated-water flow - every value reads NA with no last-updated date (public_industry_details for industry_2234).
- The CEMS connectivity dashboard lists the same site as Jubilant Pharmova Limited (OD20KA03938) with a blank connection status and no last-data date, while neighbouring rows show live same-day feeds. The category link now opens that unit's page. The portal rides the envelope as a closed source with as_of.

**Framework parity (accountability matrix)**: Nanjangud industrial areas now carry the same five fields as the Arkavathi's industrial areas - Industrial effluent / CETP, Hazardous waste, Solid waste, Sewage, Treated-water reuse. Sewage and reuse ride the plan's own section 2.5 assertions (in plan, not in MPR); solid waste is silent in both records. The effluent gap line is sharpened by the Jubilant check. Authored in cauvery-ka/accountability-C2.json and carried to kabini by re-running the script's step 10, per that file's contract.

Verified in a real browser: register and check subtabs render the new text and link; the Industrial Areas tab shows all five rows with the right badges on both surfaces. Preflight green end to end: lint 0 errors, tsc, vitest 276, data:check, generator-drift, L2 gate (prs.json and accountability.json both L2 OK), catalogue + conformance + exemptions regenerated, ruff check + format, pytest 152.

After merge: corpus mirror + corpus.lock bump, usual chain - modification-only, 3 data files, no count change.