### PR TITLE
Atlas: drop the 'What would sharpen this reading' list from the district hero

### DIFF
--- a/src/app/atlas/[state]/[district]/page.tsx
+++ b/src/app/atlas/[state]/[district]/page.tsx
@@ -250,19 +250,6 @@ export default async function AtlasDistrictPage({ params }: RouteParams) {
           <div className="mt-8">
             <AtlasQuickFind rows={rows} basePath={basePath} example={example} />
           </div>
-
-          {verdict.nextSteps.length > 0 ? (
-            <div className="mt-8">
-              <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                What would sharpen this reading
-              </h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                {verdict.nextSteps.map((step) => (
-                  <li key={step}>{step}</li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
         </AtlasContainer>
       </header>
 


### PR DESCRIPTION
The district hero ran verdict, headline facts, finder, and then a bulleted list of what would sharpen the reading. This removes that list from the district view. Nothing else on the page changes; the 'Not yet on file' section further down still names the families with nothing wired.

What to look at
- src/app/atlas/[state]/[district]/page.tsx: one block deleted from the header, after the quick finder.
- The verdict's nextSteps stay in district-reading.ts. Their builder is fed by the district registry (irrigationCurrentSource.nextStep) and six test assertions pin the wording, so the data path is untouched; it just has no renderer on this page now.
- The Panchayat page's own 'What would sharpen this' chapter (curated nextEvidence) is not part of this change.

Gates run locally: lint 0 errors, tsc clean, 297 tests pass, data:check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)