### PR TITLE
Atlas: publish Erode, Namakkal, Karur and Tiruppur with the verified corpus pin

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -38,7 +38,7 @@
     "2026-09-02: the Kabini PRS review round, tagged corpus-2026-09-02-kabini-prs-review at bbb1b547adf9640d84f0cc1617a3f06437da129f (data#62 squash). Modification-only: three artifacts re-synced from neer-vazhvu#356 - the register subtab reworded with the five named 17-Cat rows (two distilleries recorded as closed), the Jubilant OCEMS/CEMS check with CPCB's portal cited as a closed source, and the Nanjangud industrial-area card carrying the full five-field Arkavathi framework - so expected_files stays 1196/161 and this bump moves only the sha. The move also carries the 2 Sep Maharashtra-plans release (b2792e5), which had merged on data main without a pin bump - its two verified-plan artifacts reach production with this bump."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "4d1ab16df23910c77d1675a801e0c6feae577f97",
+  "sha": "1fdf3b70541a593a94a409cdee98d5968f88498a",
   "expected_files": {
     "data": 1471,
     "geojson": 161

--- a/src/lib/atlas/registry.ts
+++ b/src/lib/atlas/registry.ts
@@ -121,7 +121,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     hook: "Canal country on the Bhavani: 39% of irrigation is canal water and 49% open wells, and Nambiyur taluk pumps 171% of its recharge.",
     basin: { basinId: "cauvery-tn", subBasinKey: "120", subBasinName: "Lower Bhavani" },
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {
@@ -134,7 +134,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     hook: "Cauvery bank with almost no canal: 72% of irrigation is open wells, and 5 of 8 taluks are over-exploited, Rasipuram at 150% of its recharge.",
     basin: { basinId: "cauvery-tn", subBasinKey: "123", subBasinName: "Mettur Reservoir to Noyyal confluence" },
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {
@@ -147,7 +147,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     hook: "Where the Amaravathi meets the Cauvery: 4 of 7 taluks are over-exploited and the other 3 critical, and 84% of irrigation is from wells.",
     basin: { basinId: "cauvery-tn", subBasinKey: "113", subBasinName: "Amaravathi" },
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {
@@ -160,7 +160,7 @@ export const ATLAS_DISTRICTS: AtlasDistrict[] = [
     hook: "The Noyyal's dyeing belt: 22% of irrigation is canal water and 77% wells, and Palladam taluk pumps 121% of its recharge.",
     basin: { basinId: "cauvery-tn", subBasinKey: "126", subBasinName: "Noyyal" },
     hasCuratedBriefs: false,
-    published: false,
+    published: true,
     irrigationCurrentSource: TN_IRRIGATION_SOURCE,
   },
   {


### PR DESCRIPTION
Publishes Erode, Namakkal, Karur and Tiruppur (published: true) and moves the corpus pin to corpus-2026-09-06-atlas-tn-dep-verified (data main 1fdf3b70): the Namakkal and Karur environment plans now carry their verified review, counts unchanged at 1471 data and 161 geojson blobs. Fetch-corpus preflight against the pin verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
