### PR TITLE
Atlas: every table sortable by its columns

### DIFF
--- a/src/app/atlas/[state]/[district]/page.tsx
+++ b/src/app/atlas/[state]/[district]/page.tsx
@@ -18,7 +18,6 @@ import {
   AtlasGap,
   AtlasNote,
   AtlasSection,
-  AtlasTableScroll,
   StatTile,
   TABLE,
   TD,
@@ -27,6 +26,7 @@ import {
   TR,
   ToneBadge,
 } from "@/components/atlas/atlas-primitives";
+import { AtlasSortableTable } from "@/components/atlas/sortable-table";
 import { FloodStatement, ScarcityDistrictRead } from "@/components/atlas/scarcity-flood";
 import { getCuratedBriefs } from "@/lib/atlas/curated-briefs";
 import { loadStateFloodClassification, loadStateScarcityTankers } from "@/lib/atlas/data";
@@ -363,7 +363,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
             <AtlasFinding>{groundwater.finding}</AtlasFinding>
             {groundwater.taluks.length > 0 ? (
               <div className="mt-4">
-                <AtlasTableScroll label={`Groundwater assessment by ${unit}`}>
+                <AtlasSortableTable label={`Groundwater assessment by ${unit}`}>
                   <table className={TABLE}>
                     <thead className={THEAD}>
                       <tr>
@@ -394,7 +394,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                       ))}
                     </tbody>
                   </table>
-                </AtlasTableScroll>
+                </AtlasSortableTable>
                 <AtlasNote>
                   IN-GRES {groundwater.assessmentYear}. The stage of extraction is annual draft as a share of
                   total availability; above 100 percent, more is drawn each year than the {unit} is assessed
@@ -423,7 +423,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
               ) : null}
             </div>
             <div className="mt-5">
-              <AtlasTableScroll label="Blocks compared">
+              <AtlasSortableTable label="Blocks compared">
                 <table className={`${TABLE} min-w-[64rem]`}>
                   <thead className={THEAD}>
                     <tr className="border-b border-slate-200 dark:border-slate-700">
@@ -494,7 +494,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                     ))}
                   </tbody>
                 </table>
-              </AtlasTableScroll>
+              </AtlasSortableTable>
               <AtlasNote>
                 Canal, well and tank figures are shares of the irrigated farmland beside them, not of
                 households and not of drinking water. They come from Census 2011 ({irrigation.describes})
@@ -546,7 +546,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                       </p>
                     </AtlasCard>
                     <div>
-                      <AtlasTableScroll label="Water bodies by census class">
+                      <AtlasSortableTable label="Water bodies by census class">
                         <table className={`${TABLE} min-w-[18rem]`}>
                           <thead className={THEAD}>
                             <tr>
@@ -563,7 +563,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                             ))}
                           </tbody>
                         </table>
-                      </AtlasTableScroll>
+                      </AtlasSortableTable>
                       {reading.waterBodies.attributeNote ? (
                         <AtlasNote>
                           {reading.waterBodies.areaBasis === "withheld" ? "Waterspread is not published. " : ""}
@@ -632,7 +632,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                       </AtlasGap>
                     )}
                   </div>
-                  <AtlasTableScroll label="What the plan states about water">
+                  <AtlasSortableTable label="What the plan states about water">
                     <table className={`${TABLE} min-w-[40rem]`}>
                       <thead className={THEAD}>
                         <tr>
@@ -660,7 +660,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                         ))}
                       </tbody>
                     </table>
-                  </AtlasTableScroll>
+                  </AtlasSortableTable>
                   <AtlasNote>
                     Action points the plan sets for water:{" "}
                     {reading.environmentPlan.actionPoints.map((point) => point.text.toLowerCase()).join("; ")}.
@@ -723,7 +723,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
             title="How current these figures are"
             intro="Not everything on this page is from the same year, and the gap is large. What each figure describes is listed separately from when the Atlas last read it, straight from each artifact's own record."
           >
-            <AtlasTableScroll label="Figure vintages">
+            <AtlasSortableTable label="Figure vintages">
               <table className={TABLE}>
                 <thead className={THEAD}>
                   <tr>
@@ -754,7 +754,7 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
                   ))}
                 </tbody>
               </table>
