### PR TITLE
fix(basins): point the Paani Earth collaboration link at forrivers.life

### DIFF
--- a/src/lib/basins/arkavathi.ts
+++ b/src/lib/basins/arkavathi.ts
@@ -175,8 +175,8 @@ export const ARKAVATHI: BasinManifest = {
     label: "Developed in collaboration with",
     name: "Paani Earth Foundation",
     logo: "/partners/paani-earth-foundation.png",
-    url: "https://paani.earth",
-    sub: "Basin spatial data, field evidence and review - paani.earth ↗",
+    url: "https://forrivers.life",
+    sub: "Basin spatial data, field evidence and review - forrivers.life ↗",
   },
   credits: [
     "Spatial data: Paani Earth Foundation - Arkavathi River Basin GIS package (Feb 2026).",

--- a/src/lib/basins/kabini.ts
+++ b/src/lib/basins/kabini.ts
@@ -167,7 +167,7 @@ export const KABINI: BasinManifest = {
     label: "Developed in collaboration with",
     name: "Paani Earth Foundation",
     logo: "/partners/paani-earth-foundation.png",
-    url: "https://paani.earth",
+    url: "https://forrivers.life",
     sub: "Cauvery basin spatial data and review",
   },
   credits: [


### PR DESCRIPTION
The collaboration cards on the Arkavathi and Kabini atlases now link to https://forrivers.life ('ForRivers - Initiative by Paani Earth Foundation' - verified live), and the Arkavathi card's visible label reads forrivers.life. Deliberately left alone: the fifteen lab-analysis evidenceUrl deep links and the 'hosted on paani.earth' prose - those PDFs still resolve on the old domain (spot-checked 2 Sep 2026) and repointing them without equivalent paths on the new site would break working citations. Code-only change, no corpus release needed. Lint 0 errors, tsc clean, tests 276 pass.