### PR TITLE
Corpus pin: CPCB polluted stretches layer

### DIFF
--- a/corpus.lock
+++ b/corpus.lock
@@ -38,9 +38,9 @@
     "2026-09-02: the Kabini PRS review round, tagged corpus-2026-09-02-kabini-prs-review at bbb1b547adf9640d84f0cc1617a3f06437da129f (data#62 squash). Modification-only: three artifacts re-synced from neer-vazhvu#356 - the register subtab reworded with the five named 17-Cat rows (two distilleries recorded as closed), the Jubilant OCEMS/CEMS check with CPCB's portal cited as a closed source, and the Nanjangud industrial-area card carrying the full five-field Arkavathi framework - so expected_files stays 1196/161 and this bump moves only the sha. The move also carries the 2 Sep Maharashtra-plans release (b2792e5), which had merged on data main without a pin bump - its two verified-plan artifacts reach production with this bump."
   ],
   "repo": "github.com/SundareshPrasanna/neer-vazhvu-data",
-  "sha": "1fdf3b70541a593a94a409cdee98d5968f88498a",
+  "sha": "9e52c6885952907e80e16e13086246244084d566",
   "expected_files": {
-    "data": 1471,
+    "data": 1482,
     "geojson": 161
   }
 }


### PR DESCRIPTION
Moves the corpus pin to corpus-2026-09-06-atlas-cpcb-stretches (neer-vazhvu-data#66, data main 9e52c688): the polluted-stretches artifacts for eleven districts and their regenerated assessments and briefs; 1482 data and 161 geojson blobs. Fetch-corpus preflight against the pin verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