-            </AtlasTableScroll>
+            </AtlasSortableTable>
             <AtlasNote>
               The land, irrigation and seasonal-source figures are the oldest thing here by a wide
               margin. India&rsquo;s 2021 census did not take place, so Census 2011 remains the most

--- a/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
+++ b/src/app/atlas/[state]/[district]/panchayats/[gpCode]/page.tsx
@@ -12,7 +12,6 @@ import {
   AtlasFinding,
   AtlasGap,
   AtlasNote,
-  AtlasTableScroll,
   StatTile,
   StatusPill,
   TABLE,
@@ -24,6 +23,7 @@ import {
   type BriefStatusKey,
   type Tone,
 } from "@/components/atlas/atlas-primitives";
+import { AtlasSortableTable } from "@/components/atlas/sortable-table";
 import { getCuratedBrief } from "@/lib/atlas/curated-briefs";
 import { loadBoundaryShard, loadGroundwaterProjection, loadGroundwaterTaluks, loadWaterBodyShard } from "@/lib/atlas/data";
 import { getDistrictBrief, getDistrictDirectory } from "@/lib/atlas/district-directory";
@@ -376,7 +376,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                   title="Habitations"
                   intro="JJM records service for each habitation separately. A Panchayat total can hide a habitation that is behind."
                 >
-                  <AtlasTableScroll label="Habitations">
+                  <AtlasSortableTable label="Habitations">
                     <table className={`${TABLE} min-w-[28rem]`}>
                       <thead className={THEAD}>
                         <tr>
@@ -397,7 +397,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                         ))}
                       </tbody>
                     </table>
-                  </AtlasTableScroll>
+                  </AtlasSortableTable>
                 </Chapter>
               ) : null}
 
@@ -407,7 +407,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                   title="Where the water comes from"
                   intro="The schemes JJM records as serving this Panchayat, grouped by the kind of source they draw on."
                 >
-                  <AtlasTableScroll label="Drinking-water sources">
+                  <AtlasSortableTable label="Drinking-water sources">
                     <table className={`${TABLE} min-w-[24rem]`}>
                       <thead className={THEAD}>
                         <tr>
@@ -426,7 +426,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                         ))}
                       </tbody>
                     </table>
-                  </AtlasTableScroll>
+                  </AtlasSortableTable>
                 </Chapter>
               ) : null}
 
@@ -523,7 +523,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                     </div>
                     <div className="space-y-4">
                       {detail.waterBodies.register === "water-bodies-census" && detail.waterBodies.byType ? (
-                        <AtlasTableScroll label="Water bodies by census class">
+                        <AtlasSortableTable label="Water bodies by census class">
                           <table className={`${TABLE} min-w-[16rem]`}>
                             <thead className={THEAD}>
                               <tr>
@@ -540,9 +540,9 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                               ))}
                             </tbody>
                           </table>
-                        </AtlasTableScroll>
+                        </AtlasSortableTable>
                       ) : null}
-                      <AtlasTableScroll
+                      <AtlasSortableTable
                         label={
                           detail.waterBodies.register === "water-bodies-census"
                             ? "Water bodies by owner"
@@ -567,7 +567,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                             ))}
                           </tbody>
                         </table>
-                      </AtlasTableScroll>
+                      </AtlasSortableTable>
                     </div>
                   </div>
                 </Chapter>
@@ -589,7 +589,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                           : `${detail.sampling.unsafe} were recorded unsafe.`}
                       </AtlasNote>
                     </div>
-                    <AtlasTableScroll label="Samples by year">
+                    <AtlasSortableTable label="Samples by year">
                       <table className={`${TABLE} min-w-[12rem]`}>
                         <thead className={THEAD}>
                           <tr>
@@ -606,7 +606,7 @@ export default async function AtlasPanchayatPage({ params }: RouteParams) {
                           ))}
                         </tbody>
                       </table>
-                    </AtlasTableScroll>
+                    </AtlasSortableTable>
                   </div>
                 </Chapter>
               ) : null}

--- a/src/components/atlas/atlas-directory-explorer.tsx
+++ b/src/components/atlas/atlas-directory-explorer.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
+
+import { cellSortValue, compareCells, firstClickDescending, type ColumnKind } from "@/lib/atlas/table-sort";
 import { Search } from "lucide-react";
 
 import { STATUS_LABELS, StatusPill, type BriefStatusKey } from "./atlas-primitives";
