### PR TITLE
Corpus pin: Erode, Namakkal, Karur and Tiruppur

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -38,9 +38,9 @@
     "2026-09-02: the Kabini PRS review round, tagged corpus-2026-09-02-kabini-prs-review at bbb1b547adf9640d84f0cc1617a3f06437da129f (data#62 squash). Modification-only: three artifacts re-synced from neer-vazhvu#356 - the register subtab reworded with the five named 17-Cat rows (two distilleries recorded as closed), the Jubilant OCEMS/CEMS check with CPCB's portal cited as a closed source, and the Nanjangud industrial-area card carrying the full five-field Arkavathi framework - so expected_files stays 1196/161 and this bump moves only the sha. The move also carries the 2 Sep Maharashtra-plans release (b2792e5), which had merged on data main without a pin bump - its two verified-plan artifacts reach production with this bump."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "01ff17fb056b0e2072573bbda753dae640889121",
+  "sha": "4d1ab16df23910c77d1675a801e0c6feae577f97",
   "expected_files": {
-    "data": 1199,
+    "data": 1471,
     "geojson": 161
   }
 }


### PR DESCRIPTION
Moves the corpus pin to corpus-2026-09-06-atlas-tn-cauvery-midreach (neer-vazhvu-data#64, data main 4d1ab16d): 272 artifacts for Erode, Namakkal, Karur and Tiruppur, 1471 data and 161 geojson blobs. The four districts stay preview-gated (published: false) until the reviewed inputs are verified.

Verified locally: fetch-corpus preflight against the new pin syncs and exits 0 with the expected counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
