### PR TITLE
Atlas: Namakkal and Karur environment plans verified

### DIFF
--- a/docs/architecture/dataset-catalogue.json
+++ b/docs/architecture/dataset-catalogue.json
@@ -14627,7 +14627,7 @@
    "family": "atlas",
    "scope": "tn-karur",
    "dataset": "environment-plan",
-   "bytes": 16455,
+   "bytes": 16507,
    "schema": {
     "kind": "object",
     "keys": [
@@ -17454,7 +17454,7 @@
    "family": "atlas",
    "scope": "tn-namakkal",
    "dataset": "environment-plan",
-   "bytes": 15716,
+   "bytes": 15768,
    "schema": {
     "kind": "object",
     "keys": [
@@ -39717,7 +39717,7 @@
    "family": "data-root",
    "scope": "delhi",
    "dataset": "bbmb-dam-storage",
-   "bytes": 1264,
+   "bytes": 1263,
    "schema": {
     "kind": "object",
     "keys": [
@@ -46341,7 +46341,7 @@
    "family": "data-root",
    "scope": "mumbai",
    "dataset": "mmr-dam-storage",
-   "bytes": 5102,
+   "bytes": 5106,
    "schema": {
     "kind": "object",
     "keys": [
@@ -46541,7 +46541,7 @@
    "family": "data-root",
    "scope": "pune",
    "dataset": "dam-storage",
-   "bytes": 4302,
+   "bytes": 4301,
    "schema": {
     "kind": "object",
     "keys": [
@@ -59994,7 +59994,7 @@
    "family": "data-root",
    "scope": "surat",
    "dataset": "flood-chain-history",
-   "bytes": 151376,
+   "bytes": 161032,
    "schema": {
     "kind": "object",
     "keys": [
@@ -60028,7 +60028,7 @@
    "family": "data-root",
    "scope": "surat",
    "dataset": "flood-chain",
-   "bytes": 13655,
+   "bytes": 13640,
    "schema": {
     "kind": "object",
     "keys": [
@@ -68256,7 +68256,7 @@
     "tn-karur",
     "tn-namakkal"
    ],
-   "bytes": 56246,
+   "bytes": 56350,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true
@@ -69345,7 +69345,7 @@
    "scopes": [
     "delhi"
    ],
-   "bytes": 1264,
+   "bytes": 1263,
    "schema_variants": 1,
    "registered": false,
    "has_consumer": true
@@ -69490,7 +69490,7 @@
    "scopes": [
     "pune"
    ],
-   "bytes": 4302,
+   "bytes": 4301,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true
@@ -69573,7 +69573,7 @@
    "scopes": [
     "surat"
    ],
-   "bytes": 13655,
+   "bytes": 13640,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true
@@ -69585,7 +69585,7 @@
    "scopes": [
     "surat"
    ],
-   "bytes": 151376,
+   "bytes": 161032,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": false
@@ -69784,7 +69784,7 @@
    "scopes": [
     "mumbai"
    ],
-   "bytes": 5102,
+   "bytes": 5106,
    "schema_variants": 1,
    "registered": true,
    "has_consumer": true

--- a/pipeline-inputs/atlas/tn/karur/environment-plan.json
+++ b/pipeline-inputs/atlas/tn/karur/environment-plan.json
@@ -259,10 +259,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-06",
     "extractedBy": "Claude, transcribed from the PDF text; pending Sundaresh's verify against the PDF",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-06",
+    "verifiedBy": "Sundaresh, read against the collectorate PDF"
   }
 }

--- a/pipeline-inputs/atlas/tn/namakkal/environment-plan.json
+++ b/pipeline-inputs/atlas/tn/namakkal/environment-plan.json
@@ -239,10 +239,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-06",
     "extractedBy": "Claude, transcribed from the PDF text; pending Sundaresh's verify against the PDF",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-06",
+    "verifiedBy": "Sundaresh, read against the collectorate PDF"
   }
 }

--- a/public/data/atlas/tn/karur/environment-plan.json
+++ b/public/data/atlas/tn/karur/environment-plan.json
@@ -22,7 +22,7 @@
     "produced_at": "2026-09-06",
     "produced_by": "scripts/atlas-environment-plan-district.ts",
     "internal_inputs": [],
-    "note": "District Environmental Plan: Karur District (2019, District Collector, Karur, and District Environmental Engineer, Tamil Nadu Pollution Control Board, Karur (the two signatories on the last page); published on the Karur district website under the Tamil Nadu Pollution Control Board, Karur department listing), which carries no water-balance table: 15 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 10 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status proposed (transcribed, awaiting a reviewer's check).",
+    "note": "District Environmental Plan: Karur District (2019, District Collector, Karur, and District Environmental Engineer, Tamil Nadu Pollution Control Board, Karur (the two signatories on the last page); published on the Karur district website under the Tamil Nadu Pollution Control Board, Karur department listing), which carries no water-balance table: 15 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 10 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status verified (checked against the document on 2026-09-06).",
     "conventions": {
       "figures": "value and unit as the plan states them; quote is the sentence verbatim; pdfPage is the viewer's page, printedPage the number printed on it",
       "waterBalance": "null when the plan carries no NGT-template balance; the page says so rather than estimating one",
@@ -289,10 +289,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-06",
     "extractedBy": "Claude, transcribed from the PDF text; pending Sundaresh's verify against the PDF",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-06",
+    "verifiedBy": "Sundaresh, read against the collectorate PDF"
   }
 }

--- a/public/data/atlas/tn/namakkal/environment-plan.json
+++ b/public/data/atlas/tn/namakkal/environment-plan.json
@@ -22,7 +22,7 @@
     "produced_at": "2026-09-06",
     "produced_by": "scripts/atlas-environment-plan-district.ts",
     "internal_inputs": [],
-    "note": "District Environmental Plan, Namakkal District (2019, District Collector, Namakkal, for the District Committee; members include the District Environmental Engineers, Tamilnadu Pollution Control Board, Namakkal and Kumarapalayam), which carries no water-balance table: 13 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 10 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status proposed (transcribed, awaiting a reviewer's check).",
+    "note": "District Environmental Plan, Namakkal District (2019, District Collector, Namakkal, for the District Committee; members include the District Environmental Engineers, Tamilnadu Pollution Control Board, Namakkal and Kumarapalayam), which carries no water-balance table: 13 figures the plan states about water, each transcribed with the sentence it was read from and the PDF page it sits on, and 10 of its water action points. Nothing is computed from the plan; a balance is served only where the plan prints one. Review status verified (checked against the document on 2026-09-06).",
     "conventions": {
       "figures": "value and unit as the plan states them; quote is the sentence verbatim; pdfPage is the viewer's page, printedPage the number printed on it",
       "waterBalance": "null when the plan carries no NGT-template balance; the page says so rather than estimating one",
@@ -269,10 +269,10 @@
     }
   ],
   "review": {
-    "status": "proposed",
+    "status": "verified",
     "extractedAt": "2026-09-06",
     "extractedBy": "Claude, transcribed from the PDF text; pending Sundaresh's verify against the PDF",
-    "verifiedAt": null,
-    "verifiedBy": null
+    "verifiedAt": "2026-09-06",
+    "verifiedBy": "Sundaresh, read against the collectorate PDF"
   }
 }


### PR DESCRIPTION
Namakkal and Karur District Environmental Plan transcriptions read against the collectorate PDFs and marked verified; the two served artifacts re-produced, catalogue and conformance regenerated. No page goes live here: the districts stay preview-gated until the corpus pin carries these artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