@@ -53,6 +55,18 @@ export function AtlasDirectoryExplorer({
   const [limit, setLimit] = useState(pageSize);
 
   const normalized = query.trim().toLocaleLowerCase("en-IN");
+  type SortColumn = "name" | "blockName" | "lgdCode" | "status";
+  const SORT_KIND: Record<SortColumn, ColumnKind> = { name: "text", blockName: "text", lgdCode: "number", status: "text" };
+  // The pill ranks by how much is on file, not by its label's alphabet.
+  const STATUS_RANK: Record<BriefStatusKey, string> = { reviewed: "1", profile: "2", directory: "3" };
+  const [sort, setSort] = useState<{ column: SortColumn; descending: boolean } | null>(null);
+  const toggleSort = (column: SortColumn) =>
+    setSort((current) =>
+      current?.column === column
+        ? { column, descending: !current.descending }
+        : { column, descending: firstClickDescending(SORT_KIND[column]) },
+    );
+
   const matches = useMemo(() => {
     return rows.filter(
       (row) =>
@@ -60,8 +74,21 @@ export function AtlasDirectoryExplorer({
         (normalized.length === 0 || searchText(row).includes(normalized)),
     );
   }, [rows, blockCode, normalized]);
-  const visible = matches.slice(0, limit);
-  const remaining = matches.length - visible.length;
+  const sorted = useMemo(() => {
+    if (!sort) return matches;
+    const kind = SORT_KIND[sort.column];
+    return [...matches].sort((a, b) =>
+      compareCells(
+        cellSortValue(sort.column === "status" ? STATUS_RANK[a.status] : a[sort.column]),
+        cellSortValue(sort.column === "status" ? STATUS_RANK[b.status] : b[sort.column]),
+        kind,
+        sort.descending,
+      ),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matches, sort]);
+  const visible = sorted.slice(0, limit);
+  const remaining = sorted.length - visible.length;
 
   const statusCounts = matches.reduce<Record<BriefStatusKey, number>>(
     (acc, row) => {
@@ -136,10 +163,31 @@ export function AtlasDirectoryExplorer({
           <table className="w-full min-w-[32rem] border-collapse text-sm">
             <thead className="bg-slate-50 dark:bg-slate-800/80 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
               <tr>
-                <th className="px-3 py-2.5 font-semibold">Gram Panchayat</th>
-                <th className="px-3 py-2.5 font-semibold">Block</th>
-                <th className="px-3 py-2.5 font-semibold">LGD code</th>
-                <th className="px-3 py-2.5 font-semibold">Brief</th>
+                {(
+                  [
+                    ["name", "Gram Panchayat"],
+                    ["blockName", "Block"],
+                    ["lgdCode", "LGD code"],
+                    ["status", "Brief"],
+                  ] as Array<[SortColumn, string]>
+                ).map(([column, heading]) => (
+                  <th
+                    key={column}
+                    className="px-3 py-2.5 font-semibold"
+                    aria-sort={sort?.column === column ? (sort.descending ? "descending" : "ascending") : undefined}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(column)}
+                      className="inline-flex items-center gap-1 cursor-pointer select-none text-left font-semibold uppercase tracking-wider hover:text-slate-900 dark:hover:text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-600"
+                    >
+                      {heading}
+                      <span aria-hidden="true" className="text-[10px] leading-none text-slate-400 dark:text-slate-500">
+                        {sort?.column === column ? (sort.descending ? "\u25bc" : "\u25b2") : "\u2195"}
+                      </span>
+                    </button>
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>

--- a/src/components/atlas/scarcity-flood.tsx
+++ b/src/components/atlas/scarcity-flood.tsx
@@ -8,7 +8,6 @@
 import {
   AtlasFinding,
   AtlasNote,
-  AtlasTableScroll,
   StatTile,
   TABLE,
   TD,
@@ -16,6 +15,7 @@ import {
   THEAD,
   TR,
 } from "@/components/atlas/atlas-primitives";
+import { AtlasSortableTable } from "@/components/atlas/sortable-table";
 import type { DistrictFloodReading, DistrictScarcityReading, ScarcityWeek } from "@/lib/atlas/hazards";
 
 const num = (value: number): string => Math.round(value).toLocaleString("en-IN");
@@ -79,7 +79,7 @@ export function ScarcityStateTable({ week }: { week: ScarcityWeek }) {
         most of any division ({num(week.worstDivision.tankersTotal)}).
       </AtlasFinding>
       <div className="mt-4">
-        <AtlasTableScroll label="Districts on tanker supply, worst first">
+        <AtlasSortableTable label="Districts on tanker supply, worst first">
           <table className={TABLE}>
             <thead className={THEAD}>
               <tr>
@@ -106,7 +106,7 @@ export function ScarcityStateTable({ week }: { week: ScarcityWeek }) {
               ))}
             </tbody>
           </table>
-        </AtlasTableScroll>
+        </AtlasSortableTable>
       </div>
       <div className="mt-4">
         <AtlasNote>

--- a/src/components/atlas/sortable-table.tsx
+++ b/src/components/atlas/sortable-table.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * Drop-in replacement for AtlasTableScroll that makes the table inside it
+ * sortable by its columns. The table stays server-rendered exactly as it
+ * was - links, badges and all; this wrapper finds it after hydration, turns
+ * the header cells of the LAST thead row into buttons, and reorders the
+ * existing tbody rows in place on click. No React state is involved: the
+ * children are static server output that React never re-renders, so the DOM
+ * is ours to reorder, and without JavaScript the table simply stays in its
+ * served order.
+ *
+ * Rows that do not span the full column set (a "none counted" note under a
+ * colSpan) keep their place at the bottom, unsorted. A thead whose last row
+ * itself uses colSpan is left untouched: there is no honest cell-to-column
+ * mapping to sort by.
+ */
+import { useEffect, useRef, type ReactNode } from "react";
+
+import {
+  cellSortValue,
+  columnKindOf,
+  compareCells,
+  firstClickDescending,
+  type CellValue,
+} from "@/lib/atlas/table-sort";
+
+const BUTTON_CLASSES = [
+  "inline-flex", "items-center", "gap-1", "cursor-pointer", "select-none",
+  "text-left", "font-semibold", "hover:text-slate-900", "dark:hover:text-slate-100",
+  "focus-visible:outline", "focus-visible:outline-2", "focus-visible:outline-cyan-600",
+];
+const ARROW_CLASSES = ["text-[10px]", "leading-none", "text-slate-400", "dark:text-slate-500"];
+
+function enhance(container: HTMLDivElement): void {
+  const table = container.querySelector("table");
+  const head = table?.tHead;
+  const body = table?.tBodies[0];
+  if (!table || !head || !body || head.rows.length === 0) return;
+  const headerRow = head.rows[head.rows.length - 1];
+  const headers = Array.from(headerRow.cells);
+  if (headers.some((cell) => cell.colSpan > 1)) return;
+
+  let sortedBy = -1;
+  let descending = false;
+  const arrows: HTMLElement[] = [];
+
+  const sortBy = (column: number): void => {
+    const rows = Array.from(body.rows);
+    const sortable = rows.filter((row) => row.cells.length === headers.length);
+    const remainder = rows.filter((row) => row.cells.length !== headers.length);
+    const valueOf = (row: HTMLTableRowElement): CellValue =>
+      cellSortValue(row.cells[column].dataset.sort ?? row.cells[column].textContent ?? "");
+    const values = new Map(sortable.map((row) => [row, valueOf(row)]));
+    const kind = columnKindOf([...values.values()]);
+    descending = sortedBy === column ? !descending : firstClickDescending(kind);
+    sortedBy = column;
+    sortable.sort((a, b) => compareCells(values.get(a)!, values.get(b)!, kind, descending));
+    for (const row of [...sortable, ...remainder]) body.appendChild(row);
+    headers.forEach((cell, index) => {
+      if (index === column) cell.setAttribute("aria-sort", descending ? "descending" : "ascending");
+      else cell.removeAttribute("aria-sort");
+      arrows[index].textContent = index === column ? (descending ? "▼" : "▲") : "↕";
+    });
+  };
+
+  headers.forEach((cell, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.classList.add(...BUTTON_CLASSES);
+    while (cell.firstChild) button.appendChild(cell.firstChild);
+    const arrow = document.createElement("span");
+    arrow.classList.add(...ARROW_CLASSES);
+    arrow.setAttribute("aria-hidden", "true");
+    arrow.textContent = "↕";
+    arrows.push(arrow);
+    button.appendChild(arrow);
+    button.addEventListener("click", () => sortBy(index));
+    cell.appendChild(button);
+  });
+}
+
+export function AtlasSortableTable({ children, label }: { children: ReactNode; label: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const container = ref.current;
+    if (container && container.dataset.sortable !== "done") {
+      container.dataset.sortable = "done";
+      enhance(container);
+    }
+  }, []);
+  return (
+    <div
+      ref={ref}
+      className="overflow-x-auto rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900"
+      role="region"
+      aria-label={label}
+      tabIndex={0}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/lib/atlas/table-sort.test.ts
+++ b/src/lib/atlas/table-sort.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { cellSortValue, columnKindOf, compareCells, firstClickDescending } from "./table-sort";
+
+const v = cellSortValue;
+
+describe("cellSortValue", () => {
+  it("reads leading numbers through Indian grouping and units", () => {
+    assert.equal(v("1,234 ha").num, 1234);
+    assert.equal(v("92.5%").num, 92.5);
+    assert.equal(v("148 d").num, 148);
+    assert.equal(v("-3.2").num, -3.2);
+  });
+  it("keeps a category with an embedded count as text", () => {
+    const value = v("over-exploited (5 of 12)");
+    assert.equal(value.num, null);
+    assert.equal(value.missing, false);
+  });
+  it("reads ISO dates as dates, not as the year", () => {
+    assert.equal(v("2026-08-31").date, "2026-08-31");
+    assert.equal(v("2026-08-31").num, null);
+  });
+  it("treats the gap vocabulary as missing", () => {
+    for (const raw of ["not stated", "not projected", "", "—", "-", "n/a", "None"]) {
+      assert.equal(v(raw).missing, true, raw);
+    }
+  });
+});
+
+describe("columnKindOf", () => {
+  it("takes the majority of known cells", () => {
+    assert.equal(columnKindOf([v("12"), v("3 ha"), v("not stated"), v("x")]), "number");
+    assert.equal(columnKindOf([v("2026-08-31"), v("2025-01-01"), v("unstated")]), "date");
+    assert.equal(columnKindOf([v("canal"), v("well"), v("7")]), "text");
+  });
+  it("is text when every cell is missing", () => {
+    assert.equal(columnKindOf([v("not stated"), v("")]), "text");
+  });
+});
+
+describe("compareCells", () => {
+  it("sinks missing cells to the bottom in both directions", () => {
+    const rows = [v("5"), v("not stated"), v("12")];
+    for (const descending of [true, false]) {
+      const sorted = [...rows].sort((a, b) => compareCells(a, b, "number", descending));
+      assert.equal(sorted[2].missing, true, `descending=${descending}`);
+    }
+  });
+  it("orders numbers numerically, not lexically", () => {
+    const sorted = [v("97"), v("7"), v("348")].sort((a, b) => compareCells(a, b, "number", true));
+    assert.deepEqual(sorted.map((value) => value.num), [348, 97, 7]);
+  });
+  it("orders dates chronologically", () => {
+    const sorted = [v("2026-08-31"), v("2026-08-24")].sort((a, b) => compareCells(a, b, "date", false));
+    assert.equal(sorted[0].date, "2026-08-24");
+  });
+});
+
+describe("firstClickDescending", () => {
+  it("puts the biggest reading first, names A to Z", () => {
+    assert.equal(firstClickDescending("number"), true);
+    assert.equal(firstClickDescending("date"), true);
+    assert.equal(firstClickDescending("text"), false);
+  });
+});

--- a/src/lib/atlas/table-sort.ts
+++ b/src/lib/atlas/table-sort.ts
@@ -1,0 +1,78 @@
+/**
+ * Column sorting for the Atlas tables: the pure half. Both consumers - the
+ * drop-in wrapper that enhances server-rendered tables and the directory
+ * explorer's stateful table - classify and compare through these functions,
+ * so "what does clicking this header do" has exactly one answer.
+ *
+ * Classification is per cell, and a column takes the majority kind of its
+ * non-missing cells: a leading number reads as a number ("1,234 ha", "92.5%",
+ * "148 d"), an ISO date as a date, anything else as text - so a category like
+ * "over-exploited (5 of 12)" sorts alphabetically, not by the 5. Missing
+ * readings ("not stated", em/en dashes, blanks) sink to the bottom whichever
+ * direction the column is sorted, because "we don't know" is not a value.
+ */
+
+export type ColumnKind = "number" | "date" | "text";
+
+export interface CellValue {
+  missing: boolean;
+  num: number | null;
+  date: string | null;
+  text: string;
+}
+
+const MISSING = /^(not stated|not projected|none|unstated|n\/a|—|–|-)?$/i;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}/;
+const LEADING_NUMBER = /^-?\d[\d,]*(\.\d+)?/;
+
+export function cellSortValue(raw: string): CellValue {
+  const text = raw.replace(/\s+/g, " ").trim();
+  if (MISSING.test(text)) return { missing: true, num: null, date: null, text };
+  if (ISO_DATE.test(text)) return { missing: false, num: null, date: text.slice(0, 10), text };
+  const match = text.match(LEADING_NUMBER);
+  if (match) return { missing: false, num: Number(match[0].replace(/,/g, "")), date: null, text };
+  return { missing: false, num: null, date: null, text };
+}
+
+/** The kind most of the column's known cells agree on; text when nothing is known. */
+export function columnKindOf(values: CellValue[]): ColumnKind {
+  let numbers = 0;
+  let dates = 0;
+  let known = 0;
+  for (const value of values) {
+    if (value.missing) continue;
+    known += 1;
+    if (value.num !== null) numbers += 1;
+    else if (value.date !== null) dates += 1;
+  }
+  if (known === 0) return "text";
+  if (numbers * 2 > known) return "number";
+  if (dates * 2 > known) return "date";
+  return "text";
+}
+
+/** Compare for ascending order; the caller flips the sign for descending.
+ *  Missing cells compare as "after everything", direction-independent. */
+export function compareCells(a: CellValue, b: CellValue, kind: ColumnKind, descending: boolean): number {
+  if (a.missing || b.missing) return a.missing === b.missing ? 0 : a.missing ? 1 : -1;
+  const flip = descending ? -1 : 1;
+  if (kind === "number") {
+    const an = a.num ?? Number.NEGATIVE_INFINITY;
+    const bn = b.num ?? Number.NEGATIVE_INFINITY;
+    if (an !== bn) return flip * (an < bn ? -1 : 1);
+    return flip * a.text.localeCompare(b.text, "en-IN");
+  }
+  if (kind === "date") {
+    const ad = a.date ?? "";
+    const bd = b.date ?? "";
+    if (ad !== bd) return flip * ad.localeCompare(bd);
+    return flip * a.text.localeCompare(b.text, "en-IN");
+  }
+  return flip * a.text.localeCompare(b.text, "en-IN", { sensitivity: "base", numeric: true });
+}
+
+/** The direction a column's FIRST click sorts: biggest first for readings,
+ *  A to Z for names - the order a reader scanning for the worst case wants. */
+export function firstClickDescending(kind: ColumnKind): boolean {
+  return kind === "number" || kind === "date";
+}


### PR DESCRIPTION
Every table on the Atlas surfaces now sorts by clicking its column headers - eleven tables across the district page (groundwater by taluk, blocks compared, water bodies, environment-plan figures, vintages), the GP page (habitations, drinking-water sources, water bodies, samples by year), the state page's tanker register, and the Panchayat finder.

**How**: one client wrapper, `AtlasSortableTable`, drops in where `AtlasTableScroll` stood. The table stays server-rendered exactly as before - links, badges, grouped headers and all; after hydration the last header row becomes buttons that reorder the existing rows in place. No JavaScript, no change: the served order stands.

**One sorting brain**: `src/lib/atlas/table-sort.ts`, shared with the directory explorer's stateful table. A leading number sorts numerically ("1,234 ha", "92.5%"), an ISO date chronologically, everything else alphabetically - so "over-exploited (5 of 12)" sorts by name, not by the 5. "Not stated" sinks to the bottom whichever way the column points. First click: biggest reading first, names A to Z. In the finder, the Brief column ranks reviewed > profile > directory rather than alphabetically.

**A11y**: real buttons in the headers (keyboard + focus ring), `aria-sort` on the active column, arrow indicators outside the accessible name.

**Verified in a real browser**, not just by markup: playwright on the production build clicked the blocks, vintages, scarcity, groundwater and explorer tables and asserted row order actually changed (9/9 checks), plus a GP-page spot check. Gates: tsc, lint 0 errors, 297 tests (10 new for the sort module), i18n, data:check, drift, full build.

UI-only - no data or corpus changes, so no release chain after merge.