### PR TITLE
chore(corpus): pin corpus-2026-09-02-atlas-scarcity-flood

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -38,9 +38,9 @@
     "2026-09-02: the Kabini PRS review round, tagged corpus-2026-09-02-kabini-prs-review at bbb1b547adf9640d84f0cc1617a3f06437da129f (data#62 squash). Modification-only: three artifacts re-synced from neer-vazhvu#356 - the register subtab reworded with the five named 17-Cat rows (two distilleries recorded as closed), the Jubilant OCEMS/CEMS check with CPCB's portal cited as a closed source, and the Nanjangud industrial-area card carrying the full five-field Arkavathi framework - so expected_files stays 1196/161 and this bump moves only the sha. The move also carries the 2 Sep Maharashtra-plans release (b2792e5), which had merged on data main without a pin bump - its two verified-plan artifacts reach production with this bump."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "bbb1b547adf9640d84f0cc1617a3f06437da129f",
+  "sha": "01ff17fb056b0e2072573bbda753dae640889121",
   "expected_files": {
-    "data": 1196,
+    "data": 1199,
     "geojson": 161
   }
 }


### PR DESCRIPTION
Moves the pin to data-repo 01ff17fb (tag corpus-2026-09-02-atlas-scarcity-flood): the three verified hazard artifacts from #359 - the WSSD tanker week of 2026-08-31 and both state disaster-plan flood classifications. expected_files 1196/161 -> 1199/161. This is the go-live step: prod starts serving the scarcity and flood readings on the state and district pages once this merges.